### PR TITLE
Add explicit PR merge command

### DIFF
--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -439,6 +439,7 @@ def help_message(topic: str = "") -> str:
             "/evolve - show self-evolution mode, theme, and top candidate",
             "",
             "System:",
+            "/pr merge <number-or-URL> - inspect and merge exactly one pull request",
             "/config - show or update local system settings",
             "/resume - continue tasks paused while Codex access was unavailable",
             "/doctor - run local health checks",
@@ -510,6 +511,8 @@ def _help_topic_message(topic: str) -> str:
         )
     if topic == "config":
         return config_usage("/")
+    if topic == "pr":
+        return pr_usage("/")
     topics = {
         "start": "/start - start Enoch and point to /help",
         "self": "/self - show Enoch's identity, role, ancestor, and mission",
@@ -538,6 +541,16 @@ def _help_topic_message(topic: str) -> str:
         "thinking": thinking_usage("/"),
     }
     return topics.get(topic, "")
+
+
+def pr_usage(prefix: str = "/") -> str:
+    return "\n".join(
+        [
+            "Pull request commands:",
+            f"{prefix}pr merge <PR number or GitHub PR URL> - inspect and merge exactly that PR",
+            "A target is required; Enoch will not infer a pull request.",
+        ]
+    )
 
 
 def action_lock_message() -> str:

--- a/src/enoch/github/workflow.py
+++ b/src/enoch/github/workflow.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 from urllib.parse import urlparse
@@ -23,6 +24,8 @@ from enoch.runtime import DEFAULT_BRANCH, DEFAULT_REMOTE, PROTECTED_BRANCHES
 
 DEFAULT_PROTECTED_BRANCHES = PROTECTED_BRANCHES
 GITHUB_NOREPLY_DOMAIN = "users.noreply.github.com"
+_POSITIVE_PR_NUMBER = re.compile(r"^[1-9][0-9]*$")
+_GITHUB_REPOSITORY_PART = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 class PublishError(RuntimeError):
@@ -94,7 +97,29 @@ class PullRequestMergeStatus:
     base_branch: str
     merge_commit: str
     merged_at: str
+    number: int = 0
+    repository: str = ""
+    is_draft: bool = False
+    mergeable: str = ""
+    merge_state_status: str = ""
+    head_sha: str = ""
     note: str | None = None
