### PR TITLE
Add evolve candidate queue

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -295,6 +295,9 @@ def help_message(topic: str = "") -> str:
             "/evolve - show self-evolution mode, theme, and top candidate",
             "/evolve mode <mode> - set self-evolution behavior",
             "/evolve theme <text> - set the current self-evolution theme",
+            "/evolve candidates - show current self-evolution candidates",
+            "/evolve select <id> - select a self-evolution candidate",
+            "/evolve reject <id> - reject a self-evolution candidate",
             "/evolve schedule <text> - let Enoch interpret common schedule text",
             "",
             "Operations:",
@@ -357,6 +360,9 @@ def _help_topic_message(topic: str) -> str:
                 "/evolve mode <mode> - set self-evolution behavior",
                 "Modes: disabled, co-evolve, auto-evolve.",
                 "/evolve theme <text> - set the current self-evolution theme",
+                "/evolve candidates - show current self-evolution candidates",
+                "/evolve select <id> - select a self-evolution candidate",
+                "/evolve reject <id> - reject a self-evolution candidate",
                 "/evolve schedule <text> - let Enoch interpret common schedule text",
             ]
         )

--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -13,11 +13,14 @@ from enoch.paths import enoch_home
 
 
 SCHEMA_VERSION = 1
+CANDIDATE_SCHEMA_VERSION = 1
 MODE_DISABLED = "disabled"
 MODE_CO_EVOLVE = "co-evolve"
 MODE_AUTO_EVOLVE = "auto-evolve"
 MODES = {MODE_DISABLED, MODE_CO_EVOLVE, MODE_AUTO_EVOLVE}
 DEFAULT_MODE = MODE_CO_EVOLVE
+CANDIDATE_STATUSES = {"candidate", "selected", "running", "done", "rejected"}
+VISIBLE_CANDIDATE_STATUSES = {"candidate", "selected", "running"}
 
 
 @dataclass(frozen=True)
@@ -57,6 +60,10 @@ class EvolveReport:
 
 def evolve_state_path(root: Path | None = None) -> Path:
     return enoch_home(root) / "evolve.json"
+
+
+def evolve_candidates_path(root: Path | None = None) -> Path:
+    return enoch_home(root) / "evolve_candidates.json"
 
 
 def load_evolve_state(root: Path | None = None) -> EvolveState:
@@ -276,7 +283,7 @@ def evolve_report(root: Path | None = None) -> EvolveReport:
     state = load_evolve_state(root)
     candidates = ()
     if state.mode != MODE_DISABLED:
-        candidates = rank_evolve_candidates(collect_evolve_candidates(root), theme=state.theme)
+        candidates = sync_evolve_candidates(root, theme=state.theme)
     counts: dict[str, int] = {}
     for candidate in candidates:
         counts[candidate.source] = counts.get(candidate.source, 0) + 1
