### PR TITLE
[codex] Improve evolve mode help format

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -293,7 +293,7 @@ def help_message(topic: str = "") -> str:
             "",
             "Evolve:",
             "/evolve - show self-evolution mode, theme, and top candidate",
-            "/evolve mode disabled|co-evolve|auto-evolve - set self-evolution behavior",
+            "/evolve mode <mode> - set self-evolution behavior",
             "/evolve theme <text> - set the current self-evolution theme",
             "/evolve schedule <text> - let Enoch interpret common schedule text",
             "",
@@ -354,7 +354,8 @@ def _help_topic_message(topic: str) -> str:
             [
                 "Evolve commands:",
                 "/evolve - show self-evolution mode, theme, and top candidate",
-                "/evolve mode disabled|co-evolve|auto-evolve - set self-evolution behavior",
+                "/evolve mode <mode> - set self-evolution behavior",
+                "Modes: disabled, co-evolve, auto-evolve.",
                 "/evolve theme <text> - set the current self-evolution theme",
                 "/evolve schedule <text> - let Enoch interpret common schedule text",
             ]

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -2254,7 +2254,8 @@ def _evolve_usage() -> str:
     return "\n".join(
         [
             "Use /evolve to show Enoch's self-evolution status.",
-            "Use /evolve mode disabled|co-evolve|auto-evolve to set self-evolution behavior.",
+            "Use /evolve mode <mode> to set self-evolution behavior.",
+            "Modes: disabled, co-evolve, auto-evolve.",
             "Use /evolve theme <text> to set the current evolution theme.",
             "Use /evolve schedule <text> to let Enoch interpret common schedule text.",
         ]

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -604,7 +604,8 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/cron cancel <id> - cancel a scheduled job", client.sent[0][1])
         self.assertIn("/cron - show scheduled jobs", client.sent[0][1])
         self.assertIn("/evolve - show self-evolution mode, theme, and top candidate", client.sent[0][1])
-        self.assertIn("/evolve mode disabled|co-evolve|auto-evolve - set self-evolution behavior", client.sent[0][1])
+        self.assertIn("/evolve mode <mode> - set self-evolution behavior", client.sent[0][1])
+        self.assertNotIn("/evolve mode disabled|co-evolve|auto-evolve", client.sent[0][1])
         self.assertIn("/evolve theme <text> - set the current self-evolution theme", client.sent[0][1])
         self.assertIn("/evolve schedule <text> - let Enoch interpret common schedule text", client.sent[0][1])
         self.assertNotIn("/evolve schedule off - stop scheduled evolve checks", client.sent[0][1])
@@ -661,7 +662,9 @@ class EnochTelegramTests(unittest.TestCase):
 
         reply = client.sent[0][1]
         self.assertIn("Evolve commands:", reply)
-        self.assertIn("/evolve mode disabled|co-evolve|auto-evolve", reply)
+        self.assertIn("/evolve mode <mode>", reply)
+        self.assertIn("Modes: disabled, co-evolve, auto-evolve.", reply)
+        self.assertNotIn("/evolve mode disabled|co-evolve|auto-evolve", reply)
         self.assertNotIn("/evolve co-evolve - propose candidates", reply)
         self.assertNotIn("/evolve disabled - stop collecting", reply)
         self.assertNotIn("/evolve auto-evolve - select bounded", reply)


### PR DESCRIPTION
## Summary

Improves the visible `/evolve mode` help format.

- Changes the main help line to `/evolve mode <mode> - set self-evolution behavior`.
- In `/help evolve`, lists supported modes on a separate line: `Modes: disabled, co-evolve, auto-evolve.`
- Keeps existing mode parsing and compatibility aliases unchanged.

## Validation

- `python3 -m unittest tests.test_enoch_telegram.EnochTelegramTests.test_help_lists_safe_commands tests.test_enoch_telegram.EnochTelegramTests.test_help_evolve_shows_evolve_usage tests.test_enoch_telegram.EnochTelegramTests.test_evolve_can_set_theme_and_mode tests.test_enoch_telegram.EnochTelegramTests.test_evolve_keeps_direct_mode_aliases`
- `python3 -m unittest discover -s tests` passed: 323 tests.