### PR TITLE
Add evolve run command

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -297,6 +297,7 @@ def help_message(topic: str = "") -> str:
             "/evolve theme <text> - set the current self-evolution theme",
             "/evolve candidates - show current self-evolution candidates",
             "/evolve select <id> - select a self-evolution candidate",
+            "/evolve run <id> - queue a self-evolution candidate as a task",
             "/evolve reject <id> - reject a self-evolution candidate",
             "/evolve schedule <text> - let Enoch interpret common schedule text",
             "",
@@ -362,6 +363,7 @@ def _help_topic_message(topic: str) -> str:
                 "/evolve theme <text> - set the current self-evolution theme",
                 "/evolve candidates - show current self-evolution candidates",
                 "/evolve select <id> - select a self-evolution candidate",
+                "/evolve run <id> - queue a self-evolution candidate as a task",
                 "/evolve reject <id> - reject a self-evolution candidate",
                 "/evolve schedule <text> - let Enoch interpret common schedule text",
             ]

--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -332,12 +332,25 @@ def load_evolve_candidates(
     return tuple(candidate for candidate in candidates if candidate.status in VISIBLE_CANDIDATE_STATUSES)
 
 
+def get_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
+    candidates = list(sync_evolve_candidates(root, theme=theme))
+    candidates.extend(candidate for candidate in _load_all_evolve_candidates(root) if candidate.status not in VISIBLE_CANDIDATE_STATUSES)
+    for candidate in candidates:
+        if _candidate_matches_id(candidate, candidate_id):
+            return _score_candidate(candidate, theme=theme)
+    raise ValueError(f"No evolve candidate found for {candidate_id}.")
+
+
 def select_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
     return _set_candidate_status(candidate_id, "selected", root, theme=theme)
 
 
 def reject_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
     return _set_candidate_status(candidate_id, "rejected", root, theme=theme)
+
+
+def run_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
+    return _set_candidate_status(candidate_id, "running", root, theme=theme)
 
 
 def rank_evolve_candidates(

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -54,6 +54,7 @@ Enoch must require human direction before changing identity, mission, secrets, p
 - `/evolve candidates`
 - `/evolve candidates all`
 - `/evolve select <id>`
+- `/evolve run <id>`
 - `/evolve reject <id>`
 - `/evolve schedule <text>`
 - `/evolve schedule once a day`

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -52,8 +52,10 @@ from enoch.evolve import (
     claim_due_evolve_schedule,
     disable_evolve_schedule,
     evolve_report,
+    get_evolve_candidate,
     load_evolve_candidates,
     reject_evolve_candidate,
+    run_evolve_candidate,
     select_evolve_candidate,
     set_evolve_cron_schedule,
     set_evolve_daily_schedule,
@@ -1093,9 +1095,37 @@ class EnochTelegramBot:
             except ValueError as error:
                 return str(error)
             return "Rejected evolve candidate.\n\n" + "\n".join(_format_evolve_candidate(candidate))
+        if subcommand == "run":
+            if not rest.strip():
+                return "Use /evolve run <id> to queue a self-evolution candidate."
+            return self._evolve_run(rest)
         if subcommand == "schedule":
             return self._evolve_schedule(rest)
         return _evolve_usage()
+
+    def _evolve_run(self, candidate_id: str) -> str:
+        chat_id = self.client.config.allowed_chat_id
+        if chat_id is None:
+            return "Enoch needs a locked Telegram chat before queueing evolve work."
+        state = evolve_report(self.root).state
+        try:
+            candidate = get_evolve_candidate(candidate_id, self.root, theme=state.theme)
+        except ValueError as error:
+            return str(error)
+        try:
+            job = enqueue_task(
+                chat_id,
+                _evolve_task_request(candidate, state.theme),
+                self.root,
+                context=_evolve_task_context(candidate),
+                context_source="evolve-run",
+            )
+        except (OSError, ValueError):
+            return "Enoch could not queue that evolve candidate."
+        candidate = run_evolve_candidate(candidate.id, self.root, theme=state.theme)
+        return f"Queued evolve candidate {candidate.id} as task #{job.id}.\n\n" + "\n".join(
+            _format_evolve_candidate(candidate)
+        )
 
     def _evolve_schedule(self, argument: str) -> str:
         text = _unquote_schedule_text(argument)
@@ -1347,8 +1377,9 @@ class EnochTelegramBot:
             return None
         if claimed.mode != MODE_AUTO_EVOLVE or report.top_candidate is None:
             return None
-        request = _evolve_task_request(report.top_candidate, report.state.theme)
-        context = _evolve_task_context(report.top_candidate)
+        candidate = report.top_candidate
+        request = _evolve_task_request(candidate, report.state.theme)
+        context = _evolve_task_context(candidate)
         try:
             job = enqueue_task(
                 chat_id,
@@ -1359,6 +1390,7 @@ class EnochTelegramBot:
             )
         except (OSError, ValueError):
             return None
+        run_evolve_candidate(candidate.id, self.root, theme=report.state.theme)
         message = _format_work_status_message(
             WorkStatusMessage(
                 chat_id=chat_id,
@@ -2304,6 +2336,7 @@ def _evolve_usage() -> str:
             "Use /evolve theme <text> to set the current evolution theme.",
             "Use /evolve candidates to show current candidates.",
             "Use /evolve select <id> to select a candidate.",
+            "Use /evolve run <id> to queue a candidate as a task.",
             "Use /evolve reject <id> to reject a candidate.",
             "Use /evolve schedule <text> to let Enoch interpret common schedule text.",
         ]

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -22,6 +22,7 @@ from enoch.evolve import (
     load_evolve_state,
     rank_evolve_candidates,
     reject_evolve_candidate,
+    run_evolve_candidate,
     select_evolve_candidate,
     set_evolve_cron_schedule,
     set_evolve_daily_schedule,
@@ -123,6 +124,18 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertEqual(rejected.status, "rejected")
         self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
         self.assertIn("backlog-1", {candidate.id for candidate in all_candidates})
+
+    def test_run_candidate_marks_it_running(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(1, "ship evolve run", root, priority="p1")
+
+            running = run_evolve_candidate("backlog-1", root)
+            visible = load_evolve_candidates(root)
+
+        self.assertEqual(running.status, "running")
+        self.assertEqual(visible[0].id, "backlog-1")
+        self.assertEqual(visible[0].status, "running")
 
     def test_schedule_can_be_set_claimed_and_disabled(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -20,7 +20,7 @@ from enoch.backlog import add_backlog_item, backlog_status
 from enoch.config import read_section
 from enoch.command_surface import checktree as _checktree
 from enoch.cron import add_cron_job, cron_status
-from enoch.evolve import MODE_AUTO_EVOLVE, set_evolve_mode, set_evolve_schedule
+from enoch.evolve import MODE_AUTO_EVOLVE, evolve_report, set_evolve_mode, set_evolve_schedule
 from enoch.git_tools import GitError
 from enoch.github.workflow import (
     LocalPublishResult,
@@ -609,6 +609,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/evolve theme <text> - set the current self-evolution theme", client.sent[0][1])
         self.assertIn("/evolve candidates - show current self-evolution candidates", client.sent[0][1])
         self.assertIn("/evolve select <id> - select a self-evolution candidate", client.sent[0][1])
+        self.assertIn("/evolve run <id> - queue a self-evolution candidate as a task", client.sent[0][1])
         self.assertIn("/evolve reject <id> - reject a self-evolution candidate", client.sent[0][1])
         self.assertIn("/evolve schedule <text> - let Enoch interpret common schedule text", client.sent[0][1])
         self.assertNotIn("/evolve schedule off - stop scheduled evolve checks", client.sent[0][1])
@@ -674,6 +675,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/evolve theme <text>", reply)
         self.assertIn("/evolve candidates", reply)
         self.assertIn("/evolve select <id>", reply)
+        self.assertIn("/evolve run <id>", reply)
         self.assertIn("/evolve reject <id>", reply)
         self.assertIn("/evolve schedule <text>", reply)
         self.assertNotIn("/evolve schedule off - stop scheduled evolve checks", reply)
@@ -1243,6 +1245,23 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertNotIn("backlog-1", client.sent[4][1])
         self.assertIn("backlog-1 [rejected backlog] low value cleanup", client.sent[5][1])
 
+    def test_evolve_run_queues_candidate_as_task(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "ship evolve run", root, priority="p1")
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve run backlog-1"))
+            queued = task_queue_status(root)
+
+        self.assertEqual(queued.pending_count, 1)
+        self.assertIn("Queued evolve candidate backlog-1 as task #1.", client.sent[0][1])
+        self.assertIn("backlog-1 [running backlog] ship evolve run", client.sent[0][1])
+        self.assertIn("Evolve selected candidate backlog-1", queued.pending[0].text)
+        self.assertEqual(queued.pending[0].context_source, "evolve-run")
+        self.assertIn("Scheduled evolve candidate context:", queued.pending[0].context)
+
     def test_evolve_can_set_theme_and_mode(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
@@ -1381,11 +1400,13 @@ class EnochTelegramTests(unittest.TestCase):
 
             job = bot._run_due_evolve_schedule()
             queued = task_queue_status(root)
+            report = evolve_report(root)
 
         self.assertIsNotNone(job)
         self.assertEqual(queued.pending_count, 1)
         self.assertIn("Evolve selected candidate backlog-1", queued.pending[0].text)
         self.assertEqual(queued.pending[0].context_source, "evolve-scheduler")
+        self.assertEqual(report.top_candidate.status, "running")
         self.assertIn("Latest update: Scheduled by evolve auto-evolve.", client.sent[0][1])
 
     @patch("enoch.telegram.bot.ensure_long_term_memory")


### PR DESCRIPTION
## Summary
- Add `/evolve run <id>` to queue a selected self-evolution candidate as a task
- Mark candidates as `running` only after they are successfully queued
- Update help/docs and keep scheduler auto-evolve status in sync

## Tests
- `python3 -m unittest discover -s tests`