### PR TITLE
Add explicit pull request merge command

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -442,6 +442,7 @@ def help_message(topic: str = "") -> str:
             "/config - show or update local system settings",
             "/resume - continue tasks paused while Codex access was unavailable",
             "/doctor - run local health checks",
+            "/pr merge <number-or-url> - merge one inspected GitHub pull request",
             "/update - pull latest main, run doctor, and restart if safe",
             "/restart - restart Enoch's Telegram daemon from the locked chat",
             "",
@@ -509,6 +510,14 @@ def _help_topic_message(topic: str) -> str:
         )
     if topic == "config":
         return config_usage("/")
+    if topic == "pr":
+        return "\n".join(
+            [
+                "Pull request commands:",
+                "/pr merge <PR number or GitHub PR URL> - inspect and merge one pull request",
+                "The explicit target is required and counts as human approval for that merge only.",
+            ]
+        )
     topics = {
         "start": "/start - start Enoch and point to /help",
         "self": "/self - show Enoch's identity, role, ancestor, and mission",

--- a/src/enoch/github/workflow.py
+++ b/src/enoch/github/workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import os
 from pathlib import Path
 import shutil
@@ -83,6 +84,195 @@ class PullRequestCloseResult:
     closed: bool
     url: str
     note: str | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestTarget:
+    value: str
+    number: int
+    repository: str | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestMergeResult:
+    number: int
+    url: str
+    merged: bool
+    merge_method: str
+    commit_sha: str | None = None
+    message: str = ""
+
+
+def parse_pull_request_target(value: str) -> PullRequestTarget:
+    target = value.strip()
+    if target.isdecimal():
+        number = int(target)
+        if number > 0:
+            return PullRequestTarget(value=str(number), number=number)
+        raise PublishError("Pull request number must be positive.")
+
+    parsed = urlparse(target)
+    if (
+        parsed.scheme.lower() != "https"
+        or parsed.netloc.lower() != "github.com"
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise PublishError("Use a positive pull request number or a full https://github.com/.../pull/... URL.")
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 4 or parts[2].lower() != "pull" or not parts[3].isdecimal():
+        raise PublishError("Use a positive pull request number or a full https://github.com/.../pull/... URL.")
+    owner, repository, _pull, number_text = parts
+    number = int(number_text)
+    if not owner or not repository or number <= 0:
+        raise PublishError("Use a positive pull request number or a full https://github.com/.../pull/... URL.")
+    canonical_url = f"https://github.com/{owner}/{repository}/pull/{number}"
+    return PullRequestTarget(
+        value=canonical_url,
+        number=number,
+        repository=f"{owner}/{repository}",
+    )
+
+
+def merge_pull_request(
+    target_value: str,
+    root: Path | None = None,
+) -> PullRequestMergeResult:
+    target = parse_pull_request_target(target_value)
+    gh = shutil.which("gh")
+    if gh is None:
+        raise PublishError("GitHub CLI is not available.")
+
+    inspection = _run_gh_json(
+        [
+            gh,
+            "pr",
+            "view",
+            target.value,
+            "--json",
+            "number,url,state,isDraft,mergedAt,mergeable,mergeStateStatus,headRefOid",
+        ],
+        root,
+        f"Could not inspect pull request {target.value}.",
+    )
+    number = inspection.get("number")
+    url = str(inspection.get("url") or "")
+    if not isinstance(number, int) or not url:
+        raise PublishError(f"GitHub returned incomplete details for pull request {target.value}.")
+    inspected_target = parse_pull_request_target(url)
+    if target.repository is not None and (
+        inspected_target.repository.lower() != target.repository.lower() or number != target.number
+    ):
+        raise PublishError(f"GitHub resolved {target.value} to a different pull request; refusing to merge it.")
+    if number != inspected_target.number:
+        raise PublishError(f"GitHub returned inconsistent details for pull request {target.value}.")
+
+    merged_at = inspection.get("mergedAt")
+    state = str(inspection.get("state") or "").upper()
+    if merged_at or state == "MERGED":
+        raise PublishError(f"Pull request #{number} is already merged: {url}")
+    if state != "OPEN":
+        description = state.lower() or "not open"
+        raise PublishError(f"Pull request #{number} is {description}: {url}")
+    if inspection.get("isDraft") is True:
+        raise PublishError(f"Pull request #{number} is a draft and cannot be merged: {url}")
+
+    mergeable = str(inspection.get("mergeable") or "UNKNOWN").upper()
+    merge_state = str(inspection.get("mergeStateStatus") or "UNKNOWN").upper()
+    if mergeable == "CONFLICTING" or merge_state == "DIRTY":
+        raise PublishError(f"Pull request #{number} has merge conflicts: {url}")
+    if mergeable != "MERGEABLE" or merge_state != "CLEAN":
+        state_description = merge_state.lower().replace("_", " ")
+        raise PublishError(
+            f"Pull request #{number} is not currently mergeable "
+            f"(merge state: {state_description}): {url}"
+        )
+
+    head_sha = str(inspection.get("headRefOid") or "").strip()
+    if not head_sha:
+        raise PublishError(f"GitHub did not return the head commit for pull request #{number}.")
+    repository = inspected_target.repository
+    if repository is None:
+        raise PublishError(f"Could not identify the repository for pull request #{number}.")
+    merge_method = _repository_merge_method(gh, repository, root)
+    merge_response = _run_gh_json(
+        [
+            gh,
+            "api",
+            "--method",
+            "PUT",
+            f"repos/{repository}/pulls/{number}/merge",
+            "-f",
+            f"sha={head_sha}",
+            "-f",
+            f"merge_method={merge_method}",
+        ],
+        root,
+        f"GitHub could not merge pull request #{number}.",
+    )
+    merged = merge_response.get("merged") is True
+    message = str(merge_response.get("message") or "").strip()
+    if not merged:
+        detail = message or "GitHub declined the merge."
+        raise PublishError(f"Pull request #{number} was not merged: {detail}")
+    commit_sha = str(merge_response.get("sha") or "").strip() or None
+    return PullRequestMergeResult(
+        number=number,
+        url=url,
+        merged=True,
+        merge_method=merge_method,
+        commit_sha=commit_sha,
+        message=message or "Pull request successfully merged.",
+    )
+
+
+def _repository_merge_method(gh: str, repository: str, root: Path | None) -> str:
+    settings = _run_gh_json(
+        [
+            gh,
+            "repo",
+            "view",
+            repository,
+            "--json",
+            "mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed",
+        ],
+        root,
+        f"Could not inspect merge methods for {repository}.",
+    )
+    supported = (
+        ("merge", settings.get("mergeCommitAllowed")),
+        ("squash", settings.get("squashMergeAllowed")),
+        ("rebase", settings.get("rebaseMergeAllowed")),
+    )
+    for method, allowed in supported:
+        if allowed is True:
+            return method
+    raise PublishError(f"Repository {repository} does not allow a supported pull request merge method.")
+
+
+def _run_gh_json(
+    command: list[str],
+    root: Path | None,
+    fallback: str,
+) -> dict[str, object]:
+    result = subprocess.run(
+        command,
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise PublishError(f"{fallback} {detail}".strip())
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise PublishError(f"{fallback} GitHub returned invalid JSON.") from error
+    if not isinstance(payload, dict):
+        raise PublishError(f"{fallback} GitHub returned an unexpected response.")
+    return payload
 
 
 def prepare_local_publish(

--- a/src/enoch/skills/github/SKILL.md
+++ b/src/enoch/skills/github/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when Enoch needs to coordinate work with GitHub: branches, pull r
 6. Create or update the PR with a clear summary and validation notes.
 7. Approve a PR only when the human explicitly asks for approval.
 8. Treat the PR as the human review boundary.
-9. Never merge without explicit human approval.
+9. Merge only when the human sends `/pr merge <PR number or GitHub PR URL>` from the locked Telegram chat.
 
 ## Natural Workflow
 
@@ -62,5 +62,7 @@ The helper:
 - Refuse to publish from main unless the human explicitly asks for a direct main push.
 - Publish completed, validated work as ready for review by default.
 - Use a draft PR only when work is intentionally incomplete or the human explicitly requests a draft.
+- Treat `/pr merge <target>` as approval for exactly that inspected PR. Never infer a missing target or merge a different PR.
+- Refuse drafts, closed or already-merged PRs, conflicts, and other unmergeable states. Do not approve, mark ready, enable auto-merge, alter PR content, delete branches, or update local branches as part of the merge.
 - When an evolve task supplies an `## Evolution provenance` section, include it verbatim in the PR body. It separates evidence source, signal actor, candidate actor, approval actor, task id, and any available candidate/task causal links.
 - Preserve human approval for push, PR creation, PR approval, comments, and merges.

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -114,12 +114,14 @@ from enoch.github.workflow import (
     LocalPublishResult,
     PublishError,
     PullRequestCloseResult,
+    PullRequestMergeResult,
     PullRequestResult,
     RemotePublishResult,
     close_pull_request,
     create_pull_request,
     feature_title,
     format_evolution_provenance,
+    merge_pull_request,
     prepare_local_publish,
     push_current_branch,
 )
@@ -393,6 +395,8 @@ class EnochTelegramBot:
             reply = self._status(chat_id)
         elif command == "/doctor":
             reply = self._doctor()
+        elif command == "/pr":
+            reply = self._pr(chat_id, argument)
         elif command == "/update":
             reply = self._update()
             self._queue_session_sync(
@@ -2428,6 +2432,20 @@ class EnochTelegramBot:
             format_doctor=_format_doctor_result,
         )
 
+    def _pr(self, chat_id: int, argument: str) -> str:
+        if not self._action_allowed() or self.client.config.allowed_chat_id != chat_id:
+            return _action_lock_message()
+        parts = argument.split()
+        if len(parts) != 2 or parts[0].lower() != "merge":
+            return _pr_merge_usage()
+        try:
+            result = merge_pull_request(parts[1], root=self.root)
+        except PublishError as error:
+            return f"Enoch could not merge the pull request: {error}"
+        reply = _format_pull_request_merge(result)
+        _record_direct_action(f"/pr merge {result.url}", reply, self.root)
+        return reply
+
     def _update(self) -> str:
         if not self._action_allowed():
             return _action_lock_message()
@@ -3618,6 +3636,10 @@ def _evolve_usage() -> str:
     )
 
 
+def _pr_merge_usage() -> str:
+    return "Use /pr merge <PR number or GitHub PR URL> to inspect and merge one pull request."
+
+
 def _unquote_schedule_text(text: str) -> str:
     stripped = text.strip()
     if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
@@ -3855,6 +3877,18 @@ def _format_remote_publish_result(result: RemotePublishResult) -> str:
 
 def _format_pr_result(result: PullRequestResult) -> str:
     return format_pr_result(result)
+
+
+def _format_pull_request_merge(result: PullRequestMergeResult) -> str:
+    lines = [
+        f"Merged pull request #{result.number}.",
+        f"URL: {result.url}",
+        f"Merge method: {result.merge_method}",
+        f"Result: {result.message}",
+    ]
+    if result.commit_sha:
+        lines.append(f"Merge commit: {result.commit_sha}")
+    return "\n".join(lines)
 
 
 def _pr_step_update(result: PullRequestResult) -> str:

--- a/tests/test_enoch_github_workflow.py
+++ b/tests/test_enoch_github_workflow.py
@@ -12,6 +12,8 @@ from enoch.github.workflow import (
     PublishError,
     close_pull_request,
     create_pull_request,
+    merge_pull_request,
+    parse_pull_request_target,
     prepare_local_publish,
     push_current_branch,
 )
@@ -19,6 +21,24 @@ from enoch.immune import DoctorDiagnosis
 
 
 class EnochGithubWorkflowTests(unittest.TestCase):
+    def test_parses_pull_request_number_against_current_repository(self) -> None:
+        target = parse_pull_request_target(" 12 ")
+
+        self.assertEqual(target.number, 12)
+        self.assertEqual(target.value, "12")
+        self.assertIsNone(target.repository)
+
+    def test_parses_full_github_pull_request_url(self) -> None:
+        target = parse_pull_request_target("https://github.com/our-ark/enoch/pull/12/")
+
+        self.assertEqual(target.number, 12)
+        self.assertEqual(target.repository, "our-ark/enoch")
+        self.assertEqual(target.value, "https://github.com/our-ark/enoch/pull/12")
+
+    def test_rejects_non_pull_request_target(self) -> None:
+        with self.assertRaisesRegex(PublishError, "positive pull request number"):
+            parse_pull_request_target("https://example.com/our-ark/enoch/pull/12")
+
     @patch("enoch.github.workflow.current_branch", return_value="main")
     def test_refuses_protected_branch_by_default(self, _current_branch: MagicMock) -> None:
         with self.assertRaisesRegex(PublishError, "Refusing to publish from main"):
@@ -438,6 +458,129 @@ class EnochGithubWorkflowTests(unittest.TestCase):
         self.assertEqual(result.note, "GitHub CLI is not available.")
         self.assertEqual(result.url, "https://github.com/our-ark/enoch/pull/2")
 
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merge_rejects_already_merged_pull_request(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _json_result(
+            {
+                **_mergeable_pr(),
+                "state": "MERGED",
+                "mergedAt": "2026-07-18T12:00:00Z",
+            }
+        )
+
+        with self.assertRaisesRegex(PublishError, "already merged"):
+            merge_pull_request("12", root=ROOT)
+
+        self.assertEqual(run.call_count, 1)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merge_rejects_closed_pull_request(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _json_result({**_mergeable_pr(), "state": "CLOSED"})
+
+        with self.assertRaisesRegex(PublishError, "is closed"):
+            merge_pull_request("12", root=ROOT)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merge_rejects_draft_pull_request(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _json_result({**_mergeable_pr(), "isDraft": True})
+
+        with self.assertRaisesRegex(PublishError, "is a draft"):
+            merge_pull_request("12", root=ROOT)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merge_rejects_conflicting_pull_request(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _json_result(
+            {**_mergeable_pr(), "mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"}
+        )
+
+        with self.assertRaisesRegex(PublishError, "merge conflicts"):
+            merge_pull_request("12", root=ROOT)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merge_rejects_other_unmergeable_state(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _json_result({**_mergeable_pr(), "mergeStateStatus": "BLOCKED"})
+
+        with self.assertRaisesRegex(PublishError, "not currently mergeable.*blocked"):
+            merge_pull_request("12", root=ROOT)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merge_reports_github_inspection_failure(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _git_result(returncode=1, stderr="no pull requests found")
+
+        with self.assertRaisesRegex(PublishError, "Could not inspect.*no pull requests found"):
+            merge_pull_request("999", root=ROOT)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merges_inspected_pull_request_with_supported_default_method(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.side_effect = [
+            _json_result(_mergeable_pr()),
+            _json_result(
+                {
+                    "mergeCommitAllowed": True,
+                    "squashMergeAllowed": True,
+                    "rebaseMergeAllowed": True,
+                }
+            ),
+            _json_result(
+                {
+                    "merged": True,
+                    "message": "Pull Request successfully merged",
+                    "sha": "abc123",
+                }
+            ),
+        ]
+
+        result = merge_pull_request("https://github.com/our-ark/enoch/pull/12", root=ROOT)
+
+        self.assertTrue(result.merged)
+        self.assertEqual(result.number, 12)
+        self.assertEqual(result.url, "https://github.com/our-ark/enoch/pull/12")
+        self.assertEqual(result.merge_method, "merge")
+        self.assertEqual(result.commit_sha, "abc123")
+        inspect_command = run.call_args_list[0].args[0]
+        self.assertEqual(inspect_command[1:4], ["pr", "view", result.url])
+        merge_command = run.call_args_list[2].args[0]
+        self.assertEqual(merge_command[1:5], ["api", "--method", "PUT", "repos/our-ark/enoch/pulls/12/merge"])
+        self.assertIn("sha=head123", merge_command)
+        self.assertIn("merge_method=merge", merge_command)
+        self.assertNotIn("--auto", merge_command)
+        self.assertNotIn("--delete-branch", merge_command)
+
 def _doctor_result(passed: bool, summary: str) -> MagicMock:
     result = MagicMock()
     result.passed = passed
@@ -458,6 +601,25 @@ def _git_result(returncode: int, stdout: str = "", stderr: str = "") -> MagicMoc
     result.stdout = stdout
     result.stderr = stderr
     return result
+
+
+def _json_result(payload: dict[str, object]) -> MagicMock:
+    import json
+
+    return _git_result(returncode=0, stdout=json.dumps(payload))
+
+
+def _mergeable_pr() -> dict[str, object]:
+    return {
+        "number": 12,
+        "url": "https://github.com/our-ark/enoch/pull/12",
+        "state": "OPEN",
+        "isDraft": False,
+        "mergedAt": None,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": "head123",
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -34,7 +34,9 @@ from enoch.evolve_events import load_evolve_events
 from enoch.git_tools import GitError
 from enoch.github.workflow import (
     LocalPublishResult,
+    PublishError,
     PullRequestCloseResult,
+    PullRequestMergeResult,
     PullRequestResult,
     RemotePublishResult,
 )
@@ -609,6 +611,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("System:", client.sent[0][1])
         self.assertNotIn("Mode:", client.sent[0][1])
         self.assertIn("/doctor", client.sent[0][1])
+        self.assertIn("/pr merge <number-or-url>", client.sent[0][1])
         self.assertNotIn("/debug", client.sent[0][1])
         self.assertNotIn("/mode [chat|work]", client.sent[0][1])
         self.assertLess(client.sent[0][1].index("/mission [text]"), client.sent[0][1].index("/status"))
@@ -657,6 +660,104 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/restart - restart Enoch's Telegram daemon from the locked chat", client.sent[0][1])
         self.assertNotIn("/shutdown", client.sent[0][1])
         self.assertIn("say the request naturally", client.sent[0][1])
+
+    def test_help_pr_shows_explicit_merge_target_usage(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/help pr"))
+
+        reply = client.sent[0][1]
+        self.assertIn("/pr merge <PR number or GitHub PR URL>", reply)
+        self.assertIn("explicit target is required", reply)
+        self.assertNotIn("Enoch Telegram commands:", reply)
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_requires_explicit_target(self, merge_pull_request: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge"))
+
+        merge_pull_request.assert_not_called()
+        self.assertIn("Use /pr merge <PR number or GitHub PR URL>", client.sent[0][1])
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    @patch("enoch.telegram.bot.respond", return_value="Use the explicit system command to merge it.")
+    def test_natural_merge_request_does_not_merge(
+        self,
+        respond: MagicMock,
+        merge_pull_request: MagicMock,
+    ) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="merge PR 12"))
+
+        respond.assert_called_once()
+        merge_pull_request.assert_not_called()
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_requires_locked_chat(self, merge_pull_request: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=None)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge 12"))
+
+        merge_pull_request.assert_not_called()
+        self.assertIn("locked to one chat", client.sent[0][1])
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_ignores_unauthorized_chat(self, merge_pull_request: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=7, text="/pr merge 12"))
+
+        merge_pull_request.assert_not_called()
+        self.assertEqual(client.sent, [])
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_reports_github_failure(self, merge_pull_request: MagicMock) -> None:
+        merge_pull_request.side_effect = PublishError("GitHub declined the merge.")
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge 12"))
+
+        merge_pull_request.assert_called_once_with("12", root=ROOT)
+        self.assertIn("could not merge", client.sent[0][1])
+        self.assertIn("GitHub declined", client.sent[0][1])
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_reports_success(self, merge_pull_request: MagicMock) -> None:
+        merge_pull_request.return_value = PullRequestMergeResult(
+            number=12,
+            url="https://github.com/our-ark/enoch/pull/12",
+            merged=True,
+            merge_method="squash",
+            commit_sha="abc123",
+            message="Pull Request successfully merged",
+        )
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(
+            _message_update(
+                chat_id=42,
+                text="/pr merge https://github.com/our-ark/enoch/pull/12",
+            )
+        )
+
+        merge_pull_request.assert_called_once_with(
+            "https://github.com/our-ark/enoch/pull/12",
+            root=ROOT,
+        )
+        reply = client.sent[0][1]
+        self.assertIn("Merged pull request #12", reply)
+        self.assertIn("https://github.com/our-ark/enoch/pull/12", reply)
+        self.assertIn("Merge method: squash", reply)
+        self.assertIn("Merge commit: abc123", reply)
 
     def test_help_config_shows_only_config_commands(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)


### PR DESCRIPTION
## Summary
- add the locked-chat `/pr merge <number-or-url>` Telegram system command and help surface
- inspect the exact PR before mutation and reject missing, closed, merged, draft, conflicting, blocked, or inaccessible targets
- merge through the GitHub API with head-SHA protection and a repository-supported default method, without auto-merge or branch cleanup
- document the explicit human-approval boundary in the GitHub skill

## Validation
- `python3 -m unittest tests.test_enoch_github_workflow tests.test_enoch_telegram` (220 tests)
- `env -u ENOCH_PYTHON python3 -m unittest discover -s tests` (446 tests)
- live read-only check against merged PR #12 confirmed the already-merged safeguard
- `git diff --check`

## Human review
- ready for review