### PR TITLE
Add more evolve candidate sources

### DIFF
--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from typing import Iterable
 
 from enoch.backlog import BacklogItem, backlog_status
+from enoch.automatic_learning import LearningArtifact, learning_index_path
+from enoch.cron import CronJob, cron_status, format_cron_interval
 from enoch.lineage.core import LineageCandidate, load_parent_inbox_candidates
 from enoch.memory.paths import atomic_write, clean_text, now as current_time
 from enoch.paths import enoch_home
+from enoch.task_queue import TaskJob, task_queue_status
 
 
 SCHEMA_VERSION = 1
@@ -299,6 +302,9 @@ def collect_evolve_candidates(root: Path | None = None) -> tuple[EvolveCandidate
     candidates: list[EvolveCandidate] = []
     candidates.extend(_backlog_candidates(backlog_status(root).pending))
     candidates.extend(_inheritance_candidates(load_parent_inbox_candidates(root)))
+    candidates.extend(_task_history_candidates(task_queue_status(root).history))
+    candidates.extend(_cron_candidates(cron_status(root).active))
+    candidates.extend(_learning_candidates(_load_learning_artifacts(root)))
     return tuple(candidates)
 
 
@@ -488,6 +494,131 @@ def _inheritance_candidates(items: Iterable[LineageCandidate]) -> list[EvolveCan
     return candidates
 
 
+def _task_history_candidates(items: Iterable[TaskJob]) -> list[EvolveCandidate]:
+    candidates = []
+    for item in items:
+        if item.status not in {"failed", "cancelled"}:
+            continue
+        result = clean_text(item.result)
+        is_failed = item.status == "failed"
+        candidates.append(
+            EvolveCandidate(
+                id=f"task-{item.id}",
+                source="task-history",
+                title=f"Improve reliability after {item.status} task #{item.id}: {item.text}",
+                rationale=(
+                    f"Task #{item.id} ended as {item.status}."
+                    + (f" Result: {result}" if result else "")
+                ),
+                proposed_change=(
+                    "Inspect the task request, result, and surrounding workflow; add a small fix or guardrail that "
+                    "prevents similar work from failing again."
+                ),
+                expected_benefit="Turns recent operational friction into a concrete reliability improvement.",
+                risk="The original task may have failed for transient reasons, so avoid broad changes without evidence.",
+                test_plan="Reproduce the failed or cancelled path if possible, then run focused tests around the changed workflow.",
+                score=30 if is_failed else 18,
+            )
+        )
+    return candidates
+
+
+def _cron_candidates(items: Iterable[CronJob]) -> list[EvolveCandidate]:
+    candidates = []
+    for item in items:
+        cadence = format_cron_interval(item.interval_seconds)
+        candidates.append(
+            EvolveCandidate(
+                id=f"cron-{item.id}",
+                source="cron",
+                title=f"Review recurring workflow #{item.id}: {item.text}",
+                rationale=(
+                    f"Active cron job runs every {cadence}; next run {item.next_run_at or 'unknown'}."
+                    + (f" Last task #{item.last_task_id}." if item.last_task_id is not None else "")
+                ),
+                proposed_change=(
+                    "Inspect whether the recurring request is still useful, has enough context, and should be made "
+                    "safer or more observable."
+                ),
+                expected_benefit="Keeps scheduled automation aligned with current needs instead of letting stale jobs drift.",
+                risk="Recurring jobs are user-facing automation; changes should not silently disable or broaden their behavior.",
+                test_plan="Run cron parsing/status tests and verify the scheduled request still renders clearly in Telegram.",
+                score=12,
+            )
+        )
+    return candidates
+
+
+def _learning_candidates(items: Iterable[LearningArtifact]) -> list[EvolveCandidate]:
+    candidates = []
+    for item in items:
+        skills = ", ".join(item.skill_names) or "unknown"
+        candidates.append(
+            EvolveCandidate(
+                id=f"learning-{item.id}",
+                source="learning",
+                title=f"Turn learned skill work into reusable behavior: {skills}",
+                rationale=f"Learning artifact from task {item.task_id or 'unknown'} recorded skill work for {skills}.",
+                proposed_change=(
+                    "Inspect the learning artifact and decide whether Enoch should adapt docs, tests, or command behavior "
+                    "from that successful skill change."
+                ),
+                expected_benefit="Promotes successful skill work into deliberate self-improvement instead of passive archive data.",
+                risk="The artifact may be too context-specific to generalize; adapt only reusable pieces.",
+                test_plan="Run skill discovery tests and focused tests for any adapted skill behavior.",
+                score=20,
+            )
+        )
+    return candidates
+
+
+def _load_learning_artifacts(root: Path | None = None, *, limit: int = 10) -> tuple[LearningArtifact, ...]:
+    path = learning_index_path(root)
+    if not path.exists():
+        return ()
+    artifacts = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ()
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        artifact = _learning_artifact_from_json(raw)
+        if artifact is not None:
+            artifacts.append(artifact)
+        if len(artifacts) >= limit:
+            break
+    return tuple(artifacts)
+
+
+def _learning_artifact_from_json(raw: object) -> LearningArtifact | None:
+    if not isinstance(raw, dict):
+        return None
+    artifact_id = clean_text(str(raw.get("id") or ""))
+    request = clean_text(str(raw.get("request") or ""))
+    if not artifact_id or not request:
+        return None
+    return LearningArtifact(
+        id=artifact_id,
+        artifact_type=clean_text(str(raw.get("artifact_type") or "skill")) or "skill",
+        source_agent=clean_text(str(raw.get("source_agent") or "")),
+        created_at=str(raw.get("created_at") or ""),
+        task_id=_optional_int(raw.get("task_id")),
+        command=clean_text(str(raw.get("command") or "")),
+        request=request,
+        result_summary=clean_text(str(raw.get("result_summary") or "")),
+        pr_urls=_string_tuple(raw.get("pr_urls")),
+        changed_files=_string_tuple(raw.get("changed_files")),
+        skill_names=_string_tuple(raw.get("skill_names")),
+        context_source=clean_text(str(raw.get("context_source") or "")),
+    )
+
+
 def _score_candidate(candidate: EvolveCandidate, *, theme: str) -> EvolveCandidate:
     score = candidate.score + 25
     text = " ".join([candidate.title, candidate.rationale, candidate.proposed_change]).lower()
@@ -498,7 +629,27 @@ def _score_candidate(candidate: EvolveCandidate, *, theme: str) -> EvolveCandida
         score += 10
     if candidate.source == "inheritance":
         score += 8
+    if candidate.source == "task-history":
+        score += 12
+    if candidate.source == "learning":
+        score += 6
     return EvolveCandidate(**{**candidate.__dict__, "score": score})
+
+
+def _optional_int(value: object) -> int | None:
+    parsed = _int(value, default=0)
+    return parsed if parsed > 0 else None
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    output = []
+    for item in value:
+        cleaned = clean_text(str(item or ""))
+        if cleaned:
+            output.append(cleaned)
+    return tuple(output)
 
 
 def _utc_now() -> datetime:

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -20,10 +20,13 @@ The MVP candidate sources are:
 
 - backlog items from `.enoch/backlog.json`;
 - direct-parent inheritance candidates from `.agent/lineage_inbox.json`.
+- recent failed or cancelled task history from `.enoch/task_queue.json`;
+- active recurring work from `.enoch/cron.json`;
+- recent automatic learning artifacts from `.enoch/learning/artifacts.jsonl`.
 
 Candidates are persisted in `.enoch/evolve_candidates.json` so Enoch can remember whether a candidate has been selected, is running, is done, or has been rejected. Normal candidate views hide rejected and done candidates.
 
-Future sources may include feedback, experience, brainstorming, and learning from non-parent agents.
+Future sources may include explicit feedback, conversation patterns, brainstorming, and learning from non-parent agents.
 
 ## Scheduler
 

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -10,6 +10,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from enoch.backlog import add_backlog_item
+from enoch.automatic_learning import record_learning_artifact
+from enoch.cron import add_cron_job
 from enoch.evolve import (
     MODE_DISABLED,
     claim_due_evolve_schedule,
@@ -27,7 +29,9 @@ from enoch.evolve import (
     set_evolve_mode,
     set_evolve_theme,
 )
+from enoch.identity import load_identity
 from enoch.lineage.core import LineageCandidate
+from enoch.task_queue import begin_next_task, enqueue_task, fail_task
 
 
 class EnochEvolveTests(unittest.TestCase):
@@ -50,6 +54,34 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertEqual({candidate.source for candidate in candidates}, {"backlog", "inheritance"})
         self.assertEqual(ranked[0].source, "backlog")
         self.assertIn("Telegram", ranked[0].title)
+
+    def test_collects_operational_and_learning_candidates(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            queued = enqueue_task(42, "ship flaky workflow", root)
+            running = begin_next_task(root)
+            assert running is not None
+            fail_task(queued.id, root, result="Tests failed in Telegram workflow.")
+            add_cron_job(42, "summarize health", 24 * 60 * 60, root)
+            record_learning_artifact(
+                load_identity(),
+                request="add a notes skill",
+                result="\n".join(["Files:", "- src/enoch/skills/notes/SKILL.md"]),
+                root=root,
+                task_id=7,
+                command="/task",
+            )
+
+            candidates = collect_evolve_candidates(root)
+            report = evolve_report(root)
+
+        sources = {candidate.source for candidate in candidates}
+        self.assertIn("task-history", sources)
+        self.assertIn("cron", sources)
+        self.assertIn("learning", sources)
+        self.assertEqual(report.counts_by_source["task-history"], 1)
+        self.assertEqual(report.counts_by_source["cron"], 1)
+        self.assertEqual(report.counts_by_source["learning"], 1)
 
     def test_disabled_mode_does_not_collect_candidates(self) -> None:
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- Add evolve candidates from recent failed/cancelled task history
- Add evolve candidates for active cron jobs and recent learning artifacts
- Document the expanded candidate sources and cover them with evolve tests

## Tests
- `python3 -m unittest discover -s tests`