+
+
+@dataclass(frozen=True)
+class PullRequestTarget:
+    reference: str
+    number: int
+    repository: str = ""
+
+
+@dataclass(frozen=True)
+class PullRequestMergeResult:
+    number: int
+    url: str
+    method: str
+    merge_commit: str
+    message: str
 
 
 def prepare_local_publish(
@@ -289,9 +314,7 @@ def inspect_pull_request_merge(
     reference: str,
     root: Path | None = None,
 ) -> PullRequestMergeStatus:
-    cleaned = reference.strip()
-    if not cleaned:
-        raise PublishError("Pull request reference is required.")
+    target = parse_pull_request_target(reference)
     gh = shutil.which("gh")
     if gh is None:
         raise PublishError("GitHub CLI is not available.")
@@ -300,9 +323,12 @@ def inspect_pull_request_merge(
             gh,
             "pr",
             "view",
-            cleaned,
+            target.reference,
             "--json",
-            "state,mergedAt,mergeCommit,baseRefName,url",
+            (
+                "number,state,isDraft,mergeable,mergeStateStatus,mergedAt,"
+                "mergeCommit,baseRefName,headRefOid,url"
+            ),
         ],
         cwd=root,
         text=True,
@@ -324,14 +350,177 @@ def inspect_pull_request_merge(
         if isinstance(merge_commit, dict)
         else ""
     )
+    url = str(data.get("url") or "").strip()
+    try:
+        resolved_target = parse_pull_request_target(url)
+    except PublishError as error:
+        raise PublishError("GitHub CLI returned an invalid pull request URL.") from error
+    returned_number = data.get("number")
+    if isinstance(returned_number, int) and returned_number != resolved_target.number:
+        raise PublishError("GitHub CLI returned inconsistent pull request data.")
+    if target.repository and (
+        resolved_target.repository.casefold() != target.repository.casefold()
+        or resolved_target.number != target.number
+    ):
+        raise PublishError("GitHub returned a different pull request than the requested URL.")
     return PullRequestMergeStatus(
-        reference=cleaned,
-        url=str(data.get("url") or cleaned).strip(),
+        reference=target.reference,
+        url=resolved_target.reference,
         state=str(data.get("state") or "").strip().upper(),
         base_branch=str(data.get("baseRefName") or "").strip(),
         merge_commit=merge_oid,
         merged_at=str(data.get("mergedAt") or "").strip(),
+        number=resolved_target.number,
+        repository=resolved_target.repository,
+        is_draft=bool(data.get("isDraft")),
+        mergeable=str(data.get("mergeable") or "").strip().upper(),
+        merge_state_status=str(data.get("mergeStateStatus") or "").strip().upper(),
+        head_sha=str(data.get("headRefOid") or "").strip(),
     )
+
+
+def parse_pull_request_target(reference: str) -> PullRequestTarget:
+    cleaned = reference.strip()
+    if _POSITIVE_PR_NUMBER.fullmatch(cleaned):
+        return PullRequestTarget(reference=str(int(cleaned)), number=int(cleaned))
+
+    parsed = urlparse(cleaned)
+    parts = [part for part in parsed.path.split("/") if part]
+    valid_url = (
+        parsed.scheme.lower() == "https"
+        and parsed.netloc.lower() == "github.com"
+        and not parsed.params
+        and len(parts) == 4
+        and parts[2] == "pull"
+        and _GITHUB_REPOSITORY_PART.fullmatch(parts[0]) is not None
+        and _GITHUB_REPOSITORY_PART.fullmatch(parts[1]) is not None
+        and _POSITIVE_PR_NUMBER.fullmatch(parts[3]) is not None
+    )
+    if not valid_url:
+        raise PublishError(
+            "Use a positive PR number or a full "
+            "https://github.com/OWNER/REPO/pull/NUMBER URL."
+        )
+    number = int(parts[3])
+    repository = f"{parts[0]}/{parts[1]}"
+    return PullRequestTarget(
+        reference=f"https://github.com/{repository}/pull/{number}",
+        number=number,
+        repository=repository,
+    )
+
+
+def merge_pull_request(
+    reference: str,
+    root: Path | None = None,
+) -> PullRequestMergeResult:
+    status = inspect_pull_request_merge(reference, root)
+    _require_mergeable_pull_request(status)
+    gh = shutil.which("gh")
+    if gh is None:
+        raise PublishError("GitHub CLI is not available.")
+    method = _repository_merge_method(gh, status.repository, root)
+    payload = json.dumps({"sha": status.head_sha, "merge_method": method})
+    result = subprocess.run(
+        [
+            gh,
+            "api",
+            "--method",
+            "PUT",
+            f"repos/{status.repository}/pulls/{status.number}/merge",
+            "--input",
+            "-",
+        ],
+        cwd=root,
+        text=True,
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        note = (
+            result.stderr.strip()
+            or result.stdout.strip()
+            or "GitHub could not merge the pull request."
+        )
+        raise PublishError(note)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise PublishError("GitHub returned invalid merge data.") from error
+    if not isinstance(data, dict):
+        raise PublishError("GitHub returned invalid merge data.")
+    message = str(data.get("message") or "").strip()
+    if data.get("merged") is not True:
+        raise PublishError(message or "GitHub did not merge the pull request.")
+    return PullRequestMergeResult(
+        number=status.number,
+        url=status.url,
+        method=method,
+        merge_commit=str(data.get("sha") or "").strip(),
+        message=message or "Pull request merged.",
+    )
+
+
+def _require_mergeable_pull_request(status: PullRequestMergeStatus) -> None:
+    label = f"PR #{status.number}" if status.number else "Pull request"
+    if status.state == "MERGED" or status.merged_at:
+        raise PublishError(f"{label} is already merged.")
+    if status.state == "CLOSED":
+        raise PublishError(f"{label} is closed.")
+    if status.state != "OPEN":
+        raise PublishError(f"{label} is not open (state: {status.state or 'unknown'}).")
+    if status.is_draft:
+        raise PublishError(f"{label} is a draft. Mark it ready explicitly before merging.")
+    if status.mergeable == "CONFLICTING" or status.merge_state_status == "DIRTY":
+        raise PublishError(f"{label} has merge conflicts.")
+    if status.mergeable != "MERGEABLE":
+        raise PublishError(f"{label} is not currently mergeable (status: {status.mergeable or 'unknown'}).")
+    if status.merge_state_status not in {"CLEAN", "UNSTABLE"}:
+        raise PublishError(
+            f"{label} is not currently mergeable "
+            f"(merge state: {status.merge_state_status.lower() or 'unknown'})."
+        )
+    if not status.head_sha:
+        raise PublishError(f"{label} has no inspectable head commit.")
+
+
+def _repository_merge_method(gh: str, repository: str, root: Path | None) -> str:
+    result = subprocess.run(
+        [
+            gh,
+            "repo",
+            "view",
+            repository,
+            "--json",
+            "mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed",
+        ],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        note = (
+            result.stderr.strip()
+            or result.stdout.strip()
+            or "GitHub could not inspect merge methods."
+        )
+        raise PublishError(note)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise PublishError("GitHub returned invalid repository merge settings.") from error
+    if not isinstance(data, dict):
+        raise PublishError("GitHub returned invalid repository merge settings.")
+    for method, setting in (
+        ("merge", "mergeCommitAllowed"),
+        ("squash", "squashMergeAllowed"),
+        ("rebase", "rebaseMergeAllowed"),
+    ):
+        if data.get(setting) is True:
+            return method
+    raise PublishError("The repository has no supported pull request merge method enabled.")
 
 
 def _git_or_raise(args: list[str], root: Path | None, fallback: str) -> str:

--- a/src/enoch/skills/github/SKILL.md
+++ b/src/enoch/skills/github/SKILL.md
@@ -27,7 +27,13 @@ Use this skill when Enoch needs to coordinate work with GitHub: branches, pull r
 6. Create or update the PR with a clear summary and validation notes.
 7. Approve a PR only when the human explicitly asks for approval.
 8. Treat the PR as the human review boundary.
-9. Never merge without explicit human approval.
+9. Never merge without an explicit human `/pr merge <PR number or GitHub PR URL>` command from the locked Telegram chat.
+
+## Explicit Merge Approval
+
+`/pr merge` is the only system command that authorizes Enoch to merge a pull request. The command must name one PR by positive number or full GitHub PR URL; never infer a target from the current branch or conversation.
+
+Before merging, inspect that exact PR and refuse closed, already-merged, draft, conflicting, blocked, inaccessible, or otherwise unmergeable targets. Do not mark drafts ready, approve PRs, change their content, enable auto-merge, bypass protections, delete branches, or update local branches as part of this command. Pin the inspected head commit during the merge so changed content requires a new human command.
 
 ## Natural Workflow
 
@@ -64,3 +70,4 @@ The helper:
 - Use a draft PR only when work is intentionally incomplete or the human explicitly requests a draft.
 - When an evolve task supplies an `## Evolution provenance` section, include it verbatim in the PR body. It separates evidence source, signal actor, candidate actor, approval actor, task id, and any available candidate/task causal links.
 - Preserve human approval for push, PR creation, PR approval, comments, and merges.
+- Treat an authorized `/pr merge ...` command as approval for that exact merge only.

--- a/src/enoch/telegram/bot.py
+++ b/src/enoch/telegram/bot.py
@@ -121,12 +121,14 @@ from enoch.github.workflow import (
     LocalPublishResult,
     PublishError,
     PullRequestCloseResult,
+    PullRequestMergeResult,
     PullRequestResult,
     RemotePublishResult,
     close_pull_request,
     create_pull_request,
     feature_title,
     format_evolution_provenance,
+    merge_pull_request,
     prepare_local_publish,
     push_current_branch,
 )
@@ -204,6 +206,7 @@ from enoch.commands import (
     inherit_command,
     lineage_command,
     mission_command,
+    pr_usage,
     skills_command,
     status_message,
 )
@@ -426,6 +429,8 @@ class EnochTelegramBot:
             reply = self._status(chat_id)
         elif command == "/doctor":
             reply = self._doctor()
+        elif command == "/pr":
+            reply = self._pr(chat_id, argument)
         elif command == "/update":
             reply = self._update()
             self._queue_session_sync(
@@ -2753,6 +2758,19 @@ class EnochTelegramBot:
             format_doctor=_format_doctor_result,
         )
 
+    def _pr(self, chat_id: int, argument: str) -> str:
+        parts = argument.split()
+        if len(parts) != 2 or parts[0].lower() != "merge":
+            return pr_usage()
+        allowed_chat_id = self.client.config.allowed_chat_id
+        if allowed_chat_id is None or allowed_chat_id != chat_id:
+            return "Enoch will only merge a pull request from her locked Telegram chat."
+        try:
+            result = merge_pull_request(parts[1], self.root)
+        except PublishError as error:
+            return f"Enoch could not merge that pull request: {error}"
+        return _format_pull_request_merge_result(result)
+
     def _update(self) -> str:
         if not self._action_allowed():
             return _action_lock_message()
@@ -2890,6 +2908,19 @@ def _parse_telegram_command(text: str) -> tuple[str, str]:
         return "", text.strip()
     command = first.split("@", 1)[0].lower()
     return command, rest.strip()
+
+
+def _format_pull_request_merge_result(result: PullRequestMergeResult) -> str:
+    commit = result.merge_commit or "reported by GitHub"
+    return "\n".join(
+        [
+            f"Merged PR #{result.number}.",
+            f"URL: {result.url}",
+            f"Method: {result.method}",
+            f"Merge commit: {commit}",
+            f"GitHub result: {result.message}",
+        ]
+    )
 
 
 def _action_sandbox(_root: Path) -> str:

--- a/tests/test_enoch_github_workflow.py
+++ b/tests/test_enoch_github_workflow.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
@@ -10,9 +11,12 @@ sys.path.insert(0, str(ROOT / "src"))
 from enoch.github.workflow import (
     EvolutionProvenance,
     PublishError,
+    PullRequestMergeStatus,
     close_pull_request,
     create_pull_request,
     inspect_pull_request_merge,
+    merge_pull_request,
+    parse_pull_request_target,
     prepare_local_publish,
     push_current_branch,
 )
@@ -474,9 +478,157 @@ class EnochGithubWorkflowTests(unittest.TestCase):
                 "view",
                 "https://github.com/our-ark/enoch/pull/12",
                 "--json",
-                "state,mergedAt,mergeCommit,baseRefName,url",
+                (
+                    "number,state,isDraft,mergeable,mergeStateStatus,mergedAt,"
+                    "mergeCommit,baseRefName,headRefOid,url"
+                ),
             ],
         )
+
+    def test_parses_numeric_pull_request_target_for_current_repository(self) -> None:
+        target = parse_pull_request_target("12")
+
+        self.assertEqual(target.reference, "12")
+        self.assertEqual(target.number, 12)
+        self.assertEqual(target.repository, "")
+
+    def test_parses_and_normalizes_full_github_pull_request_url(self) -> None:
+        target = parse_pull_request_target(
+            "https://github.com/our-ark/enoch/pull/12/?tab=checks"
+        )
+
+        self.assertEqual(target.reference, "https://github.com/our-ark/enoch/pull/12")
+        self.assertEqual(target.number, 12)
+        self.assertEqual(target.repository, "our-ark/enoch")
+
+    def test_rejects_non_pull_request_target(self) -> None:
+        for target in ("", "0", "feature", "https://github.com/our-ark/enoch/issues/12"):
+            with self.subTest(target=target), self.assertRaisesRegex(
+                PublishError,
+                "positive PR number",
+            ):
+                parse_pull_request_target(target)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_numeric_target_is_inspected_in_current_repository(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _process_result(
+            stdout=(
+                '{"number":12,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE",'
+                '"mergeStateStatus":"CLEAN","mergedAt":null,"mergeCommit":null,'
+                '"baseRefName":"main","headRefOid":"abc123",'
+                '"url":"https://github.com/our-ark/enoch/pull/12"}'
+            )
+        )
+
+        result = inspect_pull_request_merge("12", ROOT)
+
+        self.assertEqual(result.repository, "our-ark/enoch")
+        self.assertEqual(result.number, 12)
+        self.assertEqual(run.call_args.args[0][3], "12")
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    def test_inaccessible_pull_request_url_reports_github_failure(
+        self,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run.return_value = _process_result(
+            returncode=1,
+            stderr="GraphQL: Could not resolve to a PullRequest",
+        )
+
+        with self.assertRaisesRegex(PublishError, "Could not resolve"):
+            inspect_pull_request_merge("https://github.com/private/repo/pull/12", ROOT)
+
+    def test_merge_refuses_draft_conflicting_blocked_closed_and_merged_prs(self) -> None:
+        cases = (
+            (_merge_status(is_draft=True), "is a draft"),
+            (
+                _merge_status(mergeable="CONFLICTING", merge_state_status="DIRTY"),
+                "merge conflicts",
+            ),
+            (_merge_status(merge_state_status="BLOCKED"), "merge state: blocked"),
+            (_merge_status(state="CLOSED"), "is closed"),
+            (_merge_status(state="MERGED", merged_at="2026-07-18T18:30:00Z"), "already merged"),
+        )
+        for status, expected in cases:
+            with self.subTest(expected=expected), patch(
+                "enoch.github.workflow.inspect_pull_request_merge",
+                return_value=status,
+            ):
+                with self.assertRaisesRegex(PublishError, expected):
+                    merge_pull_request("12", ROOT)
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    @patch("enoch.github.workflow.inspect_pull_request_merge", return_value=None)
+    def test_merges_inspected_head_with_supported_default_method(
+        self,
+        inspect: MagicMock,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        inspect.return_value = _merge_status()
+        run.side_effect = [
+            _process_result(
+                stdout=(
+                    '{"mergeCommitAllowed":true,"squashMergeAllowed":true,'
+                    '"rebaseMergeAllowed":true}'
+                )
+            ),
+            _process_result(
+                stdout=(
+                    '{"merged":true,"message":"Pull Request successfully merged",'
+                    '"sha":"def456"}'
+                )
+            ),
+        ]
+
+        result = merge_pull_request("12", ROOT)
+
+        self.assertEqual(result.number, 12)
+        self.assertEqual(result.method, "merge")
+        self.assertEqual(result.merge_commit, "def456")
+        self.assertEqual(
+            run.call_args_list[1].args[0],
+            [
+                "/usr/local/bin/gh",
+                "api",
+                "--method",
+                "PUT",
+                "repos/our-ark/enoch/pulls/12/merge",
+                "--input",
+                "-",
+            ],
+        )
+        self.assertEqual(
+            json.loads(run.call_args_list[1].kwargs["input"]),
+            {"sha": "abc123", "merge_method": "merge"},
+        )
+
+    @patch("enoch.github.workflow.subprocess.run")
+    @patch("enoch.github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    @patch("enoch.github.workflow.inspect_pull_request_merge", return_value=None)
+    def test_merge_reports_github_api_failure(
+        self,
+        inspect: MagicMock,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        inspect.return_value = _merge_status()
+        run.side_effect = [
+            _process_result(stdout='{"mergeCommitAllowed":true}'),
+            _process_result(returncode=1, stderr="HTTP 405: Pull Request is not mergeable"),
+        ]
+
+        with self.assertRaisesRegex(PublishError, "HTTP 405"):
+            merge_pull_request("12", ROOT)
 
 
 def _doctor_result(passed: bool, summary: str) -> MagicMock:
@@ -499,6 +651,33 @@ def _git_result(returncode: int, stdout: str = "", stderr: str = "") -> MagicMoc
     result.stdout = stdout
     result.stderr = stderr
     return result
+
+
+def _process_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def _merge_status(**overrides) -> PullRequestMergeStatus:
+    values = {
+        "reference": "12",
+        "url": "https://github.com/our-ark/enoch/pull/12",
+        "state": "OPEN",
+        "base_branch": "main",
+        "merge_commit": "",
+        "merged_at": "",
+        "number": 12,
+        "repository": "our-ark/enoch",
+        "is_draft": False,
+        "mergeable": "MERGEABLE",
+        "merge_state_status": "CLEAN",
+        "head_sha": "abc123",
+    }
+    values.update(overrides)
+    return PullRequestMergeStatus(**values)
 
 
 if __name__ == "__main__":

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -35,7 +35,9 @@ from enoch.evolve_events import load_evolve_events
 from enoch.git_tools import GitError
 from enoch.github.workflow import (
     LocalPublishResult,
+    PublishError,
     PullRequestCloseResult,
+    PullRequestMergeResult,
     PullRequestResult,
     RemotePublishResult,
 )
@@ -675,6 +677,84 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/config task-timeout <duration>", reply)
         self.assertIn("/config task-timeout default", reply)
         self.assertNotIn("Enoch Telegram commands:", reply)
+
+    def test_help_lists_explicit_pull_request_merge_command(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/help"))
+        bot.handle_update(_message_update(update_id=2, chat_id=42, text="/help pr"))
+
+        self.assertIn("/pr merge <number-or-URL>", client.sent[0][1])
+        self.assertIn("/pr merge <PR number or GitHub PR URL>", client.sent[1][1])
+        self.assertIn("will not infer a pull request", client.sent[1][1])
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_requires_explicit_target(self, merge: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge"))
+
+        self.assertIn("/pr merge <PR number or GitHub PR URL>", client.sent[0][1])
+        merge.assert_not_called()
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_is_ignored_from_unauthorized_chat(self, merge: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=99, text="/pr merge 12"))
+
+        self.assertEqual(client.sent, [])
+        merge.assert_not_called()
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_requires_configured_chat_lock(self, merge: MagicMock) -> None:
+        client = FakeTelegramClient()
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge 12"))
+
+        self.assertIn("locked Telegram chat", client.sent[0][1])
+        merge.assert_not_called()
+
+    @patch("enoch.telegram.bot.merge_pull_request")
+    def test_pr_merge_reports_success_for_exact_target(self, merge: MagicMock) -> None:
+        merge.return_value = PullRequestMergeResult(
+            number=12,
+            url="https://github.com/our-ark/enoch/pull/12",
+            method="merge",
+            merge_commit="def456",
+            message="Pull Request successfully merged",
+        )
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(
+            _message_update(
+                chat_id=42,
+                text="/pr merge https://github.com/our-ark/enoch/pull/12",
+            )
+        )
+
+        merge.assert_called_once_with("https://github.com/our-ark/enoch/pull/12", ROOT)
+        self.assertIn("Merged PR #12.", client.sent[0][1])
+        self.assertIn("https://github.com/our-ark/enoch/pull/12", client.sent[0][1])
+        self.assertIn("Merge commit: def456", client.sent[0][1])
+
+    @patch("enoch.telegram.bot.merge_pull_request", side_effect=PublishError("PR #12 is a draft."))
+    def test_pr_merge_reports_github_workflow_error(self, merge: MagicMock) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochTelegramBot(load_identity(), ROOT, client)
+
+        bot.handle_update(_message_update(chat_id=42, text="/pr merge 12"))
+
+        merge.assert_called_once_with("12", ROOT)
+        self.assertEqual(
+            client.sent[0][1],
+            "Enoch could not merge that pull request: PR #12 is a draft.",
+        )
 
     def test_help_resume_shows_only_resume_usage(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)


### PR DESCRIPTION
## Summary

- add the locked-chat `/pr merge <PR number or GitHub PR URL>` system command and help surface
- validate and inspect the exact PR before mutation, refusing missing, inaccessible, closed, merged, draft, conflicting, blocked, or otherwise unmergeable targets
- merge through the GitHub workflow helper using an enabled repository merge method and the inspected head SHA, without auto-merge, approvals, branch deletion, or local branch updates
- document the explicit sovereignty boundary and add focused routing/workflow tests

## Validation

- `python3 -m unittest tests.test_enoch_github_workflow tests.test_enoch_telegram tests.test_enoch_evolve_lifecycle` (230 tests passed)
- `env -u ENOCH_PYTHON python3 -m unittest discover -s tests` (473 tests passed)
- `git diff --check`