### PR TITLE
Add explicit PR merge command

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -7,6 +7,7 @@ from typing import Callable
 from enoch.brain import REASONING_EFFORTS, codex_model_options, model_summary
 from enoch.command_surface import lineage_usage
 from enoch.config import write_section_value
+from enoch.github.workflow import PullRequestMergeResult, PublishError, merge_pull_request
 from enoch.identity import Identity, identity_file_path, load_identity, update_mission
 from enoch.identity_context import display_ancestor
 from enoch.immune import ImmuneResult, run_immune_system
@@ -42,6 +43,7 @@ DoctorFn = Callable[[Path], ImmuneResult]
 ResolveLineageFn = Callable[[Path], LineageResolution]
 RefreshLineageFn = Callable[..., LineageInboxReport]
 FormatDoctorFn = Callable[[ImmuneResult], str]
+MergePullRequestFn = Callable[[str, Path], PullRequestMergeResult]
 
 
 def status_message(
@@ -399,6 +401,44 @@ def doctor_command(
     return format_doctor(run_doctor(root))
 
 
+def pr_command(
+    text: str,
+    root: Path,
+    *,
+    allowed_chat_id: int | None,
+    chat_id: int,
+    merge_pull_request_fn: MergePullRequestFn | None = None,
+) -> str:
+    parts = text.split()
+    if len(parts) != 3 or parts[1].lower() != "merge":
+        return pr_usage()
+    if allowed_chat_id is None or chat_id != allowed_chat_id:
+        return "Enoch only merges pull requests from her locked Telegram chat."
+    try:
+        result = (merge_pull_request_fn or merge_pull_request)(parts[2], root)
+    except PublishError as error:
+        return f"Enoch could not merge the pull request: {error}"
+    lines = [
+        f"Pull request #{result.number} merged.",
+        f"PR: {result.url}",
+        f"Merge method: {result.method}",
+    ]
+    if result.merge_commit:
+        lines.append(f"Merge commit: {result.merge_commit}")
+    lines.append(f"GitHub result: {result.message}")
+    return "\n".join(lines)
+
+
+def pr_usage() -> str:
+    return "\n".join(
+        [
+            "Pull request commands:",
+            "/pr merge <PR number or GitHub PR URL> - inspect and merge exactly one PR",
+            "A PR target is required; Enoch will not infer one from the current branch.",
+        ]
+    )
+
+
 def help_message(topic: str = "") -> str:
     normalized_topic = _normalize_help_topic(topic)
     if normalized_topic:
@@ -442,6 +482,7 @@ def help_message(topic: str = "") -> str:
             "/config - show or update local system settings",
             "/resume - continue tasks paused while Codex access was unavailable",
             "/doctor - run local health checks",
+            "/pr merge <number-or-URL> - inspect and merge exactly one pull request",
             "/update - pull latest main, run doctor, and restart if safe",
             "/restart - restart Enoch's Telegram daemon from the locked chat",
             "",
@@ -510,6 +551,8 @@ def _help_topic_message(topic: str) -> str:
         )
     if topic == "config":
         return config_usage("/")
+    if topic == "pr":
+        return pr_usage()
     topics = {
         "start": "/start - start Enoch and point to /help",
         "self": "/self - show Enoch's identity, role, ancestor, and mission",

--- a/src/enoch/github/workflow.py
+++ b/src/enoch/github/workflow.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 from urllib.parse import urlparse
@@ -95,6 +96,40 @@ class PullRequestMergeStatus:
     merge_commit: str
     merged_at: str
     note: str | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestTarget:
+    reference: str
+    number: int
+    repository: str = ""
+
+
+@dataclass(frozen=True)
+class PullRequestMergeCandidate:
+    target: PullRequestTarget
+    number: int
+    repository: str
+    url: str
+    state: str
+    is_draft: bool
+    mergeable: str
+    merge_state_status: str
+    head_oid: str
+    base_branch: str
+
+
+@dataclass(frozen=True)
+class PullRequestMergeResult:
+    number: int
+    url: str
+    method: str
+    merge_commit: str
+    message: str
+    merged: bool = True
+
+
+_PR_NUMBER_PATTERN = re.compile(r"^[0-9]+$")
 
 
 def prepare_local_publish(
@@ -332,6 +367,223 @@ def inspect_pull_request_merge(
         merge_commit=merge_oid,
         merged_at=str(data.get("mergedAt") or "").strip(),
     )
+
+
+def parse_pull_request_target(reference: str) -> PullRequestTarget:
+    cleaned = reference.strip()
+    if not cleaned:
+        raise PublishError("Pull request target is required.")
+    if _PR_NUMBER_PATTERN.fullmatch(cleaned):
+        number = int(cleaned)
+        if number <= 0:
+            raise PublishError("Pull request number must be positive.")
+        return PullRequestTarget(reference=str(number), number=number)
+
+    parsed = urlparse(cleaned)
+    path_parts = parsed.path.strip("/").split("/")
+    if (
+        parsed.scheme.lower() != "https"
+        or parsed.netloc.lower() != "github.com"
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or len(path_parts) != 4
+        or path_parts[2] != "pull"
+        or not _PR_NUMBER_PATTERN.fullmatch(path_parts[3])
+    ):
+        raise PublishError(
+            "Use a positive PR number or a full URL like "
+            "https://github.com/owner/repository/pull/123."
+        )
+    owner, repository = path_parts[0], path_parts[1]
+    number = int(path_parts[3])
+    if not owner or not repository or number <= 0:
+        raise PublishError(
+            "Use a positive PR number or a full URL like "
+            "https://github.com/owner/repository/pull/123."
+        )
+    repo = f"{owner}/{repository}"
+    return PullRequestTarget(
+        reference=f"https://github.com/{repo}/pull/{number}",
+        number=number,
+        repository=repo,
+    )
+
+
+def inspect_pull_request_candidate(
+    reference: str,
+    root: Path | None = None,
+) -> PullRequestMergeCandidate:
+    target = parse_pull_request_target(reference)
+    gh = shutil.which("gh")
+    if gh is None:
+        raise PublishError("GitHub CLI is not available.")
+    result = subprocess.run(
+        [
+            gh,
+            "pr",
+            "view",
+            target.reference,
+            "--json",
+            (
+                "number,url,state,isDraft,mergeable,mergeStateStatus,"
+                "headRefOid,baseRefName,mergedAt"
+            ),
+        ],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        note = result.stderr.strip() or result.stdout.strip() or "GitHub could not find that PR."
+        raise PublishError(f"Could not inspect {target.reference}: {note}")
+    data = _github_json_object(result.stdout, "pull request")
+    try:
+        number = int(data.get("number"))
+    except (TypeError, ValueError) as error:
+        raise PublishError("GitHub CLI returned invalid pull request data.") from error
+    url = str(data.get("url") or "").strip()
+    canonical = parse_pull_request_target(url)
+    if number != target.number or canonical.number != target.number:
+        raise PublishError("GitHub returned a different pull request than the requested target.")
+    if target.repository and canonical.repository.lower() != target.repository.lower():
+        raise PublishError("GitHub returned a different pull request than the requested target.")
+
+    candidate = PullRequestMergeCandidate(
+        target=target,
+        number=number,
+        repository=canonical.repository,
+        url=canonical.reference,
+        state=str(data.get("state") or "").strip().upper(),
+        is_draft=bool(data.get("isDraft")),
+        mergeable=str(data.get("mergeable") or "").strip().upper(),
+        merge_state_status=str(data.get("mergeStateStatus") or "").strip().upper(),
+        head_oid=str(data.get("headRefOid") or "").strip(),
+        base_branch=str(data.get("baseRefName") or "").strip(),
+    )
+    _ensure_pull_request_mergeable(candidate, merged_at=str(data.get("mergedAt") or "").strip())
+    return candidate
+
+
+def merge_pull_request(
+    reference: str,
+    root: Path | None = None,
+) -> PullRequestMergeResult:
+    candidate = inspect_pull_request_candidate(reference, root)
+    gh = shutil.which("gh")
+    if gh is None:
+        raise PublishError("GitHub CLI is not available.")
+    method = _repository_merge_method(candidate.repository, gh, root)
+    result = subprocess.run(
+        [
+            gh,
+            "api",
+            "--method",
+            "PUT",
+            f"repos/{candidate.repository}/pulls/{candidate.number}/merge",
+            "-f",
+            f"sha={candidate.head_oid}",
+            "-f",
+            f"merge_method={method}",
+        ],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        note = result.stderr.strip() or result.stdout.strip() or "GitHub could not merge the PR."
+        raise PublishError(f"GitHub could not merge PR #{candidate.number}: {note}")
+    data = _github_json_object(result.stdout, "merge result")
+    message = str(data.get("message") or "").strip()
+    if data.get("merged") is not True:
+        raise PublishError(message or f"GitHub did not merge PR #{candidate.number}.")
+    return PullRequestMergeResult(
+        number=candidate.number,
+        url=candidate.url,
+        method=method,
+        merge_commit=str(data.get("sha") or "").strip(),
+        message=message or "Pull request merged.",
+    )
+
+
+def _ensure_pull_request_mergeable(
+    candidate: PullRequestMergeCandidate,
+    *,
+    merged_at: str,
+) -> None:
+    label = f"PR #{candidate.number} ({candidate.url})"
+    if merged_at or candidate.state == "MERGED":
+        raise PublishError(f"{label} is already merged.")
+    if candidate.state == "CLOSED":
+        raise PublishError(f"{label} is closed.")
+    if candidate.state != "OPEN":
+        state = candidate.state or "unknown"
+        raise PublishError(f"{label} is not open (GitHub reports {state}).")
+    if candidate.is_draft:
+        raise PublishError(f"{label} is a draft. Mark it ready for review before merging it.")
+    if candidate.mergeable == "CONFLICTING":
+        raise PublishError(f"{label} has merge conflicts.")
+    if candidate.mergeable != "MERGEABLE":
+        status = candidate.mergeable or "UNKNOWN"
+        raise PublishError(f"{label} is not currently mergeable (GitHub reports {status}).")
+    if candidate.merge_state_status != "CLEAN":
+        status = candidate.merge_state_status or "UNKNOWN"
+        raise PublishError(
+            f"{label} is not ready to merge (GitHub merge state: {status})."
+        )
+    if not candidate.head_oid:
+        raise PublishError(f"{label} has no inspectable head commit.")
+
+
+def _repository_merge_method(repository: str, gh: str, root: Path | None) -> str:
+    result = subprocess.run(
+        [
+            gh,
+            "repo",
+            "view",
+            repository,
+            "--json",
+            (
+                "nameWithOwner,viewerDefaultMergeMethod,mergeCommitAllowed,"
+                "squashMergeAllowed,rebaseMergeAllowed"
+            ),
+        ],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        note = result.stderr.strip() or result.stdout.strip() or "GitHub could not inspect merge methods."
+        raise PublishError(f"Could not inspect merge methods for {repository}: {note}")
+    data = _github_json_object(result.stdout, "repository")
+    returned_repo = str(data.get("nameWithOwner") or "").strip()
+    if returned_repo.lower() != repository.lower():
+        raise PublishError("GitHub returned a different repository than the requested PR target.")
+    allowed = {
+        "MERGE": data.get("mergeCommitAllowed") is True,
+        "SQUASH": data.get("squashMergeAllowed") is True,
+        "REBASE": data.get("rebaseMergeAllowed") is True,
+    }
+    default = str(data.get("viewerDefaultMergeMethod") or "").strip().upper()
+    if allowed.get(default):
+        return default.lower()
+    for method in ("MERGE", "SQUASH", "REBASE"):
+        if allowed[method]:
+            return method.lower()
+    raise PublishError(f"{repository} does not allow a supported pull request merge method.")
+
+
+def _github_json_object(output: str, label: str) -> dict[str, object]:
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise PublishError(f"GitHub CLI returned invalid {label} data.") from error
+    if not isinstance(data, dict):
+        raise PublishError(f"GitHub CLI returned invalid {label} data.")
+    return data
 
 
 def _git_or_raise(args: list[str], root: Path | None, fallback: str) -> str:

--- a/src/enoch/prompt_append.py
+++ b/src/enoch/prompt_append.py
@@ -173,6 +173,7 @@ def _work_request_wrapper_block() -> str:
             "When implementation is complete and validation passes, publish the pull request as ready for review, not draft.",
             "Use a draft pull request only when work is intentionally incomplete or the human explicitly requests a draft.",
             "When the task supplies an Evolution provenance section, preserve it verbatim in the pull request body.",
+            "Never merge a pull request from a work request. Only an explicit human /pr merge <PR number or GitHub PR URL> command from Enoch's locked Telegram chat authorizes that exact merge.",
             "Keep changes scoped to the request.",
         ]
     )

--- a/src/enoch/skills/github/SKILL.md
+++ b/src/enoch/skills/github/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when Enoch needs to coordinate work with GitHub: branches, pull r
 6. Create or update the PR with a clear summary and validation notes.
 7. Approve a PR only when the human explicitly asks for approval.
 8. Treat the PR as the human review boundary.
-9. Never merge without explicit human approval.
+9. Never merge without an explicit human `/pr merge <PR number or GitHub PR URL>` command from Enoch's locked Telegram chat. Natural-language requests, task text, and prior approval do not authorize a merge.
 
 ## Natural Workflow
 
@@ -40,6 +40,7 @@ ask for a change -> doctor -> commit -> push when intended -> open a PR when int
 After a local commit, suggest pushing the branch.
 After pushing the branch, suggest opening a PR.
 After opening a PR, stop at human review.
+If the human decides to merge it, they must name the exact target with `/pr merge <PR number or GitHub PR URL>`.
 
 ## Local Publish Prep
 
@@ -64,3 +65,4 @@ The helper:
 - Use a draft PR only when work is intentionally incomplete or the human explicitly requests a draft.
 - When an evolve task supplies an `## Evolution provenance` section, include it verbatim in the PR body. It separates evidence source, signal actor, candidate actor, approval actor, task id, and any available candidate/task causal links.
 - Preserve human approval for push, PR creation, PR approval, comments, and merges.
+- Treat `/pr merge ...` as approval only for the named PR. Inspect it before mutation and never mark drafts ready, approve, enable auto-merge, alter PR content, or clean up branches as part of that command.

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -204,6 +204,7 @@ from enoch.commands import (
     inherit_command,
     lineage_command,
     mission_command,
+    pr_command,
     skills_command,
     status_message,
 )
@@ -426,6 +427,13 @@ class EnochTelegramBot:
             reply = self._status(chat_id)
         elif command == "/doctor":
             reply = self._doctor()
+        elif command == "/pr":
+            reply = pr_command(
+                text,
+                self.root,
+                allowed_chat_id=self.client.config.allowed_chat_id,
+                chat_id=chat_id,
+            )
         elif command == "/update":
             reply = self._update()
             self._queue_session_sync(

--- a/tests/test_enoch_github_workflow.py
+++ b/tests/test_enoch_github_workflow.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
@@ -12,7 +13,10 @@ from enoch.github.workflow import (
     PublishError,
     close_pull_request,
     create_pull_request,
+    inspect_pull_request_candidate,
     inspect_pull_request_merge,
+    merge_pull_request,
+    parse_pull_request_target,
     prepare_local_publish,
     push_current_branch,
 )
@@ -478,6 +482,138 @@ class EnochGithubWorkflowTests(unittest.TestCase):
             ],
         )
 
+    def test_parses_numeric_pull_request_target_for_current_repository(self) -> None:
+        target = parse_pull_request_target(" 12 ")
+
+        self.assertEqual(target.reference, "12")
+        self.assertEqual(target.number, 12)
+        self.assertEqual(target.repository, "")
+
+    def test_parses_full_github_pull_request_url(self) -> None:
+        target = parse_pull_request_target("https://github.com/our-ark/enoch/pull/12/")
+
+        self.assertEqual(target.reference, "https://github.com/our-ark/enoch/pull/12")
+        self.assertEqual(target.number, 12)
+        self.assertEqual(target.repository, "our-ark/enoch")
+
+    def test_rejects_non_pull_request_targets(self) -> None:
+        invalid = (
+            "",
+            "0",
+            "main",
+            "https://example.com/our-ark/enoch/pull/12",
+            "https://github.com/our-ark/enoch/issues/12",
+            "https://github.com/our-ark/enoch/pull/12?diff=split",
+        )
+
+        for reference in invalid:
+            with self.subTest(reference=reference):
+                with self.assertRaises(PublishError):
+                    parse_pull_request_target(reference)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_reports_missing_pull_request(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _process_result(returncode=1, stderr="GraphQL: Could not resolve to a PullRequest")
+
+        with self.assertRaisesRegex(PublishError, "Could not inspect 404"):
+            inspect_pull_request_candidate("404", ROOT)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_refuses_closed_already_merged_draft_and_unmergeable_pull_requests(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        cases = (
+            ({"state": "CLOSED"}, "is closed"),
+            ({"state": "MERGED", "mergedAt": "2026-07-18T18:30:00Z"}, "already merged"),
+            ({"isDraft": True}, "is a draft"),
+            ({"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"}, "merge conflicts"),
+            ({"mergeStateStatus": "BLOCKED"}, "merge state: BLOCKED"),
+            ({"mergeable": "UNKNOWN"}, "not currently mergeable"),
+        )
+        for changes, expected in cases:
+            with self.subTest(expected=expected):
+                payload = _merge_candidate_payload()
+                payload.update(changes)
+                run.return_value = _process_result(stdout=json.dumps(payload))
+
+                with self.assertRaisesRegex(PublishError, expected):
+                    inspect_pull_request_candidate("12", ROOT)
+
+                self.assertEqual(run.call_count, 1)
+                run.reset_mock()
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merge_reports_github_failure_without_retry_or_side_effects(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.side_effect = [
+            _process_result(stdout=json.dumps(_merge_candidate_payload())),
+            _process_result(stdout=json.dumps(_merge_method_payload())),
+            _process_result(returncode=1, stderr="HTTP 405: Pull Request is not mergeable"),
+        ]
+
+        with self.assertRaisesRegex(PublishError, "GitHub could not merge PR #12"):
+            merge_pull_request("12", ROOT)
+
+        self.assertEqual(run.call_count, 3)
+        mutation = run.call_args_list[2].args[0]
+        self.assertNotIn("--auto", mutation)
+        self.assertNotIn("--delete-branch", mutation)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_merges_exact_inspected_head_with_repository_default_method(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.side_effect = [
+            _process_result(stdout=json.dumps(_merge_candidate_payload())),
+            _process_result(stdout=json.dumps(_merge_method_payload(default="SQUASH"))),
+            _process_result(
+                stdout=json.dumps(
+                    {
+                        "merged": True,
+                        "message": "Pull Request successfully merged",
+                        "sha": "abc123merge",
+                    }
+                )
+            ),
+        ]
+
+        result = merge_pull_request("https://github.com/our-ark/enoch/pull/12", ROOT)
+
+        self.assertTrue(result.merged)
+        self.assertEqual(result.number, 12)
+        self.assertEqual(result.url, "https://github.com/our-ark/enoch/pull/12")
+        self.assertEqual(result.method, "squash")
+        self.assertEqual(result.merge_commit, "abc123merge")
+        self.assertEqual(
+            run.call_args_list[2].args[0],
+            [
+                "/usr/local/bin/gh",
+                "api",
+                "--method",
+                "PUT",
+                "repos/our-ark/enoch/pulls/12/merge",
+                "-f",
+                "sha=head123",
+                "-f",
+                "merge_method=squash",
+            ],
+        )
+
 
 def _doctor_result(passed: bool, summary: str) -> MagicMock:
     result = MagicMock()
@@ -499,6 +635,38 @@ def _git_result(returncode: int, stdout: str = "", stderr: str = "") -> MagicMoc
     result.stdout = stdout
     result.stderr = stderr
     return result
+
+
+def _process_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def _merge_candidate_payload() -> dict[str, object]:
+    return {
+        "number": 12,
+        "url": "https://github.com/our-ark/enoch/pull/12",
+        "state": "OPEN",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": "head123",
+        "baseRefName": "main",
+        "mergedAt": None,
+    }
+
+
+def _merge_method_payload(default: str = "MERGE") -> dict[str, object]:
+    return {
+        "nameWithOwner": "our-ark/enoch",
+        "viewerDefaultMergeMethod": default,
+        "mergeCommitAllowed": True,
+        "squashMergeAllowed": True,
+        "rebaseMergeAllowed": True,
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_enoch_prompt_append.py
+++ b/tests/test_enoch_prompt_append.py
@@ -48,6 +48,8 @@ class EnochPromptAppendTests(unittest.TestCase):
         self.assertIn("ready for review, not draft", prompt)
         self.assertIn("intentionally incomplete", prompt)
         self.assertIn("Evolution provenance", prompt)
+        self.assertIn("Never merge a pull request from a work request", prompt)
+        self.assertIn("/pr merge <PR number or GitHub PR URL>", prompt)
         self.assertIn("forward-fixed", prompt)
 
     def test_extract_edit_request_strips_marker_from_visible_reply(self) -> None:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -35,6 +35,7 @@ from enoch.evolve_events import load_evolve_events
 from enoch.git_tools import GitError
 from enoch.github.workflow import (
     LocalPublishResult,
+    PullRequestMergeResult,
     PullRequestCloseResult,
     PullRequestResult,
     RemotePublishResult,
@@ -686,6 +687,75 @@ class EnochTelegramTests(unittest.TestCase):
             client.sent[0][1],
             "/resume - continue tasks paused while Codex access was unavailable",
         )
+
+    def test_help_lists_and_explains_pr_merge_command(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/help"))
+        bot.handle_update(_message_update(update_id=2, chat_id=42, text="/help pr"))
+
+        self.assertIn(
+            "/pr merge <number-or-URL> - inspect and merge exactly one pull request",
+            client.sent[0][1],
+        )
+        self.assertIn("/pr merge <PR number or GitHub PR URL>", client.sent[1][1])
+        self.assertIn("will not infer one", client.sent[1][1])
+
+    @patch("enoch.commands.merge_pull_request")
+    def test_pr_merge_requires_explicit_target(self, merge_pull_request: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge"))
+
+        merge_pull_request.assert_not_called()
+        self.assertIn("/pr merge <PR number or GitHub PR URL>", client.sent[0][1])
+        self.assertIn("will not infer one", client.sent[0][1])
+
+    @patch("enoch.commands.merge_pull_request")
+    def test_pr_merge_requires_locked_chat(self, merge_pull_request: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=None)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=7, text="/pr merge 12"))
+
+        merge_pull_request.assert_not_called()
+        self.assertEqual(
+            client.sent[0][1],
+            "Enoch only merges pull requests from her locked Telegram chat.",
+        )
+
+    @patch("enoch.telegram.bot.pr_command")
+    def test_pr_merge_ignores_unauthorized_chat(self, pr_command: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=7, text="/pr merge 12"))
+
+        pr_command.assert_not_called()
+        self.assertEqual(client.sent, [])
+
+    @patch("enoch.commands.merge_pull_request")
+    def test_pr_merge_reports_success(self, merge_pull_request: MagicMock) -> None:
+        merge_pull_request.return_value = PullRequestMergeResult(
+            number=12,
+            url="https://github.com/our-ark/enoch/pull/12",
+            method="squash",
+            merge_commit="abc123merge",
+            message="Pull Request successfully merged",
+        )
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge 12"))
+
+        merge_pull_request.assert_called_once_with("12", ROOT)
+        reply = client.sent[0][1]
+        self.assertIn("Pull request #12 merged.", reply)
+        self.assertIn("https://github.com/our-ark/enoch/pull/12", reply)
+        self.assertIn("Merge method: squash", reply)
+        self.assertIn("Merge commit: abc123merge", reply)
 
     def test_config_shows_sets_and_resets_task_timeout(self) -> None:
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- add `/pr merge <PR number or GitHub PR URL>` to the locked Telegram system command router and help output
- inspect the exact PR target and reject missing, closed, merged, draft, conflicting, blocked, or otherwise unmergeable states before mutation
- pin merges to the inspected head commit, use the repository-supported default merge method, and avoid auto-merge, approvals, content changes, branch deletion, or local branch updates
- reinforce that work requests and natural-language instructions never authorize a PR merge

## Validation
- `python3 -m unittest tests.test_enoch_prompt_append tests.test_enoch_github_workflow tests.test_enoch_telegram` (230 tests passed)
- `python3 -m unittest discover -s tests` (470 tests passed with the external `ENOCH_PYTHON` override removed)
- `bin/enoch doctor` (passed on Python 3.12.13 after rebasing onto current `origin/main`)
- `git diff --check`