### PR TITLE
[codex] Add evolve scheduler

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -295,6 +295,7 @@ def help_message(topic: str = "") -> str:
             "/evolve - show self-evolution mode, theme, and top candidate",
             "/evolve theme <text> - set the current self-evolution theme",
             "/evolve schedule every <interval> - run periodic evolve checks",
+            "/evolve schedule daily HH:MM - run evolve once per day at local time",
             "/evolve schedule off - disable scheduled evolve checks",
             "",
             "Operations:",
@@ -359,6 +360,7 @@ def _help_topic_message(topic: str) -> str:
                 "/evolve auto-evolve - select bounded candidates under guardrails",
                 "/evolve theme <text> - set the current self-evolution theme",
                 "/evolve schedule every <interval> - run periodic evolve checks",
+                "/evolve schedule daily HH:MM - run evolve once per day at local time",
                 "/evolve schedule off - disable scheduled evolve checks",
             ]
         )

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -294,6 +294,8 @@ def help_message(topic: str = "") -> str:
             "Evolve:",
             "/evolve - show self-evolution mode, theme, and top candidate",
             "/evolve theme <text> - set the current self-evolution theme",
+            "/evolve schedule every <interval> - run periodic evolve checks",
+            "/evolve schedule off - disable scheduled evolve checks",
             "",
             "Operations:",
             "/doctor - run local health checks",
@@ -356,6 +358,8 @@ def _help_topic_message(topic: str) -> str:
                 "/evolve co-evolve - propose candidates and wait for human approval",
                 "/evolve auto-evolve - select bounded candidates under guardrails",
                 "/evolve theme <text> - set the current self-evolution theme",
+                "/evolve schedule every <interval> - run periodic evolve checks",
+                "/evolve schedule off - disable scheduled evolve checks",
             ]
         )
     topics = {

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -296,6 +296,7 @@ def help_message(topic: str = "") -> str:
             "/evolve theme <text> - set the current self-evolution theme",
             "/evolve schedule every <interval> - run periodic evolve checks",
             "/evolve schedule daily HH:MM - run evolve once per day at local time",
+            "/evolve schedule cron '30 9 * * *' - run evolve with a cron-style daily schedule",
             "/evolve schedule off - disable scheduled evolve checks",
             "",
             "Operations:",
@@ -361,6 +362,7 @@ def _help_topic_message(topic: str) -> str:
                 "/evolve theme <text> - set the current self-evolution theme",
                 "/evolve schedule every <interval> - run periodic evolve checks",
                 "/evolve schedule daily HH:MM - run evolve once per day at local time",
+                "/evolve schedule cron '30 9 * * *' - run evolve with a cron-style daily schedule",
                 "/evolve schedule off - disable scheduled evolve checks",
             ]
         )

--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -27,6 +27,7 @@ class EvolveState:
     updated_at: str = ""
     schedule_enabled: bool = False
     schedule_interval_seconds: int = 0
+    schedule_daily_time: str = ""
     schedule_next_run_at: str = ""
     schedule_last_run_at: str = ""
 
@@ -76,6 +77,7 @@ def load_evolve_state(root: Path | None = None) -> EvolveState:
         updated_at=updated_at,
         schedule_enabled=bool(raw.get("schedule_enabled", False)),
         schedule_interval_seconds=max(0, _int(raw.get("schedule_interval_seconds"), default=0)),
+        schedule_daily_time=_normalize_daily_time(str(raw.get("schedule_daily_time") or ""), allow_empty=True),
         schedule_next_run_at=str(raw.get("schedule_next_run_at") or ""),
         schedule_last_run_at=str(raw.get("schedule_last_run_at") or ""),
     )
@@ -86,8 +88,10 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
         mode=normalize_evolve_mode(state.mode),
         theme=clean_text(state.theme),
         updated_at=state.updated_at or current_time(),
-        schedule_enabled=state.schedule_enabled and state.schedule_interval_seconds > 0,
+        schedule_enabled=state.schedule_enabled
+        and (state.schedule_interval_seconds > 0 or bool(_normalize_daily_time(state.schedule_daily_time, allow_empty=True))),
         schedule_interval_seconds=max(0, int(state.schedule_interval_seconds)),
+        schedule_daily_time=_normalize_daily_time(state.schedule_daily_time, allow_empty=True),
         schedule_next_run_at=state.schedule_next_run_at,
         schedule_last_run_at=state.schedule_last_run_at,
     )
@@ -98,6 +102,7 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
         "updated_at": normalized.updated_at,
         "schedule_enabled": normalized.schedule_enabled,
         "schedule_interval_seconds": normalized.schedule_interval_seconds,
+        "schedule_daily_time": normalized.schedule_daily_time,
         "schedule_next_run_at": normalized.schedule_next_run_at,
         "schedule_last_run_at": normalized.schedule_last_run_at,
     }
@@ -113,6 +118,7 @@ def set_evolve_mode(mode: str, root: Path | None = None) -> EvolveState:
             theme=current.theme,
             schedule_enabled=current.schedule_enabled,
             schedule_interval_seconds=current.schedule_interval_seconds,
+            schedule_daily_time=current.schedule_daily_time,
             schedule_next_run_at=current.schedule_next_run_at,
             schedule_last_run_at=current.schedule_last_run_at,
         ),
@@ -128,6 +134,7 @@ def set_evolve_theme(theme: str, root: Path | None = None) -> EvolveState:
             theme=clean_text(theme),
             schedule_enabled=current.schedule_enabled,
             schedule_interval_seconds=current.schedule_interval_seconds,
+            schedule_daily_time=current.schedule_daily_time,
             schedule_next_run_at=current.schedule_next_run_at,
             schedule_last_run_at=current.schedule_last_run_at,
         ),
