### PR TITLE
[codex] Add Enoch evolve MVP

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -282,6 +282,8 @@ def help_message(topic: str = "") -> str:
             "/cron every <interval> <request> - schedule recurring work",
             "/cron cancel <id> - cancel a scheduled job",
             "/cron - show scheduled jobs",
+            "/evolve - show self-evolution mode, theme, and top candidate",
+            "/evolve theme <text> - set the current self-evolution theme",
             "",
             "Inherit:",
             "/ancestors - show ancestor chain and ancestor skills",
@@ -343,6 +345,17 @@ def _help_topic_message(topic: str) -> str:
                 "/cron - show scheduled jobs",
             ]
         )
+    if topic == "evolve":
+        return "\n".join(
+            [
+                "Evolve commands:",
+                "/evolve - show self-evolution mode, theme, and top candidate",
+                "/evolve disabled - stop collecting and ranking self-evolution candidates",
+                "/evolve co-evolve - propose candidates and wait for human approval",
+                "/evolve auto-evolve - select bounded candidates under guardrails",
+                "/evolve theme <text> - set the current self-evolution theme",
+            ]
+        )
     topics = {
         "start": "/start - start Enoch and point to /help",
         "self": "/self - show Enoch's identity, role, ancestor, and mission",
@@ -358,6 +371,7 @@ def _help_topic_message(topic: str) -> str:
         ),
         "tasks": "/tasks - show running, queued, and recent task history",
         "stop": "/stop - stop the currently running /do or /task job",
+        "evolve": "/evolve - show self-evolution mode, theme, and top candidate",
         "skills": "/skills [agent-or-path] - show declared skills",
         "learn": "/learn <skill> from <agent> - adapt a published skill from another Our-Ark agent",
         "mode": "/mode [chat|work] - show or set whether Enoch only chats or can work on repo changes",

