### PR TITLE
Track failed evolve tasks

### DIFF
--- a/src/enoch/evolve.py
+++ b/src/enoch/evolve.py
@@ -22,7 +22,7 @@ MODE_CO_EVOLVE = "co-evolve"
 MODE_AUTO_EVOLVE = "auto-evolve"
 MODES = {MODE_DISABLED, MODE_CO_EVOLVE, MODE_AUTO_EVOLVE}
 DEFAULT_MODE = MODE_CO_EVOLVE
-CANDIDATE_STATUSES = {"candidate", "selected", "running", "done", "rejected"}
+CANDIDATE_STATUSES = {"candidate", "selected", "running", "done", "failed", "cancelled", "rejected"}
 VISIBLE_CANDIDATE_STATUSES = {"candidate", "selected", "running"}
 
 
@@ -357,6 +357,14 @@ def complete_evolve_candidate(candidate_id: str, root: Path | None = None, *, th
     return _set_candidate_status(candidate_id, "done", root, theme=theme)
 
 
+def fail_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
+    return _set_candidate_status(candidate_id, "failed", root, theme=theme)
+
+
+def cancel_evolve_candidate(candidate_id: str, root: Path | None = None, *, theme: str = "") -> EvolveCandidate:
+    return _set_candidate_status(candidate_id, "cancelled", root, theme=theme)
+
+
 def complete_evolve_candidate_for_task(
     job: TaskJob,
     root: Path | None = None,
@@ -368,6 +376,36 @@ def complete_evolve_candidate_for_task(
         return None
     try:
         return complete_evolve_candidate(candidate_id, root, theme=theme)
+    except ValueError:
+        return None
+
+
+def fail_evolve_candidate_for_task(
+    job: TaskJob,
+    root: Path | None = None,
+    *,
+    theme: str = "",
+) -> EvolveCandidate | None:
+    candidate_id = _evolve_candidate_id_from_task(job)
+    if not candidate_id:
+        return None
+    try:
+        return fail_evolve_candidate(candidate_id, root, theme=theme)
+    except ValueError:
+        return None
+
+
+def cancel_evolve_candidate_for_task(
+    job: TaskJob,
+    root: Path | None = None,
+    *,
+    theme: str = "",
+) -> EvolveCandidate | None:
+    candidate_id = _evolve_candidate_id_from_task(job)
+    if not candidate_id:
+        return None
+    try:
+        return cancel_evolve_candidate(candidate_id, root, theme=theme)
     except ValueError:
         return None
 
@@ -492,7 +530,9 @@ def _candidate_status_order(status: str) -> int:
         "running": 1,
         "candidate": 2,
         "done": 3,
-        "rejected": 4,
+        "failed": 4,
+        "cancelled": 5,
+        "rejected": 6,
     }.get(status, 2)
 
 

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -24,7 +24,7 @@ The MVP candidate sources are:
 - active recurring work from `.enoch/cron.json`;
 - recent automatic learning artifacts from `.enoch/learning/artifacts.jsonl`.
 
-Candidates are persisted in `.enoch/evolve_candidates.json` so Enoch can remember whether a candidate has been selected, is running, is done, or has been rejected. Normal candidate views hide rejected and done candidates.
+Candidates are persisted in `.enoch/evolve_candidates.json` so Enoch can remember whether a candidate has been selected, is running, is done, failed, cancelled, or has been rejected. Normal candidate views hide done, failed, cancelled, and rejected candidates.
 
 Future sources may include explicit feedback, conversation patterns, brainstorming, and learning from non-parent agents.
 

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -49,10 +49,12 @@ from enoch.evolve import (
     EvolveCandidate,
     EvolveReport,
     EvolveState,
+    cancel_evolve_candidate_for_task,
     claim_due_evolve_schedule,
     complete_evolve_candidate_for_task,
     disable_evolve_schedule,
     evolve_report,
+    fail_evolve_candidate_for_task,
     get_evolve_candidate,
     load_evolve_candidates,
     reject_evolve_candidate,
@@ -1474,8 +1476,10 @@ class EnochTelegramBot:
             self._task_cancellations.pop(job.id, None)
             if completed_status == "cancelled":
                 cancel_running_task(self.root, result=reply)
+                cancel_evolve_candidate_for_task(job, self.root)
             elif completed_status == "failed":
                 fail_task(job.id, self.root, result=reply)
+                fail_evolve_candidate_for_task(job, self.root)
             else:
                 complete_task(job.id, self.root, result=reply)
                 complete_evolve_candidate_for_task(job, self.root)
@@ -1989,6 +1993,7 @@ def _recover_running_task_from_direct_action_log(root: Path) -> None:
         return
     if _work_reply_failed(result):
         fail_task(running.id, root, result=result)
+        fail_evolve_candidate_for_task(running, root)
     else:
         complete_task(running.id, root, result=result)
         complete_evolve_candidate_for_task(running, root)

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -14,11 +14,13 @@ from enoch.automatic_learning import record_learning_artifact
 from enoch.cron import add_cron_job
 from enoch.evolve import (
     MODE_DISABLED,
+    cancel_evolve_candidate_for_task,
     claim_due_evolve_schedule,
     collect_evolve_candidates,
     disable_evolve_schedule,
     evolve_report,
     complete_evolve_candidate_for_task,
+    fail_evolve_candidate_for_task,
     load_evolve_candidates,
     load_evolve_state,
     rank_evolve_candidates,
@@ -160,6 +162,42 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
         self.assertEqual(all_candidates[0].id, "backlog-1")
         self.assertEqual(all_candidates[0].status, "done")
+
+    def test_failed_and_cancelled_evolve_tasks_mark_candidates_inactive(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(1, "ship failing evolve", root, priority="p1")
+            add_backlog_item(2, "ship cancelled evolve", root, priority="p1")
+            run_evolve_candidate("backlog-1", root)
+            run_evolve_candidate("backlog-2", root)
+            failed_job = enqueue_task(
+                42,
+                "Evolve selected candidate backlog-1",
+                root,
+                context="\n".join(["Scheduled evolve candidate context:", "ID: backlog-1"]),
+                context_source="evolve-run",
+            )
+            cancelled_job = enqueue_task(
+                42,
+                "Evolve selected candidate backlog-2",
+                root,
+                context="\n".join(["Scheduled evolve candidate context:", "ID: backlog-2"]),
+                context_source="evolve-run",
+            )
+
+            failed = fail_evolve_candidate_for_task(failed_job, root)
+            cancelled = cancel_evolve_candidate_for_task(cancelled_job, root)
+            visible = load_evolve_candidates(root)
+            all_candidates = load_evolve_candidates(root, include_inactive=True)
+
+        assert failed is not None
+        assert cancelled is not None
+        self.assertEqual(failed.status, "failed")
+        self.assertEqual(cancelled.status, "cancelled")
+        self.assertEqual(visible, ())
+        statuses = {candidate.id: candidate.status for candidate in all_candidates}
+        self.assertEqual(statuses["backlog-1"], "failed")
+        self.assertEqual(statuses["backlog-2"], "cancelled")
 
     def test_schedule_can_be_set_claimed_and_disabled(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -1288,6 +1288,34 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertEqual(all_candidates[0].status, "done")
         self.assertIn("Final status: completed", client.sent[-1][1])
 
+    @patch("enoch.telegram.bot.ensure_long_term_memory")
+    @patch("enoch.telegram.bot.log_conversation_turn")
+    def test_evolve_run_candidate_is_marked_failed_after_task_failure(
+        self,
+        _log_conversation_turn: MagicMock,
+        _update_memory: MagicMock,
+    ) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "ship failing evolve", root, priority="p1")
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochTelegramBot(load_identity(), root, client)
+
+            bot.handle_update(_message_update(chat_id=42, text="/evolve run backlog-1"))
+            job = begin_next_task(root)
+            assert job is not None
+            with patch.object(bot, "_run_direct_work", return_value="Enoch could not publish this edit as a pull request: GH007"):
+                bot._run_task_job(job)
+            visible = load_evolve_candidates(root)
+            all_candidates = load_evolve_candidates(root, include_inactive=True)
+            report = evolve_report(root)
+
+        self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
+        statuses = {candidate.id: candidate.status for candidate in all_candidates}
+        self.assertEqual(statuses["backlog-1"], "failed")
+        self.assertIn("task-history", report.counts_by_source)
+        self.assertIn("Final status: failed", client.sent[-1][1])
+
     def test_evolve_can_set_theme_and_mode(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)


### PR DESCRIPTION
## Summary
- Add explicit `failed` and `cancelled` evolve candidate statuses
- Mark evolve-run/evolve-scheduler candidates failed or cancelled when their task ends that way
- Keep failed/cancelled candidates hidden from normal candidate views while preserving task-history follow-up candidates

## Tests
- `python3 -m unittest discover -s tests`