### PR TITLE
Document Enoch config precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ ENOCH_PYTHON=/Users/garyzhao/.cache/codex-runtimes/codex-primary-runtime/depende
 
 Then open the bot in Telegram and send `/status`.
 
+## Codex configuration
+
+Enoch has her own local runtime configuration in `.enoch/config.yaml`. For the
+Codex model and reasoning effort, settings are resolved in this order:
+
+1. `ENOCH_CODEX_MODEL` or `ENOCH_CODEX_REASONING_EFFORT`
+2. `codex.model` or `codex.reasoning_effort` in `.enoch/config.yaml`
+3. The user-level Codex configuration in `$CODEX_HOME/config.toml` (normally
+   `~/.codex/config.toml`)
+4. The Codex CLI default
+
+Use `/config` in Telegram to inspect the effective settings and `/config model`
+or `/config reasoning-effort` to change Enoch's local overrides.
+
 ## Lineage
 
 - created by: Genesis

--- a/src/enoch/brain.py
+++ b/src/enoch/brain.py
@@ -138,7 +138,10 @@ def model_summary(root: Path | None = None) -> str:
         model_source = str(config_path)
     else:
         model = "Codex CLI default"
-        model_source = "Codex, because ENOCH_CODEX_MODEL and Codex config model are not set"
+        model_source = (
+            "Codex, because ENOCH_CODEX_MODEL, Enoch config codex.model, "
+            "and Codex config model are not set"
+        )
 
     lines = [
         f"AI model: {model}",

--- a/tests/test_enoch_brain.py
+++ b/tests/test_enoch_brain.py
@@ -42,6 +42,7 @@ class EnochBrainTests(unittest.TestCase):
                 summary = model_summary()
 
         self.assertIn("AI model: Codex CLI default", summary)
+        self.assertIn("Enoch config codex.model", summary)
         self.assertIn("Codex config model are not set", summary)
 
     def test_model_summary_reports_codex_config_model_and_reasoning(self) -> None:
@@ -89,6 +90,38 @@ class EnochBrainTests(unittest.TestCase):
         self.assertIn("Model source: ENOCH_CODEX_MODEL", summary)
         self.assertIn("Reasoning effort: medium", summary)
         self.assertIn("Codex config model: gpt-5.5", summary)
+
+    def test_model_summary_prefers_enoch_config_over_codex_config_per_setting(self) -> None:
+        with TemporaryDirectory() as temp, TemporaryDirectory() as codex_home:
+            root = Path(temp)
+            config = root / ".enoch" / "config.yaml"
+            config.parent.mkdir()
+            config.write_text(
+                "\n".join(
+                    [
+                        "codex:",
+                        "  model: gpt-enoch-local",
+                        "  reasoning_effort: high",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (Path(codex_home) / "config.toml").write_text(
+                "\n".join(
+                    [
+                        'model = "gpt-global"',
+                        'model_reasoning_effort = "low"',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with patch.dict("os.environ", {"CODEX_HOME": codex_home}, clear=True):
+                summary = model_summary(root)
+
+        self.assertIn("AI model: gpt-enoch-local", summary)
+        self.assertIn("Model source: Enoch config codex.model", summary)
+        self.assertIn("Reasoning effort: high", summary)
+        self.assertIn("Reasoning source: Enoch config codex.reasoning_effort", summary)
 
     def test_model_summary_reports_enoch_reasoning_override(self) -> None:
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
## What changed

- document Enoch's project-local `.enoch/config.yaml` and the complete Codex configuration precedence in the OSS README
- include Enoch's local model key in the default model-source explanation
- add focused coverage proving Enoch-local model and reasoning values override user-level Codex values independently

## Why

Enoch already resolves her own local configuration before the user-level Codex configuration, but the fallback status explanation and public documentation did not fully account for that source. This made the effective configuration model easy to misunderstand.

## Impact

Status output and OSS documentation now make Enoch's own configuration layer explicit without changing the established precedence or storing instance-private values.

## Validation

- `/Users/garyzhao/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m unittest discover -s tests` (416 tests passed)
- `git diff --check`

## Evolution provenance

- Candidate: `feedback-c3ed71fd1d2d`
- Source: `feedback`
- Trigger: `/evolve retry`
- Task: `#3`
- Retry of task: `#1`

This PR is the completed output of retry task #3 for the failed original evolve task #1.