@@ -151,7 +158,31 @@ def set_evolve_schedule(
             theme=current.theme,
             schedule_enabled=True,
             schedule_interval_seconds=interval_seconds,
+            schedule_daily_time="",
             schedule_next_run_at=_iso(current_time + timedelta(seconds=interval_seconds)),
+            schedule_last_run_at=current.schedule_last_run_at,
+        ),
+        root,
+    )
+
+
+def set_evolve_daily_schedule(
+    daily_time: str,
+    root: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> EvolveState:
+    normalized_time = _normalize_daily_time(daily_time)
+    current = load_evolve_state(root)
+    current_time = _coerce_local(now) if now is not None else _local_now()
+    return save_evolve_state(
+        EvolveState(
+            mode=current.mode,
+            theme=current.theme,
+            schedule_enabled=True,
+            schedule_interval_seconds=24 * 60 * 60,
+            schedule_daily_time=normalized_time,
+            schedule_next_run_at=_iso(_next_daily_run(normalized_time, current_time)),
             schedule_last_run_at=current.schedule_last_run_at,
         ),
         root,
@@ -167,18 +198,21 @@ def claim_due_evolve_schedule(root: Path | None = None, *, now: datetime | None 
     state = load_evolve_state(root)
     if not state.schedule_enabled or state.schedule_interval_seconds <= 0:
         return None
-    current = _coerce_utc(now) if now is not None else _utc_now()
+    current_source = now if now is not None else _local_now()
+    current = _coerce_utc(current_source)
     next_run_at = _parse_time(state.schedule_next_run_at)
     if next_run_at is None or next_run_at > current:
         return None
     claimed = state
+    next_run_at = _next_scheduled_run(state, current_source)
     save_evolve_state(
         EvolveState(
             mode=state.mode,
             theme=state.theme,
             schedule_enabled=True,
             schedule_interval_seconds=state.schedule_interval_seconds,
-            schedule_next_run_at=_iso(current + timedelta(seconds=state.schedule_interval_seconds)),
+            schedule_daily_time=state.schedule_daily_time,
+            schedule_next_run_at=_iso(next_run_at),
             schedule_last_run_at=_iso(current),
         ),
         root,
@@ -286,10 +320,20 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc).replace(microsecond=0)
 
 
+def _local_now() -> datetime:
+    return datetime.now().astimezone().replace(microsecond=0)
+
+
 def _coerce_utc(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc, microsecond=0)
     return value.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def _coerce_local(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.astimezone().replace(microsecond=0)
+    return value.replace(microsecond=0)
 
 
 def _iso(value: datetime) -> str:
@@ -311,3 +355,40 @@ def _int(value: object, *, default: int) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _next_scheduled_run(state: EvolveState, current: datetime) -> datetime:
+    if state.schedule_daily_time:
+        return _next_daily_run(state.schedule_daily_time, current)
+    return current + timedelta(seconds=state.schedule_interval_seconds)
+
+
+def _next_daily_run(daily_time: str, current: datetime) -> datetime:
+    hour, minute = _daily_time_parts(daily_time)
+    local_current = _coerce_local(current)
+    candidate = local_current.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= local_current:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def _normalize_daily_time(value: str, *, allow_empty: bool = False) -> str:
+    cleaned = value.strip()
+    if not cleaned and allow_empty:
+        return ""
+    hour, minute = _daily_time_parts(cleaned)
+    return f"{hour:02d}:{minute:02d}"
+
+
+def _daily_time_parts(value: str) -> tuple[int, int]:
+    parts = value.strip().split(":")
+    if len(parts) != 2:
+        raise ValueError("Evolve daily schedule time must look like HH:MM.")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError as error:
+        raise ValueError("Evolve daily schedule time must look like HH:MM.") from error
+    if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+        raise ValueError("Evolve daily schedule time must use 00:00 through 23:59.")
+    return hour, minute

--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 from typing import Iterable
@@ -24,6 +25,10 @@ class EvolveState:
     mode: str = DEFAULT_MODE
     theme: str = ""
     updated_at: str = ""
+    schedule_enabled: bool = False
+    schedule_interval_seconds: int = 0
+    schedule_next_run_at: str = ""
+    schedule_last_run_at: str = ""
 
 
 @dataclass(frozen=True)
@@ -65,7 +70,15 @@ def load_evolve_state(root: Path | None = None) -> EvolveState:
     mode = normalize_evolve_mode(str(raw.get("mode") or DEFAULT_MODE))
     theme = clean_text(str(raw.get("theme") or ""))
     updated_at = str(raw.get("updated_at") or "")
-    return EvolveState(mode=mode, theme=theme, updated_at=updated_at)
+    return EvolveState(
+        mode=mode,
+        theme=theme,
+        updated_at=updated_at,
+        schedule_enabled=bool(raw.get("schedule_enabled", False)),
+        schedule_interval_seconds=max(0, _int(raw.get("schedule_interval_seconds"), default=0)),
+        schedule_next_run_at=str(raw.get("schedule_next_run_at") or ""),
+        schedule_last_run_at=str(raw.get("schedule_last_run_at") or ""),
+    )
 
 
 def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveState:
@@ -73,12 +86,20 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
         mode=normalize_evolve_mode(state.mode),
         theme=clean_text(state.theme),
         updated_at=state.updated_at or current_time(),
+        schedule_enabled=state.schedule_enabled and state.schedule_interval_seconds > 0,
+        schedule_interval_seconds=max(0, int(state.schedule_interval_seconds)),
+        schedule_next_run_at=state.schedule_next_run_at,
+        schedule_last_run_at=state.schedule_last_run_at,
     )
     payload = {
         "schema_version": SCHEMA_VERSION,
         "mode": normalized.mode,
         "theme": normalized.theme,
         "updated_at": normalized.updated_at,
+        "schedule_enabled": normalized.schedule_enabled,
+        "schedule_interval_seconds": normalized.schedule_interval_seconds,
+        "schedule_next_run_at": normalized.schedule_next_run_at,
+        "schedule_last_run_at": normalized.schedule_last_run_at,
     }
     atomic_write(evolve_state_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
     return normalized
@@ -86,12 +107,83 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
 
 def set_evolve_mode(mode: str, root: Path | None = None) -> EvolveState:
     current = load_evolve_state(root)
-    return save_evolve_state(EvolveState(mode=normalize_evolve_mode(mode), theme=current.theme), root)
+    return save_evolve_state(
+        EvolveState(
+            mode=normalize_evolve_mode(mode),
+            theme=current.theme,
+            schedule_enabled=current.schedule_enabled,
+            schedule_interval_seconds=current.schedule_interval_seconds,
+            schedule_next_run_at=current.schedule_next_run_at,
+            schedule_last_run_at=current.schedule_last_run_at,
+        ),
+        root,
+    )
 
 
 def set_evolve_theme(theme: str, root: Path | None = None) -> EvolveState:
     current = load_evolve_state(root)
-    return save_evolve_state(EvolveState(mode=current.mode, theme=clean_text(theme)), root)
+    return save_evolve_state(
+        EvolveState(
+            mode=current.mode,
+            theme=clean_text(theme),
+            schedule_enabled=current.schedule_enabled,
+            schedule_interval_seconds=current.schedule_interval_seconds,
+            schedule_next_run_at=current.schedule_next_run_at,
+            schedule_last_run_at=current.schedule_last_run_at,
+        ),
+        root,
+    )
+
+
+def set_evolve_schedule(
+    interval_seconds: int,
+    root: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> EvolveState:
+    if interval_seconds <= 0:
+        raise ValueError("Evolve schedule interval must be greater than zero.")
+    current = load_evolve_state(root)
+    current_time = _coerce_utc(now) if now is not None else _utc_now()
+    return save_evolve_state(
+        EvolveState(
+            mode=current.mode,
+            theme=current.theme,
+            schedule_enabled=True,
+            schedule_interval_seconds=interval_seconds,
+            schedule_next_run_at=_iso(current_time + timedelta(seconds=interval_seconds)),
+            schedule_last_run_at=current.schedule_last_run_at,
+        ),
+        root,
+    )
+
+
+def disable_evolve_schedule(root: Path | None = None) -> EvolveState:
+    current = load_evolve_state(root)
+    return save_evolve_state(EvolveState(mode=current.mode, theme=current.theme), root)
+
+
+def claim_due_evolve_schedule(root: Path | None = None, *, now: datetime | None = None) -> EvolveState | None:
+    state = load_evolve_state(root)
+    if not state.schedule_enabled or state.schedule_interval_seconds <= 0:
+        return None
+    current = _coerce_utc(now) if now is not None else _utc_now()
+    next_run_at = _parse_time(state.schedule_next_run_at)
+    if next_run_at is None or next_run_at > current:
+        return None
+    claimed = state
+    save_evolve_state(
+        EvolveState(
+            mode=state.mode,
+            theme=state.theme,
+            schedule_enabled=True,
+            schedule_interval_seconds=state.schedule_interval_seconds,
+            schedule_next_run_at=_iso(current + timedelta(seconds=state.schedule_interval_seconds)),
+            schedule_last_run_at=_iso(current),
+        ),
+        root,
+    )
+    return claimed
 
 
 def normalize_evolve_mode(mode: str) -> str:
@@ -188,3 +280,34 @@ def _score_candidate(candidate: EvolveCandidate, *, theme: str) -> EvolveCandida
     if candidate.source == "inheritance":
         score += 8
     return EvolveCandidate(**{**candidate.__dict__, "score": score})
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _coerce_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc, microsecond=0)
+    return value.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def _iso(value: datetime) -> str:
+    return _coerce_utc(value).isoformat()
+
+
+def _parse_time(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return _coerce_utc(parsed)
+
+
+def _int(value: object, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -28,6 +28,7 @@ class EvolveState:
     schedule_enabled: bool = False
     schedule_interval_seconds: int = 0
     schedule_daily_time: str = ""
+    schedule_cron_expression: str = ""
     schedule_next_run_at: str = ""
     schedule_last_run_at: str = ""
 
@@ -78,6 +79,10 @@ def load_evolve_state(root: Path | None = None) -> EvolveState:
         schedule_enabled=bool(raw.get("schedule_enabled", False)),
         schedule_interval_seconds=max(0, _int(raw.get("schedule_interval_seconds"), default=0)),
         schedule_daily_time=_normalize_daily_time(str(raw.get("schedule_daily_time") or ""), allow_empty=True),
+        schedule_cron_expression=_normalize_cron_expression(
+            str(raw.get("schedule_cron_expression") or ""),
+            allow_empty=True,
+        ),
         schedule_next_run_at=str(raw.get("schedule_next_run_at") or ""),
         schedule_last_run_at=str(raw.get("schedule_last_run_at") or ""),
     )
@@ -89,9 +94,14 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
         theme=clean_text(state.theme),
         updated_at=state.updated_at or current_time(),
         schedule_enabled=state.schedule_enabled
-        and (state.schedule_interval_seconds > 0 or bool(_normalize_daily_time(state.schedule_daily_time, allow_empty=True))),
+        and (
+            state.schedule_interval_seconds > 0
+            or bool(_normalize_daily_time(state.schedule_daily_time, allow_empty=True))
+            or bool(_normalize_cron_expression(state.schedule_cron_expression, allow_empty=True))
+        ),
         schedule_interval_seconds=max(0, int(state.schedule_interval_seconds)),
         schedule_daily_time=_normalize_daily_time(state.schedule_daily_time, allow_empty=True),
+        schedule_cron_expression=_normalize_cron_expression(state.schedule_cron_expression, allow_empty=True),
         schedule_next_run_at=state.schedule_next_run_at,
         schedule_last_run_at=state.schedule_last_run_at,
     )
@@ -103,6 +113,7 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
         "schedule_enabled": normalized.schedule_enabled,
         "schedule_interval_seconds": normalized.schedule_interval_seconds,
         "schedule_daily_time": normalized.schedule_daily_time,
+        "schedule_cron_expression": normalized.schedule_cron_expression,
         "schedule_next_run_at": normalized.schedule_next_run_at,
         "schedule_last_run_at": normalized.schedule_last_run_at,
     }
@@ -119,6 +130,7 @@ def set_evolve_mode(mode: str, root: Path | None = None) -> EvolveState:
             schedule_enabled=current.schedule_enabled,
             schedule_interval_seconds=current.schedule_interval_seconds,
             schedule_daily_time=current.schedule_daily_time,
+            schedule_cron_expression=current.schedule_cron_expression,
             schedule_next_run_at=current.schedule_next_run_at,
             schedule_last_run_at=current.schedule_last_run_at,
         ),
@@ -135,6 +147,7 @@ def set_evolve_theme(theme: str, root: Path | None = None) -> EvolveState:
             schedule_enabled=current.schedule_enabled,
             schedule_interval_seconds=current.schedule_interval_seconds,
             schedule_daily_time=current.schedule_daily_time,
+            schedule_cron_expression=current.schedule_cron_expression,
             schedule_next_run_at=current.schedule_next_run_at,
             schedule_last_run_at=current.schedule_last_run_at,
         ),
@@ -159,6 +172,7 @@ def set_evolve_schedule(
             schedule_enabled=True,
             schedule_interval_seconds=interval_seconds,
             schedule_daily_time="",
+            schedule_cron_expression="",
             schedule_next_run_at=_iso(current_time + timedelta(seconds=interval_seconds)),
             schedule_last_run_at=current.schedule_last_run_at,
         ),
@@ -173,6 +187,7 @@ def set_evolve_daily_schedule(
     now: datetime | None = None,
 ) -> EvolveState:
     normalized_time = _normalize_daily_time(daily_time)
+    hour, minute = _daily_time_parts(normalized_time)
     current = load_evolve_state(root)
     current_time = _coerce_local(now) if now is not None else _local_now()
     return save_evolve_state(
@@ -182,7 +197,32 @@ def set_evolve_daily_schedule(
             schedule_enabled=True,
             schedule_interval_seconds=24 * 60 * 60,
             schedule_daily_time=normalized_time,
+            schedule_cron_expression=f"{minute} {hour} * * *",
             schedule_next_run_at=_iso(_next_daily_run(normalized_time, current_time)),
+            schedule_last_run_at=current.schedule_last_run_at,
+        ),
+        root,
+    )
+
+
+def set_evolve_cron_schedule(
+    expression: str,
+    root: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> EvolveState:
+    normalized_expression = _normalize_cron_expression(expression)
+    current = load_evolve_state(root)
+    current_time = _coerce_local(now) if now is not None else _local_now()
+    return save_evolve_state(
+        EvolveState(
+            mode=current.mode,
+            theme=current.theme,
+            schedule_enabled=True,
+            schedule_interval_seconds=24 * 60 * 60,
+            schedule_daily_time="",
+            schedule_cron_expression=normalized_expression,
+            schedule_next_run_at=_iso(_next_cron_run(normalized_expression, current_time)),
             schedule_last_run_at=current.schedule_last_run_at,
         ),
         root,
@@ -212,6 +252,7 @@ def claim_due_evolve_schedule(root: Path | None = None, *, now: datetime | None 
             schedule_enabled=True,
             schedule_interval_seconds=state.schedule_interval_seconds,
             schedule_daily_time=state.schedule_daily_time,
+            schedule_cron_expression=state.schedule_cron_expression,
             schedule_next_run_at=_iso(next_run_at),
             schedule_last_run_at=_iso(current),
         ),
@@ -360,6 +401,8 @@ def _int(value: object, *, default: int) -> int:
 def _next_scheduled_run(state: EvolveState, current: datetime) -> datetime:
     if state.schedule_daily_time:
         return _next_daily_run(state.schedule_daily_time, current)
+    if state.schedule_cron_expression:
+        return _next_cron_run(state.schedule_cron_expression, current)
     return current + timedelta(seconds=state.schedule_interval_seconds)
 
 
@@ -392,3 +435,37 @@ def _daily_time_parts(value: str) -> tuple[int, int]:
     if hour < 0 or hour > 23 or minute < 0 or minute > 59:
         raise ValueError("Evolve daily schedule time must use 00:00 through 23:59.")
     return hour, minute
+
+
+def _next_cron_run(expression: str, current: datetime) -> datetime:
+    minute, hour = _cron_daily_parts(expression)
+    local_current = _coerce_local(current)
+    candidate = local_current.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= local_current:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def _normalize_cron_expression(value: str, *, allow_empty: bool = False) -> str:
+    cleaned = " ".join(value.strip().split())
+    if not cleaned and allow_empty:
+        return ""
+    minute, hour = _cron_daily_parts(cleaned)
+    return f"{minute} {hour} * * *"
+
+
+def _cron_daily_parts(value: str) -> tuple[int, int]:
+    parts = value.strip().split()
+    if len(parts) != 5:
+        raise ValueError("Evolve cron schedule must look like: minute hour * * *.")
+    minute_text, hour_text, day_of_month, month, day_of_week = parts
+    if (day_of_month, month, day_of_week) != ("*", "*", "*"):
+        raise ValueError("Evolve cron schedule currently supports daily expressions like: 30 9 * * *.")
+    try:
+        minute = int(minute_text)
+        hour = int(hour_text)
+    except ValueError as error:
+        raise ValueError("Evolve cron schedule minute and hour must be whole numbers.") from error
+    if minute < 0 or minute > 59 or hour < 0 or hour > 23:
+        raise ValueError("Evolve cron schedule minute/hour must be within 0-59 and 0-23.")
+    return minute, hour

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -27,6 +27,8 @@ Future sources may include feedback, experience, brainstorming, and learning fro
 
 The evolve scheduler stores its frequency and next run time in `.enoch/evolve.json`.
 
+It can run on a fixed interval or once per day at a local HH:MM time.
+
 When the scheduler is due:
 
 - `disabled` mode advances the schedule and takes no action.
@@ -47,4 +49,5 @@ Enoch must require human direction before changing identity, mission, secrets, p
 - `/evolve auto-evolve`
 - `/evolve theme <text>`
 - `/evolve schedule every <interval>`
+- `/evolve schedule daily HH:MM`
 - `/evolve schedule off`

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -27,7 +27,7 @@ Future sources may include feedback, experience, brainstorming, and learning fro
 
 The evolve scheduler stores its frequency and next run time in `.enoch/evolve.json`.
 
-It can run on a fixed interval or once per day at a local HH:MM time.
+It can run on a fixed interval, once per day at a local HH:MM time, or a cron-style daily expression like `30 9 * * *`.
 
 When the scheduler is due:
 
@@ -50,4 +50,5 @@ Enoch must require human direction before changing identity, mission, secrets, p
 - `/evolve theme <text>`
 - `/evolve schedule every <interval>`
 - `/evolve schedule daily HH:MM`
+- `/evolve schedule cron '30 9 * * *'`
 - `/evolve schedule off`

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -23,6 +23,16 @@ The MVP candidate sources are:
 
 Future sources may include feedback, experience, brainstorming, and learning from non-parent agents.
 
+## Scheduler
+
+The evolve scheduler stores its frequency and next run time in `.enoch/evolve.json`.
+
+When the scheduler is due:
+
+- `disabled` mode advances the schedule and takes no action.
+- `co-evolve` mode sends the ranked evolve report to the locked Telegram chat.
+- `auto-evolve` mode turns the top bounded candidate into a queued task for review-oriented implementation.
+
 ## Guardrails
 
 Evolve candidates should be small, testable, reversible, and aligned with Enoch's mission and current theme.
@@ -36,3 +46,5 @@ Enoch must require human direction before changing identity, mission, secrets, p
 - `/evolve co-evolve`
 - `/evolve auto-evolve`
 - `/evolve theme <text>`
+- `/evolve schedule every <interval>`
+- `/evolve schedule off`

--- a/src/enoch/skills/evolve/skill.yaml
+++ b/src/enoch/skills/evolve/skill.yaml
@@ -7,6 +7,7 @@ mode: co-evolution
 entrypoint: src/enoch/evolve.py
 capabilities:
   state: src/enoch/evolve.py
+  scheduler: src/enoch/evolve.py
   candidate_collection:
     - src/enoch/backlog.py
     - src/enoch/lineage/core.py

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -52,6 +52,7 @@ from enoch.evolve import (
     claim_due_evolve_schedule,
     disable_evolve_schedule,
     evolve_report,
+    set_evolve_cron_schedule,
     set_evolve_daily_schedule,
     set_evolve_schedule,
     set_evolve_mode,
@@ -1075,6 +1076,14 @@ class EnochTelegramBot:
             except ValueError as error:
                 return str(error)
             return _format_evolve_report(evolve_report(self.root))
+        if subcommand == "cron":
+            if not rest.strip():
+                return "Use /evolve schedule cron '30 9 * * *' to run evolve with a cron-style schedule."
+            try:
+                set_evolve_cron_schedule(rest, self.root)
+            except ValueError as error:
+                return str(error)
+            return _format_evolve_report(evolve_report(self.root))
         if subcommand != "every":
             return _evolve_usage()
         if not rest.strip():
@@ -2038,6 +2047,8 @@ def _format_evolve_schedule(state: EvolveState) -> str:
     last_run = f"; last {state.schedule_last_run_at}" if state.schedule_last_run_at else ""
     if state.schedule_daily_time:
         return f"daily {state.schedule_daily_time}; next {next_run}{last_run}"
+    if state.schedule_cron_expression:
+        return f"cron {state.schedule_cron_expression}; next {next_run}{last_run}"
     return f"every {format_cron_interval(state.schedule_interval_seconds)}; next {next_run}{last_run}"
 
 
@@ -2193,6 +2204,7 @@ def _evolve_usage() -> str:
             "Use /evolve theme <text> to set the current evolution theme.",
             "Use /evolve schedule every <interval> to run periodic evolve checks.",
             "Use /evolve schedule daily HH:MM to run evolve once per day at local time.",
+            "Use /evolve schedule cron '30 9 * * *' for a cron-style daily schedule.",
             "Use /evolve schedule off to disable scheduled evolve checks.",
         ]
     )

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -48,7 +48,11 @@ from enoch.evolve import (
     MODE_DISABLED,
     EvolveCandidate,
     EvolveReport,
+    EvolveState,
+    claim_due_evolve_schedule,
+    disable_evolve_schedule,
     evolve_report,
+    set_evolve_schedule,
     set_evolve_mode,
     set_evolve_theme,
 )
@@ -251,6 +255,7 @@ class EnochTelegramBot:
         for update in self.client.get_updates(self.offset):
             self.handle_update(update)
         self._enqueue_due_cron_jobs()
+        self._run_due_evolve_schedule()
         self._maybe_start_task_worker()
 
     def handle_update(self, update: dict[str, Any]) -> None:
@@ -1048,7 +1053,29 @@ class EnochTelegramBot:
                 return "Use /evolve theme <text> to set Enoch's current evolution theme."
             set_evolve_theme(rest, self.root)
             return _format_evolve_report(evolve_report(self.root))
+        if subcommand == "schedule":
+            return self._evolve_schedule(rest)
         return _evolve_usage()
+
+    def _evolve_schedule(self, argument: str) -> str:
+        parts = argument.strip().split(maxsplit=1)
+        if not parts:
+            return _format_evolve_report(evolve_report(self.root))
+        subcommand = parts[0].lower()
+        rest = parts[1] if len(parts) > 1 else ""
+        if subcommand in {"off", "disable", "disabled"}:
+            disable_evolve_schedule(self.root)
+            return _format_evolve_report(evolve_report(self.root))
+        if subcommand != "every":
+            return _evolve_usage()
+        if not rest.strip():
+            return "Use /evolve schedule every <interval> to set the scheduler frequency."
+        try:
+            interval_seconds = parse_cron_interval(rest)
+            set_evolve_schedule(interval_seconds, self.root)
+        except ValueError as error:
+            return str(error)
+        return _format_evolve_report(evolve_report(self.root))
 
     def _cron(self, chat_id: int, text: str) -> str:
         command, argument = _parse_telegram_command(text)
@@ -1204,6 +1231,49 @@ class EnochTelegramBot:
                 self._work_status_messages[job.id] = message_id
                 record_task_status_message(job.id, message_id, self.root)
         return tuple(jobs)
+
+    def _run_due_evolve_schedule(self) -> TaskJob | None:
+        claimed = claim_due_evolve_schedule(self.root)
+        if claimed is None:
+            return None
+        chat_id = self.client.config.allowed_chat_id
+        if chat_id is None or claimed.mode == MODE_DISABLED:
+            return None
+        report = evolve_report(self.root)
+        if claimed.mode == MODE_CO_EVOLVE:
+            self._safe_send_message(chat_id, "Scheduled evolve check\n\n" + _format_evolve_report(report))
+            return None
+        if claimed.mode != MODE_AUTO_EVOLVE or report.top_candidate is None:
+            return None
+        request = _evolve_task_request(report.top_candidate, report.state.theme)
+        context = _evolve_task_context(report.top_candidate)
+        try:
+            job = enqueue_task(
+                chat_id,
+                request,
+                self.root,
+                context=context,
+                context_source="evolve-scheduler",
+            )
+        except (OSError, ValueError):
+            return None
+        message = _format_work_status_message(
+            WorkStatusMessage(
+                chat_id=chat_id,
+                message_id=0,
+                request=job.text,
+                started_at=time.monotonic(),
+                task_id=job.id,
+                status="queued",
+                latest_update=f"Scheduled by evolve {claimed.mode}.",
+                context=job.context,
+            )
+        )
+        message_id = self._safe_send_message_id(chat_id, message)
+        if message_id is not None:
+            self._work_status_messages[job.id] = message_id
+            record_task_status_message(job.id, message_id, self.root)
+        return job
 
     def _run_task_job(self, job: TaskJob) -> None:
         self._run_action_job(
@@ -1934,6 +2004,7 @@ def _format_evolve_report(report: EvolveReport) -> str:
         "Evolve:",
         f"Mode: {state.mode}",
         f"Theme: {state.theme or 'not set'}",
+        f"Schedule: {_format_evolve_schedule(state)}",
         "",
         "Candidate counts:",
     ]
@@ -1949,6 +2020,14 @@ def _format_evolve_report(report: EvolveReport) -> str:
         lines.extend(_format_evolve_candidate(report.top_candidate))
     lines.extend(["", f"Next action: {_evolve_next_action(report)}"])
     return "\n".join(lines)
+
+
+def _format_evolve_schedule(state: EvolveState) -> str:
+    if not state.schedule_enabled or state.schedule_interval_seconds <= 0:
+        return "off"
+    next_run = state.schedule_next_run_at or "unknown"
+    last_run = f"; last {state.schedule_last_run_at}" if state.schedule_last_run_at else ""
+    return f"every {format_cron_interval(state.schedule_interval_seconds)}; next {next_run}{last_run}"
 
 
 def _format_evolve_candidate(candidate: EvolveCandidate) -> list[str]:
@@ -1969,6 +2048,38 @@ def _evolve_next_action(report: EvolveReport) -> str:
     if report.state.mode == MODE_AUTO_EVOLVE:
         return "select this bounded candidate, then queue or run work only after guardrails pass."
     return "propose this candidate and wait for human approval before changing code."
+
+
+def _evolve_task_request(candidate: EvolveCandidate, theme: str) -> str:
+    lines = [
+        f"Evolve selected candidate {candidate.id}: {candidate.title}",
+        "",
+        f"Source: {candidate.source}",
+        f"Theme: {theme or 'not set'}",
+        f"Proposed change: {candidate.proposed_change}",
+        f"Expected benefit: {candidate.expected_benefit}",
+        f"Risk: {candidate.risk}",
+        f"Test plan: {candidate.test_plan}",
+        "",
+        "Keep the change small, reversible, and covered by focused tests. Open a PR for human review; do not merge it.",
+    ]
+    return "\n".join(lines)
+
+
+def _evolve_task_context(candidate: EvolveCandidate) -> str:
+    return "\n".join(
+        [
+            "Scheduled evolve candidate context:",
+            f"ID: {candidate.id}",
+            f"Source: {candidate.source}",
+            f"Score: {candidate.score}",
+            f"Rationale: {candidate.rationale}",
+            f"Proposed change: {candidate.proposed_change}",
+            f"Expected benefit: {candidate.expected_benefit}",
+            f"Risk: {candidate.risk}",
+            f"Test plan: {candidate.test_plan}",
+        ]
+    )
 
 
 def _history_task(task_id: int, root: Path) -> TaskJob | None:
@@ -2069,6 +2180,8 @@ def _evolve_usage() -> str:
             "Use /evolve to show Enoch's self-evolution status.",
             "Use /evolve disabled|co-evolve|auto-evolve to set the mode.",
             "Use /evolve theme <text> to set the current evolution theme.",
+            "Use /evolve schedule every <interval> to run periodic evolve checks.",
+            "Use /evolve schedule off to disable scheduled evolve checks.",
         ]
     )
 

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -52,6 +52,7 @@ from enoch.evolve import (
     claim_due_evolve_schedule,
     disable_evolve_schedule,
     evolve_report,
+    set_evolve_daily_schedule,
     set_evolve_schedule,
     set_evolve_mode,
     set_evolve_theme,
@@ -1066,6 +1067,14 @@ class EnochTelegramBot:
         if subcommand in {"off", "disable", "disabled"}:
             disable_evolve_schedule(self.root)
             return _format_evolve_report(evolve_report(self.root))
+        if subcommand == "daily":
+            if not rest.strip():
+                return "Use /evolve schedule daily HH:MM to run evolve once per day at local time."
+            try:
+                set_evolve_daily_schedule(rest, self.root)
+            except ValueError as error:
+                return str(error)
+            return _format_evolve_report(evolve_report(self.root))
         if subcommand != "every":
             return _evolve_usage()
         if not rest.strip():
@@ -2027,6 +2036,8 @@ def _format_evolve_schedule(state: EvolveState) -> str:
         return "off"
     next_run = state.schedule_next_run_at or "unknown"
     last_run = f"; last {state.schedule_last_run_at}" if state.schedule_last_run_at else ""
+    if state.schedule_daily_time:
+        return f"daily {state.schedule_daily_time}; next {next_run}{last_run}"
     return f"every {format_cron_interval(state.schedule_interval_seconds)}; next {next_run}{last_run}"
 
 
@@ -2181,6 +2192,7 @@ def _evolve_usage() -> str:
             "Use /evolve disabled|co-evolve|auto-evolve to set the mode.",
             "Use /evolve theme <text> to set the current evolution theme.",
             "Use /evolve schedule every <interval> to run periodic evolve checks.",
+            "Use /evolve schedule daily HH:MM to run evolve once per day at local time.",
             "Use /evolve schedule off to disable scheduled evolve checks.",
         ]
     )

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -18,6 +18,7 @@ from enoch.evolve import (
     evolve_report,
     load_evolve_state,
     rank_evolve_candidates,
+    set_evolve_cron_schedule,
     set_evolve_daily_schedule,
     set_evolve_schedule,
     set_evolve_mode,
@@ -111,6 +112,26 @@ class EnochEvolveTests(unittest.TestCase):
         with TemporaryDirectory() as temp:
             with self.assertRaisesRegex(ValueError, "HH:MM"):
                 set_evolve_daily_schedule("tomorrow morning", Path(temp))
+
+    def test_cron_schedule_uses_daily_cron_expression(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            start = datetime(2020, 1, 1, 8, 30, tzinfo=timezone.utc)
+            due = datetime(2020, 1, 1, 9, 30, tzinfo=timezone.utc)
+
+            scheduled = set_evolve_cron_schedule("30 9 * * *", root, now=start)
+            claimed = claim_due_evolve_schedule(root, now=due)
+            state_after_claim = load_evolve_state(root)
+
+        self.assertEqual(scheduled.schedule_cron_expression, "30 9 * * *")
+        self.assertEqual(scheduled.schedule_next_run_at, "2020-01-01T09:30:00+00:00")
+        self.assertIsNotNone(claimed)
+        self.assertEqual(state_after_claim.schedule_next_run_at, "2020-01-02T09:30:00+00:00")
+
+    def test_cron_schedule_rejects_non_daily_expression(self) -> None:
+        with TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, "daily expressions"):
+                set_evolve_cron_schedule("30 9 * * 1", Path(temp))
 
 
 def _write_lineage_candidate(root: Path, candidate: LineageCandidate) -> None:

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime, timezone
 import json
 import sys
 from tempfile import TemporaryDirectory
@@ -11,10 +12,13 @@ sys.path.insert(0, str(ROOT / "src"))
 from enoch.backlog import add_backlog_item
 from enoch.evolve import (
     MODE_DISABLED,
+    claim_due_evolve_schedule,
     collect_evolve_candidates,
+    disable_evolve_schedule,
     evolve_report,
     load_evolve_state,
     rank_evolve_candidates,
+    set_evolve_schedule,
     set_evolve_mode,
     set_evolve_theme,
 )
@@ -63,6 +67,28 @@ class EnochEvolveTests(unittest.TestCase):
 
         self.assertEqual(state.theme, "improve Telegram work UX")
         self.assertEqual(loaded.theme, "improve Telegram work UX")
+
+    def test_schedule_can_be_set_claimed_and_disabled(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            start = datetime(2020, 1, 1, tzinfo=timezone.utc)
+            due = datetime(2020, 1, 2, tzinfo=timezone.utc)
+
+            scheduled = set_evolve_schedule(86400, root, now=start)
+            before_due = claim_due_evolve_schedule(root, now=datetime(2020, 1, 1, 23, tzinfo=timezone.utc))
+            claimed = claim_due_evolve_schedule(root, now=due)
+            claimed_again = claim_due_evolve_schedule(root, now=due)
+            disabled = disable_evolve_schedule(root)
+
+        self.assertTrue(scheduled.schedule_enabled)
+        self.assertEqual(scheduled.schedule_interval_seconds, 86400)
+        self.assertEqual(scheduled.schedule_next_run_at, "2020-01-02T00:00:00+00:00")
+        self.assertIsNone(before_due)
+        self.assertIsNotNone(claimed)
+        assert claimed is not None
+        self.assertEqual(claimed.schedule_next_run_at, "2020-01-02T00:00:00+00:00")
+        self.assertIsNone(claimed_again)
+        self.assertFalse(disabled.schedule_enabled)
 
 
 def _write_lineage_candidate(root: Path, candidate: LineageCandidate) -> None:

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -18,6 +18,7 @@ from enoch.evolve import (
     evolve_report,
     load_evolve_state,
     rank_evolve_candidates,
+    set_evolve_daily_schedule,
     set_evolve_schedule,
     set_evolve_mode,
     set_evolve_theme,
@@ -89,6 +90,27 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertEqual(claimed.schedule_next_run_at, "2020-01-02T00:00:00+00:00")
         self.assertIsNone(claimed_again)
         self.assertFalse(disabled.schedule_enabled)
+
+    def test_daily_schedule_uses_next_local_time(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            start = datetime(2020, 1, 1, 8, 30, tzinfo=timezone.utc)
+            due = datetime(2020, 1, 1, 9, 0, tzinfo=timezone.utc)
+
+            scheduled = set_evolve_daily_schedule("9:00", root, now=start)
+            claimed = claim_due_evolve_schedule(root, now=due)
+            state_after_claim = load_evolve_state(root)
+
+        self.assertEqual(scheduled.schedule_daily_time, "09:00")
+        self.assertEqual(scheduled.schedule_interval_seconds, 86400)
+        self.assertEqual(scheduled.schedule_next_run_at, "2020-01-01T09:00:00+00:00")
+        self.assertIsNotNone(claimed)
+        self.assertEqual(state_after_claim.schedule_next_run_at, "2020-01-02T09:00:00+00:00")
+
+    def test_daily_schedule_rejects_invalid_time(self) -> None:
+        with TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, "HH:MM"):
+                set_evolve_daily_schedule("tomorrow morning", Path(temp))
 
 
 def _write_lineage_candidate(root: Path, candidate: LineageCandidate) -> None:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -607,6 +607,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/evolve theme <text> - set the current self-evolution theme", client.sent[0][1])
         self.assertIn("/evolve schedule every <interval> - run periodic evolve checks", client.sent[0][1])
         self.assertIn("/evolve schedule daily HH:MM - run evolve once per day at local time", client.sent[0][1])
+        self.assertIn("/evolve schedule cron '30 9 * * *' - run evolve with a cron-style daily schedule", client.sent[0][1])
         self.assertIn("/evolve schedule off - disable scheduled evolve checks", client.sent[0][1])
         self.assertIn("/update", client.sent[0][1])
         self.assertIn("/restart - restart Enoch's Telegram daemon from the locked chat", client.sent[0][1])
@@ -661,6 +662,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/evolve theme <text>", reply)
         self.assertIn("/evolve schedule every <interval>", reply)
         self.assertIn("/evolve schedule daily HH:MM", reply)
+        self.assertIn("/evolve schedule cron '30 9 * * *'", reply)
         self.assertIn("/evolve schedule off", reply)
         self.assertNotIn("Enoch Telegram commands:", reply)
 
@@ -1234,6 +1236,16 @@ class EnochTelegramTests(unittest.TestCase):
             bot.handle_update(_message_update(chat_id=42, text="/evolve schedule daily 09:30"))
 
         self.assertIn("Schedule: daily 09:30; next", client.sent[0][1])
+
+    def test_evolve_can_set_cron_schedule(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve schedule cron 30 9 * * *"))
+
+        self.assertIn("Schedule: cron 30 9 * * *; next", client.sent[0][1])
 
     def test_due_evolve_schedule_reports_in_co_evolve_mode(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -606,6 +606,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/evolve - show self-evolution mode, theme, and top candidate", client.sent[0][1])
         self.assertIn("/evolve theme <text> - set the current self-evolution theme", client.sent[0][1])
         self.assertIn("/evolve schedule every <interval> - run periodic evolve checks", client.sent[0][1])
+        self.assertIn("/evolve schedule daily HH:MM - run evolve once per day at local time", client.sent[0][1])
         self.assertIn("/evolve schedule off - disable scheduled evolve checks", client.sent[0][1])
         self.assertIn("/update", client.sent[0][1])
         self.assertIn("/restart - restart Enoch's Telegram daemon from the locked chat", client.sent[0][1])
@@ -659,6 +660,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/evolve co-evolve", reply)
         self.assertIn("/evolve theme <text>", reply)
         self.assertIn("/evolve schedule every <interval>", reply)
+        self.assertIn("/evolve schedule daily HH:MM", reply)
         self.assertIn("/evolve schedule off", reply)
         self.assertNotIn("Enoch Telegram commands:", reply)
 
@@ -1222,6 +1224,16 @@ class EnochTelegramTests(unittest.TestCase):
 
         self.assertIn("Schedule: every 1d; next", client.sent[0][1])
         self.assertIn("Schedule: off", client.sent[1][1])
+
+    def test_evolve_can_set_daily_schedule(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve schedule daily 09:30"))
+
+        self.assertIn("Schedule: daily 09:30; next", client.sent[0][1])
 
     def test_due_evolve_schedule_reports_in_co_evolve_mode(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -20,6 +20,7 @@ from enoch.backlog import add_backlog_item, backlog_status
 from enoch.config import read_section
 from enoch.command_surface import checktree as _checktree
 from enoch.cron import add_cron_job, cron_status
+from enoch.evolve import MODE_AUTO_EVOLVE, set_evolve_mode, set_evolve_schedule
 from enoch.git_tools import GitError
 from enoch.github.workflow import (
     LocalPublishResult,
@@ -604,6 +605,8 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/cron - show scheduled jobs", client.sent[0][1])
         self.assertIn("/evolve - show self-evolution mode, theme, and top candidate", client.sent[0][1])
         self.assertIn("/evolve theme <text> - set the current self-evolution theme", client.sent[0][1])
+        self.assertIn("/evolve schedule every <interval> - run periodic evolve checks", client.sent[0][1])
+        self.assertIn("/evolve schedule off - disable scheduled evolve checks", client.sent[0][1])
         self.assertIn("/update", client.sent[0][1])
         self.assertIn("/restart - restart Enoch's Telegram daemon from the locked chat", client.sent[0][1])
         self.assertLess(client.sent[0][1].index("Operations:"), client.sent[0][1].index("/shutdown"))
@@ -655,6 +658,8 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("Evolve commands:", reply)
         self.assertIn("/evolve co-evolve", reply)
         self.assertIn("/evolve theme <text>", reply)
+        self.assertIn("/evolve schedule every <interval>", reply)
+        self.assertIn("/evolve schedule off", reply)
         self.assertNotIn("Enoch Telegram commands:", reply)
 
     def test_help_debug_reports_unknown_command(self) -> None:
@@ -1205,6 +1210,58 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("Theme: improve recovery", client.sent[0][1])
         self.assertIn("Mode: disabled", client.sent[1][1])
         self.assertIn("Candidate counts:\n- none", client.sent[1][1])
+
+    def test_evolve_can_set_and_disable_schedule(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve schedule every 1d"))
+            bot.handle_update(_message_update(update_id=2, chat_id=42, text="/evolve schedule off"))
+
+        self.assertIn("Schedule: every 1d; next", client.sent[0][1])
+        self.assertIn("Schedule: off", client.sent[1][1])
+
+    def test_due_evolve_schedule_reports_in_co_evolve_mode(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            set_evolve_schedule(
+                60,
+                root,
+                now=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            )
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            job = bot._run_due_evolve_schedule()
+
+        self.assertIsNone(job)
+        self.assertIn("Scheduled evolve check", client.sent[0][1])
+        self.assertIn("backlog-1 [backlog] improve Telegram work UX", client.sent[0][1])
+
+    def test_due_evolve_schedule_auto_mode_queues_top_candidate(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            set_evolve_mode(MODE_AUTO_EVOLVE, root)
+            set_evolve_schedule(
+                60,
+                root,
+                now=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            )
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            job = bot._run_due_evolve_schedule()
+            queued = task_queue_status(root)
+
+        self.assertIsNotNone(job)
+        self.assertEqual(queued.pending_count, 1)
+        self.assertIn("Evolve selected candidate backlog-1", queued.pending[0].text)
+        self.assertEqual(queued.pending[0].context_source, "evolve-scheduler")
+        self.assertIn("Latest update: Scheduled by evolve auto-evolve.", client.sent[0][1])
 
     @patch("enoch.telegram.bot.ensure_long_term_memory")
     @patch("enoch.telegram.bot.log_conversation_turn")


### PR DESCRIPTION
## Summary

Adds a scheduler for Enoch's `/evolve` skill.

- Stores schedule state in `.enoch/evolve.json` alongside mode and theme.
- Adds `/evolve schedule every <interval>`, `/evolve schedule daily HH:MM`, `/evolve schedule cron '30 9 * * *'`, and `/evolve schedule off`.
- Shows schedule status in `/evolve` output.
- Supports fixed intervals, once-per-day local-time scheduling, and cron-style daily expressions.
- Checks the evolve schedule during each Telegram daemon `run_once()` loop.
- Applies mode-specific behavior when due:
  - `disabled`: advance schedule and take no action;
  - `co-evolve`: send the ranked evolve report to the locked Telegram chat;
  - `auto-evolve`: queue the top bounded candidate as a background task with candidate context.
- Updates evolve skill docs and help text.

## Validation

- `python3 -m unittest tests.test_enoch_evolve tests.test_enoch_telegram.EnochTelegramTests.test_help_lists_safe_commands tests.test_enoch_telegram.EnochTelegramTests.test_help_evolve_shows_evolve_usage tests.test_enoch_telegram.EnochTelegramTests.test_evolve_can_set_daily_schedule tests.test_enoch_telegram.EnochTelegramTests.test_evolve_can_set_cron_schedule tests.test_enoch_telegram.EnochTelegramTests.test_due_evolve_schedule_reports_in_co_evolve_mode tests.test_enoch_telegram.EnochTelegramTests.test_due_evolve_schedule_auto_mode_queues_top_candidate`
- `python3 -m unittest discover -s tests` passed: 317 tests.