### PR TITLE
Mark completed evolve tasks done

### DIFF
--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -353,6 +353,25 @@ def run_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: 
     return _set_candidate_status(candidate_id, "running", root, theme=theme)
 
 
+def complete_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
+    return _set_candidate_status(candidate_id, "done", root, theme=theme)
+
+
+def complete_evolve_candidate_for_task(
+    job: TaskJob,
+    root: Path | None = None,
+    *,
+    theme: str = "",
+) -> EvolveCandidate | None:
+    candidate_id = _evolve_candidate_id_from_task(job)
+    if not candidate_id:
+        return None
+    try:
+        return complete_evolve_candidate(candidate_id, root, theme=theme)
+    except ValueError:
+        return None
+
+
 def rank_evolve_candidates(
     candidates: Iterable[EvolveCandidate],
     *,
@@ -455,6 +474,16 @@ def _candidate_from_json(raw: dict[str, object]) -> EvolveCandidate | None:
 def _candidate_matches_id(candidate: EvolveCandidate, candidate_id: str) -> bool:
     normalized = candidate_id.strip().lower().lstrip("#")
     return candidate.id.lower() == normalized or candidate.id.lower().split("-", 1)[-1] == normalized
+
+
+def _evolve_candidate_id_from_task(job: TaskJob) -> str:
+    if job.context_source not in {"evolve-run", "evolve-scheduler"}:
+        return ""
+    for raw_line in job.context.splitlines():
+        label, separator, value = raw_line.partition(":")
+        if separator and label.strip().lower() == "id":
+            return clean_text(value)
+    return ""
 
 
 def _candidate_status_order(status: str) -> int:

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -50,6 +50,7 @@ from enoch.evolve import (
     EvolveReport,
     EvolveState,
     claim_due_evolve_schedule,
+    complete_evolve_candidate_for_task,
     disable_evolve_schedule,
     evolve_report,
     get_evolve_candidate,
@@ -1477,6 +1478,7 @@ class EnochTelegramBot:
                 fail_task(job.id, self.root, result=reply)
             else:
                 complete_task(job.id, self.root, result=reply)
+                complete_evolve_candidate_for_task(job, self.root)
         completed_job = _history_task(job.id, self.root)
         summary_job = completed_job or job
         if completed_status == "completed":
@@ -1989,6 +1991,7 @@ def _recover_running_task_from_direct_action_log(root: Path) -> None:
         fail_task(running.id, root, result=result)
     else:
         complete_task(running.id, root, result=result)
+        complete_evolve_candidate_for_task(running, root)
 
 
 def _latest_direct_action_result_for_task(job: TaskJob, root: Path) -> str:

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -18,6 +18,7 @@ from enoch.evolve import (
     collect_evolve_candidates,
     disable_evolve_schedule,
     evolve_report,
+    complete_evolve_candidate_for_task,
     load_evolve_candidates,
     load_evolve_state,
     rank_evolve_candidates,
@@ -136,6 +137,29 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertEqual(running.status, "running")
         self.assertEqual(visible[0].id, "backlog-1")
         self.assertEqual(visible[0].status, "running")
+
+    def test_completed_evolve_task_marks_candidate_done(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(1, "ship evolve completion", root, priority="p1")
+            run_evolve_candidate("backlog-1", root)
+            job = enqueue_task(
+                42,
+                "Evolve selected candidate backlog-1",
+                root,
+                context="\n".join(["Scheduled evolve candidate context:", "ID: backlog-1"]),
+                context_source="evolve-run",
+            )
+
+            completed = complete_evolve_candidate_for_task(job, root)
+            visible = load_evolve_candidates(root)
+            all_candidates = load_evolve_candidates(root, include_inactive=True)
+
+        assert completed is not None
+        self.assertEqual(completed.status, "done")
+        self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
+        self.assertEqual(all_candidates[0].id, "backlog-1")
+        self.assertEqual(all_candidates[0].status, "done")
 
     def test_schedule_can_be_set_claimed_and_disabled(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -20,7 +20,7 @@ from enoch.backlog import add_backlog_item, backlog_status
 from enoch.config import read_section
 from enoch.command_surface import checktree as _checktree
 from enoch.cron import add_cron_job, cron_status
-from enoch.evolve import MODE_AUTO_EVOLVE, evolve_report, set_evolve_mode, set_evolve_schedule
+from enoch.evolve import MODE_AUTO_EVOLVE, evolve_report, load_evolve_candidates, set_evolve_mode, set_evolve_schedule
 from enoch.git_tools import GitError
 from enoch.github.workflow import (
     LocalPublishResult,
@@ -1261,6 +1261,32 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("Evolve selected candidate backlog-1", queued.pending[0].text)
         self.assertEqual(queued.pending[0].context_source, "evolve-run")
         self.assertIn("Scheduled evolve candidate context:", queued.pending[0].context)
+
+    @patch("enoch.telegram.bot.ensure_long_term_memory")
+    @patch("enoch.telegram.bot.log_conversation_turn")
+    def test_evolve_run_candidate_is_marked_done_after_task_completion(
+        self,
+        _log_conversation_turn: MagicMock,
+        _update_memory: MagicMock,
+    ) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "ship evolve completion", root, priority="p1")
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve run backlog-1"))
+            job = begin_next_task(root)
+            assert job is not None
+            with patch.object(bot, "_run_direct_work", return_value="Done with evolve work."):
+                bot._run_task_job(job)
+            visible = load_evolve_candidates(root)
+            all_candidates = load_evolve_candidates(root, include_inactive=True)
+
+        self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
+        self.assertEqual(all_candidates[0].id, "backlog-1")
+        self.assertEqual(all_candidates[0].status, "done")
+        self.assertIn("Final status: completed", client.sent[-1][1])
 
     def test_evolve_can_set_theme_and_mode(self) -> None:
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- Mark evolve candidates `done` when their queued evolve task completes successfully
- Parse evolve candidate IDs from evolve-run/evolve-scheduler task context
- Preserve failed/cancelled evolve tasks for task-history follow-up candidates

## Tests
- `python3 -m unittest discover -s tests`