### PR TITLE
Make portable wheel CI reproducible

### DIFF
--- a/.github/requirements/test-build.txt
+++ b/.github/requirements/test-build.txt
@@ -1,0 +1,3 @@
+# Required by the offline wheel builds in tests/test_enoch_portable_install.py.
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Install locked test build backend
+        run: python -m pip install --disable-pip-version-check --require-hashes -r .github/requirements/test-build.txt
+
       - name: Run unit and hermetic E2E tests
         run: python -m unittest discover -s tests
 

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -15,6 +15,25 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class EnochPortableInstallTests(unittest.TestCase):
+    def test_ci_provisions_locked_build_backend_before_offline_wheel_test(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "tests.yml").read_text(
+            encoding="utf-8"
+        )
+        install_command = (
+            "python -m pip install --disable-pip-version-check --require-hashes "
+            "-r .github/requirements/test-build.txt"
+        )
+        test_command = "python -m unittest discover -s tests"
+
+        self.assertIn(install_command, workflow)
+        self.assertLess(workflow.index(install_command), workflow.index(test_command))
+
+        requirements = (
+            ROOT / ".github" / "requirements" / "test-build.txt"
+        ).read_text(encoding="utf-8")
+        self.assertRegex(requirements, r"(?m)^setuptools==\d+\.\d+\.\d+ \\$\n")
+        self.assertRegex(requirements, r"--hash=sha256:[0-9a-f]{64}$")
+
     def test_reference_providers_share_the_core_contract_pin(self) -> None:
         root_metadata = _project_metadata(ROOT / "pyproject.toml")
         core_contract = _dependency(root_metadata["project"]["dependencies"], "our-ark-provider-kit")


### PR DESCRIPTION
## Summary

- provision the setuptools build backend explicitly before the hermetic test suite
- pin the backend artifact by version and SHA-256 hash
- guard the CI ordering and lock-file requirements with a focused regression test

## Validation

- `python -m unittest discover -s tests` (537 tests)
- `python -m unittest discover -s libraries/launchd/tests` (4 tests)
- `python -m unittest discover -s libraries/systemd/tests` (4 tests)
- portable-install tests pass in a clean Python 3.12 venv without preinstalled setuptools after applying the locked CI setup step

## Evolution provenance

- Candidate: `feedback-3339be53ed97`
- Evidence source: feedback
- Signal actor: human
- Candidate actor: agent
- Approval actor: human
- Task: #15