--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Iterable
+
+from enoch.backlog import BacklogItem, backlog_status
+from enoch.lineage.core import LineageCandidate, load_parent_inbox_candidates
+from enoch.memory.paths import atomic_write, clean_text, now as current_time
+from enoch.paths import enoch_home
+
+
+SCHEMA_VERSION = 1
+MODE_DISABLED = "disabled"
+MODE_CO_EVOLVE = "co-evolve"
+MODE_AUTO_EVOLVE = "auto-evolve"
+MODES = {MODE_DISABLED, MODE_CO_EVOLVE, MODE_AUTO_EVOLVE}
+DEFAULT_MODE = MODE_CO_EVOLVE
+
+
+@dataclass(frozen=True)
+class EvolveState:
+    mode: str = DEFAULT_MODE
+    theme: str = ""
+    updated_at: str = ""
+
+
+@dataclass(frozen=True)
+class EvolveCandidate:
+    id: str
+    source: str
+    title: str
+    rationale: str
+    proposed_change: str
+    expected_benefit: str
+    risk: str
+    test_plan: str
+    status: str = "candidate"
+    score: int = 0
+
+
+@dataclass(frozen=True)
+class EvolveReport:
+    state: EvolveState
+    candidates: tuple[EvolveCandidate, ...]
+    top_candidate: EvolveCandidate | None
+    counts_by_source: dict[str, int]
+
+
+def evolve_state_path(root: Path | None = None) -> Path:
+    return enoch_home(root) / "evolve.json"
+
+
+def load_evolve_state(root: Path | None = None) -> EvolveState:
+    path = evolve_state_path(root)
+    if not path.exists():
+        return EvolveState()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return EvolveState()
+    if not isinstance(raw, dict):
+        return EvolveState()
+    mode = normalize_evolve_mode(str(raw.get("mode") or DEFAULT_MODE))
+    theme = clean_text(str(raw.get("theme") or ""))
+    updated_at = str(raw.get("updated_at") or "")
+    return EvolveState(mode=mode, theme=theme, updated_at=updated_at)
+
+
+def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveState:
+    normalized = EvolveState(
+        mode=normalize_evolve_mode(state.mode),
+        theme=clean_text(state.theme),
+        updated_at=state.updated_at or current_time(),
+    )
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "mode": normalized.mode,
+        "theme": normalized.theme,
+        "updated_at": normalized.updated_at,
+    }
+    atomic_write(evolve_state_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return normalized
+
+
+def set_evolve_mode(mode: str, root: Path | None = None) -> EvolveState:
+    current = load_evolve_state(root)
+    return save_evolve_state(EvolveState(mode=normalize_evolve_mode(mode), theme=current.theme), root)
+
+
+def set_evolve_theme(theme: str, root: Path | None = None) -> EvolveState:
+    current = load_evolve_state(root)
+    return save_evolve_state(EvolveState(mode=current.mode, theme=clean_text(theme)), root)
+
+
+def normalize_evolve_mode(mode: str) -> str:
+    normalized = mode.strip().lower()
+    if normalized in {"co", "coevolve", "co_evolve"}:
+        normalized = MODE_CO_EVOLVE
+    if normalized in {"auto", "autoevolve", "auto_evolve"}:
+        normalized = MODE_AUTO_EVOLVE
+    if normalized not in MODES:
+        raise ValueError("Evolve mode must be disabled, co-evolve, or auto-evolve.")
+    return normalized
+
+
+def evolve_report(root: Path | None = None) -> EvolveReport:
+    state = load_evolve_state(root)
+    candidates = ()
+    if state.mode != MODE_DISABLED:
+        candidates = rank_evolve_candidates(collect_evolve_candidates(root), theme=state.theme)
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        counts[candidate.source] = counts.get(candidate.source, 0) + 1
+    return EvolveReport(
+        state=state,
+        candidates=candidates,
+        top_candidate=candidates[0] if candidates else None,
+        counts_by_source=counts,
+    )
+
+
+def collect_evolve_candidates(root: Path | None = None) -> tuple[EvolveCandidate, ...]:
+    candidates: list[EvolveCandidate] = []
+    candidates.extend(_backlog_candidates(backlog_status(root).pending))
+    candidates.extend(_inheritance_candidates(load_parent_inbox_candidates(root)))
+    return tuple(candidates)
+
+
+def rank_evolve_candidates(
+    candidates: Iterable[EvolveCandidate],
+    *,
+    theme: str = "",
+) -> tuple[EvolveCandidate, ...]:
+    scored = [_score_candidate(candidate, theme=theme) for candidate in candidates]
+    return tuple(sorted(scored, key=lambda item: (-item.score, item.source, item.id)))
+
+
+def _backlog_candidates(items: Iterable[BacklogItem]) -> list[EvolveCandidate]:
+    priority_score = {"p0": 35, "p1": 25, "p2": 15}
+    candidates = []
+    for item in items:
+        candidates.append(
+            EvolveCandidate(
+                id=f"backlog-{item.id}",
+                source="backlog",
+                title=item.text,
+                rationale=f"Pending {item.priority} backlog item.",
+                proposed_change=item.text,
+                expected_benefit="Completes deferred human-visible work that may improve Enoch's body or workflow.",
+                risk="Backlog item may need clarification before implementation.",
+                test_plan="Run focused tests for the changed behavior and Enoch doctor if code changes.",
+                score=priority_score.get(item.priority, 10),
+            )
+        )
+    return candidates
+
+
+def _inheritance_candidates(items: Iterable[LineageCandidate]) -> list[EvolveCandidate]:
+    relevance_score = {"high": 32, "medium": 22, "low": 8}
+    candidates = []
+    for item in items:
+        candidates.append(
+            EvolveCandidate(
+                id=f"inheritance-{item.id}",
+                source="inheritance",
+                title=item.title,
+                rationale=f"Direct-parent change from {item.repo}; relevance {item.relevance}. {item.reason}",
+                proposed_change=f"Inspect and adapt direct-parent change {item.id}.",
+                expected_benefit="Keeps Enoch aligned with useful parent improvements without blindly copying them.",
+                risk="Parent change may not apply cleanly to Enoch or may duplicate existing behavior.",
+                test_plan="Inspect changed files, adapt only relevant pieces, then run affected tests.",
+                score=relevance_score.get(item.relevance, 8),
+            )
+        )
+    return candidates
+
+
+def _score_candidate(candidate: EvolveCandidate, *, theme: str) -> EvolveCandidate:
+    score = candidate.score + 25
+    text = " ".join([candidate.title, candidate.rationale, candidate.proposed_change]).lower()
+    theme_words = {word for word in clean_text(theme).lower().split() if len(word) >= 4}
+    if theme_words and any(word in text for word in theme_words):
+        score += 20
+    if candidate.source == "backlog":
+        score += 10
+    if candidate.source == "inheritance":
+        score += 8
+    return EvolveCandidate(**{**candidate.__dict__, "score": score})

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -42,6 +42,16 @@ from enoch.cron import (
     parse_cron_interval,
     record_cron_task,
 )
+from enoch.evolve import (
+    MODE_AUTO_EVOLVE,
+    MODE_CO_EVOLVE,
+    MODE_DISABLED,
+    EvolveCandidate,
+    EvolveReport,
+    evolve_report,
+    set_evolve_mode,
+    set_evolve_theme,
+)
 from enoch.git_tools import (
     GitError,
     changed_files,
@@ -287,6 +297,8 @@ class EnochTelegramBot:
             reply = self._backlog(chat_id, work_text)
         elif command in {"/cron", "/crons"}:
             reply = self._cron(chat_id, work_text)
+        elif command == "/evolve":
+            reply = self._evolve(argument)
         elif command == "/mode":
             reply = self._mode(text)
         elif command == "/shutdown":
@@ -1018,6 +1030,25 @@ class EnochTelegramBot:
         except (OSError, ValueError):
             return "Enoch could not add that backlog item."
         return f"Backlog #{item.id} [{item.priority}] saved. Enoch will promote it when the task queue is idle."
+
+    def _evolve(self, argument: str) -> str:
+        parts = argument.strip().split(maxsplit=1)
+        if not parts:
+            return _format_evolve_report(evolve_report(self.root))
+        subcommand = parts[0].lower()
+        rest = parts[1] if len(parts) > 1 else ""
+        if subcommand in {MODE_DISABLED, MODE_CO_EVOLVE, MODE_AUTO_EVOLVE, "co", "auto"}:
+            try:
+                set_evolve_mode(subcommand, self.root)
+            except ValueError as error:
+                return str(error)
+            return _format_evolve_report(evolve_report(self.root))
+        if subcommand == "theme":
+            if not rest.strip():
+                return "Use /evolve theme <text> to set Enoch's current evolution theme."
+            set_evolve_theme(rest, self.root)
+            return _format_evolve_report(evolve_report(self.root))
+        return _evolve_usage()
 
     def _cron(self, chat_id: int, text: str) -> str:
         command, argument = _parse_telegram_command(text)
@@ -1897,6 +1928,49 @@ def _format_cron_list_item(job: CronJob) -> str:
     return f"{label} (last task #{job.last_task_id})"
 
 
+def _format_evolve_report(report: EvolveReport) -> str:
+    state = report.state
+    lines = [
+        "Evolve:",
+        f"Mode: {state.mode}",
+        f"Theme: {state.theme or 'not set'}",
+        "",
+        "Candidate counts:",
+    ]
+    if report.counts_by_source:
+        for source in sorted(report.counts_by_source):
+            lines.append(f"- {source}: {report.counts_by_source[source]}")
+    else:
+        lines.append("- none")
+    lines.extend(["", "Top candidate:"])
+    if report.top_candidate is None:
+        lines.append("- none")
+    else:
+        lines.extend(_format_evolve_candidate(report.top_candidate))
+    lines.extend(["", f"Next action: {_evolve_next_action(report)}"])
+    return "\n".join(lines)
+
+
+def _format_evolve_candidate(candidate: EvolveCandidate) -> list[str]:
+    return [
+        f"- {candidate.id} [{candidate.source}] {_clip_activity_text(candidate.title, limit=100)}",
+        f"  Score: {candidate.score}",
+        f"  Rationale: {_clip_activity_text(candidate.rationale, limit=180)}",
+        f"  Proposed change: {_clip_activity_text(candidate.proposed_change, limit=180)}",
+        f"  Test plan: {_clip_activity_text(candidate.test_plan, limit=180)}",
+    ]
+
+
+def _evolve_next_action(report: EvolveReport) -> str:
+    if report.state.mode == MODE_DISABLED:
+        return "disabled; Enoch will not collect or rank self-evolution candidates."
+    if report.top_candidate is None:
+        return "no candidate yet."
+    if report.state.mode == MODE_AUTO_EVOLVE:
+        return "select this bounded candidate, then queue or run work only after guardrails pass."
+    return "propose this candidate and wait for human approval before changing code."
+
+
 def _history_task(task_id: int, root: Path) -> TaskJob | None:
     for job in reversed(task_queue_status(root).history):
         if job.id == task_id:
@@ -1985,6 +2059,16 @@ def _cron_usage() -> str:
             "Intervals can be like 10m, 2h, or 1d.",
             "Use /cron cancel <id> to cancel a scheduled job.",
             "Use /cron to show scheduled jobs.",
+        ]
+    )
+
+
+def _evolve_usage() -> str:
+    return "\n".join(
+        [
+            "Use /evolve to show Enoch's self-evolution status.",
+            "Use /evolve disabled|co-evolve|auto-evolve to set the mode.",
+            "Use /evolve theme <text> to set the current evolution theme.",
         ]
     )
 

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+import json
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from enoch.backlog import add_backlog_item
+from enoch.evolve import (
+    MODE_DISABLED,
+    collect_evolve_candidates,
+    evolve_report,
+    load_evolve_state,
+    rank_evolve_candidates,
+    set_evolve_mode,
+    set_evolve_theme,
+)
+from enoch.lineage.core import LineageCandidate
+
+
+class EnochEvolveTests(unittest.TestCase):
+    def test_default_state_is_co_evolve(self) -> None:
+        with TemporaryDirectory() as temp:
+            state = load_evolve_state(Path(temp))
+
+        self.assertEqual(state.mode, "co-evolve")
+        self.assertEqual(state.theme, "")
+
+    def test_collects_backlog_and_parent_inheritance_candidates(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            _write_lineage_candidate(root, _lineage_candidate())
+
+            candidates = collect_evolve_candidates(root)
+            ranked = rank_evolve_candidates(candidates, theme="Telegram UX")
+
+        self.assertEqual({candidate.source for candidate in candidates}, {"backlog", "inheritance"})
+        self.assertEqual(ranked[0].source, "backlog")
+        self.assertIn("Telegram", ranked[0].title)
+
+    def test_disabled_mode_does_not_collect_candidates(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "do this later", root, priority="p0")
+            set_evolve_mode(MODE_DISABLED, root)
+
+            report = evolve_report(root)
+
+        self.assertEqual(report.state.mode, MODE_DISABLED)
+        self.assertEqual(report.candidates, ())
+        self.assertIsNone(report.top_candidate)
+
+    def test_theme_is_persisted(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+
+            state = set_evolve_theme(" improve Telegram work UX ", root)
+            loaded = load_evolve_state(root)
+
+        self.assertEqual(state.theme, "improve Telegram work UX")
+        self.assertEqual(loaded.theme, "improve Telegram work UX")
+
+
+def _write_lineage_candidate(root: Path, candidate: LineageCandidate) -> None:
+    lineage = root / ".agent" / "lineage.yaml"
+    lineage.parent.mkdir(parents=True)
+    lineage.write_text("parent:\n  name: Seth\n  repo: our-ark/enoch\n", encoding="utf-8")
+    inbox = root / ".agent" / "lineage_inbox.json"
+    inbox.write_text(json.dumps({"schema_version": 1, "candidates": [candidate.__dict__]}), encoding="utf-8")
+
+
+def _lineage_candidate() -> LineageCandidate:
+    return LineageCandidate(
+        id="our-ark/enoch#32",
+        repo="our-ark/enoch",
+        pr_number=32,
+        title="Add Telegram recovery command",
+        url="https://github.com/our-ark/enoch/pull/32",
+        merged_at="2026-06-17T01:31:12Z",
+        merge_commit="abc123",
+        ancestor_name="Seth",
+        depth=1,
+        labels=("inherit:recommended",),
+        files=("src/enoch/telegram/bot.py",),
+        relevance="high",
+        confidence="high",
+        reason="PR has an inheritance label.",
+        body_excerpt="Adds a recovery command.",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -599,6 +599,8 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/cron every <interval> <request> - schedule recurring work", client.sent[0][1])
         self.assertIn("/cron cancel <id> - cancel a scheduled job", client.sent[0][1])
         self.assertIn("/cron - show scheduled jobs", client.sent[0][1])
+        self.assertIn("/evolve - show self-evolution mode, theme, and top candidate", client.sent[0][1])
+        self.assertIn("/evolve theme <text> - set the current self-evolution theme", client.sent[0][1])
         self.assertIn("/update", client.sent[0][1])
         self.assertIn("/restart - restart Enoch's Telegram daemon from the locked chat", client.sent[0][1])
         self.assertLess(client.sent[0][1].index("Operations:"), client.sent[0][1].index("/shutdown"))
@@ -639,6 +641,18 @@ class EnochTelegramTests(unittest.TestCase):
         reply = client.sent[0][1]
         self.assertIn("Cron commands:", reply)
         self.assertIn("/cron every <interval> <request>", reply)
+
+    def test_help_evolve_shows_evolve_usage(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/help evolve"))
+
+        reply = client.sent[0][1]
+        self.assertIn("Evolve commands:", reply)
+        self.assertIn("/evolve co-evolve", reply)
+        self.assertIn("/evolve theme <text>", reply)
+        self.assertNotIn("Enoch Telegram commands:", reply)
 
     def test_help_debug_reports_unknown_command(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -1159,6 +1173,35 @@ class EnochTelegramTests(unittest.TestCase):
 
         self.assertIn("Backlog:", client.sent[1][1])
         self.assertIn("#1 [p0 pending] first", client.sent[1][1])
+
+    def test_evolve_reports_top_candidate_from_backlog(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve"))
+
+        reply = client.sent[0][1]
+        self.assertIn("Evolve:", reply)
+        self.assertIn("Mode: co-evolve", reply)
+        self.assertIn("- backlog: 1", reply)
+        self.assertIn("backlog-1 [backlog] improve Telegram work UX", reply)
+        self.assertIn("wait for human approval", reply)
+
+    def test_evolve_can_set_theme_and_mode(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve theme improve recovery"))
+            bot.handle_update(_message_update(update_id=2, chat_id=42, text="/evolve disabled"))
+
+        self.assertIn("Theme: improve recovery", client.sent[0][1])
+        self.assertIn("Mode: disabled", client.sent[1][1])
+        self.assertIn("Candidate counts:\n- none", client.sent[1][1])
 
     @patch("enoch.telegram.bot.ensure_long_term_memory")
     @patch("enoch.telegram.bot.log_conversation_turn")


### PR DESCRIPTION
## Summary

Adds the first MVP of Enoch's `/evolve` self-evolution command surface.

- Adds persisted evolve state for mode and theme.
- Collects and ranks MVP candidates from backlog and direct-parent inheritance.
- Adds `/evolve`, `/evolve disabled|co-evolve|auto-evolve`, and `/evolve theme <text>` in Telegram.
- Updates help text and test coverage for the new command.

## Validation

- `python3 -m unittest discover -s tests` passed: 307 tests.

## Notes

This MVP proposes candidates and reports next action. It does not yet auto-run evolution work or open PRs from selected candidates.