@@ -295,13 +302,150 @@ def collect_evolve_candidates(root: Path | None = None) -> tuple[EvolveCandidate
     return tuple(candidates)
 
 
+def sync_evolve_candidates(root: Path | None = None, *, theme: str = "") -> tuple[EvolveCandidate, ...]:
+    stored = {candidate.id: candidate for candidate in _load_all_evolve_candidates(root)}
+    merged: dict[str, EvolveCandidate] = dict(stored)
+    for candidate in collect_evolve_candidates(root):
+        previous = stored.get(candidate.id)
+        status = previous.status if previous is not None else candidate.status
+        merged[candidate.id] = EvolveCandidate(**{**candidate.__dict__, "status": status})
+    ranked = rank_evolve_candidates(merged.values(), theme=theme)
+    _write_evolve_candidates(ranked, root)
+    return tuple(candidate for candidate in ranked if candidate.status in VISIBLE_CANDIDATE_STATUSES)
+
+
+def load_evolve_candidates(
+    root: Path | None = None,
+    *,
+    include_inactive: bool = False,
+    theme: str = "",
+) -> tuple[EvolveCandidate, ...]:
+    candidates = rank_evolve_candidates(_load_all_evolve_candidates(root), theme=theme)
+    if include_inactive:
+        return candidates
+    return tuple(candidate for candidate in candidates if candidate.status in VISIBLE_CANDIDATE_STATUSES)
+
+
+def select_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
+    return _set_candidate_status(candidate_id, "selected", root, theme=theme)
+
+
+def reject_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
+    return _set_candidate_status(candidate_id, "rejected", root, theme=theme)
+
+
 def rank_evolve_candidates(
     candidates: Iterable[EvolveCandidate],
     *,
     theme: str = "",
 ) -> tuple[EvolveCandidate, ...]:
     scored = [_score_candidate(candidate, theme=theme) for candidate in candidates]
-    return tuple(sorted(scored, key=lambda item: (-item.score, item.source, item.id)))
+    return tuple(sorted(scored, key=lambda item: (_candidate_status_order(item.status), -item.score, item.source, item.id)))
+
+
+def _load_all_evolve_candidates(root: Path | None = None) -> tuple[EvolveCandidate, ...]:
+    path = evolve_candidates_path(root)
+    if not path.exists():
+        return ()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ()
+    if not isinstance(raw, dict):
+        return ()
+    raw_candidates = raw.get("candidates")
+    if not isinstance(raw_candidates, list):
+        return ()
+    candidates = []
+    for raw_candidate in raw_candidates:
+        if isinstance(raw_candidate, dict):
+            candidate = _candidate_from_json(raw_candidate)
+            if candidate is not None:
+                candidates.append(candidate)
+    return tuple(candidates)
+
+
+def _write_evolve_candidates(candidates: Iterable[EvolveCandidate], root: Path | None = None) -> None:
+    payload = {
+        "schema_version": CANDIDATE_SCHEMA_VERSION,
+        "updated_at": current_time(),
+        "candidates": [_candidate_to_json(candidate) for candidate in candidates],
+    }
+    atomic_write(evolve_candidates_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _set_candidate_status(
+    candidate_id: str,
+    status: str,
+    root: Path | None = None,
+    *,
+    theme: str = "",
+) -> EvolveCandidate:
+    if status not in CANDIDATE_STATUSES:
+        raise ValueError(f"Evolve candidate status must be one of: {', '.join(sorted(CANDIDATE_STATUSES))}.")
+    candidates = list(sync_evolve_candidates(root, theme=theme))
+    inactive = [candidate for candidate in _load_all_evolve_candidates(root) if candidate.status not in VISIBLE_CANDIDATE_STATUSES]
+    candidates.extend(inactive)
+    for index, candidate in enumerate(candidates):
+        if _candidate_matches_id(candidate, candidate_id):
+            updated = EvolveCandidate(**{**candidate.__dict__, "status": status})
+            candidates[index] = updated
+            ranked = rank_evolve_candidates(candidates, theme=theme)
+            _write_evolve_candidates(ranked, root)
+            return _score_candidate(updated, theme=theme)
+    raise ValueError(f"No evolve candidate found for {candidate_id}.")
+
+
+def _candidate_to_json(candidate: EvolveCandidate) -> dict[str, object]:
+    return {
+        "id": candidate.id,
+        "source": candidate.source,
+        "title": candidate.title,
+        "rationale": candidate.rationale,
+        "proposed_change": candidate.proposed_change,
+        "expected_benefit": candidate.expected_benefit,
+        "risk": candidate.risk,
+        "test_plan": candidate.test_plan,
+        "status": candidate.status if candidate.status in CANDIDATE_STATUSES else "candidate",
+        "score": int(candidate.score),
+    }
+
+
+def _candidate_from_json(raw: dict[str, object]) -> EvolveCandidate | None:
+    candidate_id = clean_text(str(raw.get("id") or ""))
+    title = clean_text(str(raw.get("title") or ""))
+    if not candidate_id or not title:
+        return None
+    status = clean_text(str(raw.get("status") or "candidate")).lower()
+    if status not in CANDIDATE_STATUSES:
+        status = "candidate"
+    return EvolveCandidate(
+        id=candidate_id,
+        source=clean_text(str(raw.get("source") or "unknown")) or "unknown",
+        title=title,
+        rationale=clean_text(str(raw.get("rationale") or "")),
+        proposed_change=clean_text(str(raw.get("proposed_change") or "")),
+        expected_benefit=clean_text(str(raw.get("expected_benefit") or "")),
+        risk=clean_text(str(raw.get("risk") or "")),
+        test_plan=clean_text(str(raw.get("test_plan") or "")),
+        status=status,
+        score=_int(raw.get("score"), default=0),
+    )
+
+
+def _candidate_matches_id(candidate: EvolveCandidate, candidate_id: str) -> bool:
+    normalized = candidate_id.strip().lower().lstrip("#")
+    return candidate.id.lower() == normalized or candidate.id.lower().split("-", 1)[-1] == normalized
+
+
+def _candidate_status_order(status: str) -> int:
+    return {
+        "selected": 0,
+        "running": 1,
+        "candidate": 2,
+        "done": 3,
+        "rejected": 4,
+    }.get(status, 2)
 
 
 def _backlog_candidates(items: Iterable[BacklogItem]) -> list[EvolveCandidate]:

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -21,6 +21,8 @@ The MVP candidate sources are:
 - backlog items from `.enoch/backlog.json`;
 - direct-parent inheritance candidates from `.agent/lineage_inbox.json`.
 
+Candidates are persisted in `.enoch/evolve_candidates.json` so Enoch can remember whether a candidate has been selected, is running, is done, or has been rejected. Normal candidate views hide rejected and done candidates.
+
 Future sources may include feedback, experience, brainstorming, and learning from non-parent agents.
 
 ## Scheduler
@@ -44,8 +46,12 @@ Enoch must require human direction before changing identity, mission, secrets, p
 ## Commands
 
 - `/evolve`
-- `/evolve mode disabled|co-evolve|auto-evolve`
+- `/evolve mode <mode>`
 - `/evolve theme <text>`
+- `/evolve candidates`
+- `/evolve candidates all`
+- `/evolve select <id>`
+- `/evolve reject <id>`
 - `/evolve schedule <text>`
 - `/evolve schedule once a day`
 - `/evolve schedule every <interval>`

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -52,6 +52,9 @@ from enoch.evolve import (
     claim_due_evolve_schedule,
     disable_evolve_schedule,
     evolve_report,
+    load_evolve_candidates,
+    reject_evolve_candidate,
+    select_evolve_candidate,
     set_evolve_cron_schedule,
     set_evolve_daily_schedule,
     set_evolve_schedule,
@@ -1052,7 +1055,7 @@ class EnochTelegramBot:
             return _format_evolve_report(evolve_report(self.root))
         if subcommand == "mode":
             if not rest.strip():
-                return "Use /evolve mode disabled|co-evolve|auto-evolve to set self-evolution behavior."
+                return "Use /evolve mode <mode> to set self-evolution behavior. Modes: disabled, co-evolve, auto-evolve."
             try:
                 set_evolve_mode(rest, self.root)
             except ValueError as error:
@@ -1063,6 +1066,33 @@ class EnochTelegramBot:
                 return "Use /evolve theme <text> to set Enoch's current evolution theme."
             set_evolve_theme(rest, self.root)
             return _format_evolve_report(evolve_report(self.root))
+        if subcommand in {"candidate", "candidates"}:
+            report = evolve_report(self.root)
+            include_inactive = rest.strip().lower() in {"all", "inactive"}
+            candidates = (
+                load_evolve_candidates(self.root, include_inactive=True, theme=report.state.theme)
+                if include_inactive
+                else report.candidates
+            )
+            return _format_evolve_candidates(candidates, include_inactive=include_inactive)
+        if subcommand == "select":
+            if not rest.strip():
+                return "Use /evolve select <id> to select a self-evolution candidate."
+            state = evolve_report(self.root).state
+            try:
+                candidate = select_evolve_candidate(rest, self.root, theme=state.theme)
+            except ValueError as error:
+                return str(error)
+            return "Selected evolve candidate.\n\n" + "\n".join(_format_evolve_candidate(candidate))
+        if subcommand == "reject":
+            if not rest.strip():
+                return "Use /evolve reject <id> to reject a self-evolution candidate."
+            state = evolve_report(self.root).state
+            try:
+                candidate = reject_evolve_candidate(rest, self.root, theme=state.theme)
+            except ValueError as error:
+                return str(error)
+            return "Rejected evolve candidate.\n\n" + "\n".join(_format_evolve_candidate(candidate))
         if subcommand == "schedule":
             return self._evolve_schedule(rest)
         return _evolve_usage()
@@ -2108,12 +2138,27 @@ def _format_evolve_schedule(state: EvolveState) -> str:
 
 def _format_evolve_candidate(candidate: EvolveCandidate) -> list[str]:
     return [
-        f"- {candidate.id} [{candidate.source}] {_clip_activity_text(candidate.title, limit=100)}",
+        f"- {candidate.id} [{candidate.status} {candidate.source}] {_clip_activity_text(candidate.title, limit=100)}",
         f"  Score: {candidate.score}",
         f"  Rationale: {_clip_activity_text(candidate.rationale, limit=180)}",
         f"  Proposed change: {_clip_activity_text(candidate.proposed_change, limit=180)}",
         f"  Test plan: {_clip_activity_text(candidate.test_plan, limit=180)}",
     ]
+
+
+def _format_evolve_candidates(candidates: tuple[EvolveCandidate, ...], *, include_inactive: bool = False) -> str:
+    title = "Evolve candidates"
+    if include_inactive:
+        title += " (all)"
+    lines = [f"{title}:"]
+    if not candidates:
+        lines.append("- none")
+        return "\n".join(lines)
+    for candidate in candidates[:10]:
+        lines.extend(_format_evolve_candidate(candidate))
+    if len(candidates) > 10:
+        lines.append(f"- {len(candidates) - 10} more")
+    return "\n".join(lines)
 
 
 def _evolve_next_action(report: EvolveReport) -> str:
@@ -2257,6 +2302,9 @@ def _evolve_usage() -> str:
             "Use /evolve mode <mode> to set self-evolution behavior.",
             "Modes: disabled, co-evolve, auto-evolve.",
             "Use /evolve theme <text> to set the current evolution theme.",
+            "Use /evolve candidates to show current candidates.",
+            "Use /evolve select <id> to select a candidate.",
+            "Use /evolve reject <id> to reject a candidate.",
             "Use /evolve schedule <text> to let Enoch interpret common schedule text.",
         ]
     )

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -16,8 +16,11 @@ from enoch.evolve import (
     collect_evolve_candidates,
     disable_evolve_schedule,
     evolve_report,
+    load_evolve_candidates,
     load_evolve_state,
     rank_evolve_candidates,
+    reject_evolve_candidate,
+    select_evolve_candidate,
     set_evolve_cron_schedule,
     set_evolve_daily_schedule,
     set_evolve_schedule,
@@ -69,6 +72,25 @@ class EnochEvolveTests(unittest.TestCase):
 
         self.assertEqual(state.theme, "improve Telegram work UX")
         self.assertEqual(loaded.theme, "improve Telegram work UX")
+
+    def test_candidate_status_is_persisted_across_reports(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(1, "low value cleanup", root, priority="p2")
+            add_backlog_item(2, "important Telegram recovery", root, priority="p0")
+
+            selected = select_evolve_candidate("backlog-1", root)
+            report = evolve_report(root)
+            rejected = reject_evolve_candidate("backlog-1", root)
+            visible = load_evolve_candidates(root)
+            all_candidates = load_evolve_candidates(root, include_inactive=True)
+
+        self.assertEqual(selected.status, "selected")
+        self.assertEqual(report.top_candidate.id, "backlog-1")
+        self.assertEqual(report.top_candidate.status, "selected")
+        self.assertEqual(rejected.status, "rejected")
+        self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
+        self.assertIn("backlog-1", {candidate.id for candidate in all_candidates})
 
     def test_schedule_can_be_set_claimed_and_disabled(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -607,6 +607,9 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/evolve mode <mode> - set self-evolution behavior", client.sent[0][1])
         self.assertNotIn("/evolve mode disabled|co-evolve|auto-evolve", client.sent[0][1])
         self.assertIn("/evolve theme <text> - set the current self-evolution theme", client.sent[0][1])
+        self.assertIn("/evolve candidates - show current self-evolution candidates", client.sent[0][1])
+        self.assertIn("/evolve select <id> - select a self-evolution candidate", client.sent[0][1])
+        self.assertIn("/evolve reject <id> - reject a self-evolution candidate", client.sent[0][1])
         self.assertIn("/evolve schedule <text> - let Enoch interpret common schedule text", client.sent[0][1])
         self.assertNotIn("/evolve schedule off - stop scheduled evolve checks", client.sent[0][1])
         self.assertNotIn("/evolve schedule once a day - run evolve once per day", client.sent[0][1])
@@ -669,6 +672,9 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertNotIn("/evolve disabled - stop collecting", reply)
         self.assertNotIn("/evolve auto-evolve - select bounded", reply)
         self.assertIn("/evolve theme <text>", reply)
+        self.assertIn("/evolve candidates", reply)
+        self.assertIn("/evolve select <id>", reply)
+        self.assertIn("/evolve reject <id>", reply)
         self.assertIn("/evolve schedule <text>", reply)
         self.assertNotIn("/evolve schedule off - stop scheduled evolve checks", reply)
         self.assertNotIn("/evolve schedule once a day - run evolve once per day", reply)
@@ -1210,8 +1216,32 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("Evolve:", reply)
         self.assertIn("Mode: co-evolve", reply)
         self.assertIn("- backlog: 1", reply)
-        self.assertIn("backlog-1 [backlog] improve Telegram work UX", reply)
+        self.assertIn("backlog-1 [candidate backlog] improve Telegram work UX", reply)
         self.assertIn("wait for human approval", reply)
+
+    def test_evolve_can_list_select_and_reject_candidates(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "low value cleanup", root, priority="p2")
+            add_backlog_item(42, "important Telegram recovery", root, priority="p0")
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve candidates"))
+            bot.handle_update(_message_update(update_id=2, chat_id=42, text="/evolve select backlog-1"))
+            bot.handle_update(_message_update(update_id=3, chat_id=42, text="/evolve"))
+            bot.handle_update(_message_update(update_id=4, chat_id=42, text="/evolve reject 1"))
+            bot.handle_update(_message_update(update_id=5, chat_id=42, text="/evolve candidates"))
+            bot.handle_update(_message_update(update_id=6, chat_id=42, text="/evolve candidates all"))
+
+        self.assertIn("Evolve candidates:", client.sent[0][1])
+        self.assertIn("backlog-1 [candidate backlog] low value cleanup", client.sent[0][1])
+        self.assertIn("Selected evolve candidate.", client.sent[1][1])
+        self.assertIn("backlog-1 [selected backlog] low value cleanup", client.sent[1][1])
+        self.assertIn("backlog-1 [selected backlog] low value cleanup", client.sent[2][1])
+        self.assertIn("Rejected evolve candidate.", client.sent[3][1])
+        self.assertNotIn("backlog-1", client.sent[4][1])
+        self.assertIn("backlog-1 [rejected backlog] low value cleanup", client.sent[5][1])
 
     def test_evolve_can_set_theme_and_mode(self) -> None:
         with TemporaryDirectory() as temp:
@@ -1334,7 +1364,7 @@ class EnochTelegramTests(unittest.TestCase):
 
         self.assertIsNone(job)
         self.assertIn("Scheduled evolve check", client.sent[0][1])
-        self.assertIn("backlog-1 [backlog] improve Telegram work UX", client.sent[0][1])
+        self.assertIn("backlog-1 [candidate backlog] improve Telegram work UX", client.sent[0][1])
 
     def test_due_evolve_schedule_auto_mode_queues_top_candidate(self) -> None:
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- Persist evolve candidates in `.enoch/evolve_candidates.json` with candidate/selected/running/done/rejected state
- Add `/evolve candidates`, `/evolve select <id>`, and `/evolve reject <id>` Telegram commands
- Update `/help`, evolve skill docs, and tests for the candidate queue workflow

## Tests
- `python3 -m unittest discover -s tests`