### PR TITLE
Use LLM semantic curation for evolve proposals

### DIFF
--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -2261,10 +2261,17 @@ class EnochApplication:
             return _format_evolve_candidates(candidates, include_inactive=include_inactive)
         if subcommand == "remove":
             if not rest.strip():
-                return "Use /evolve remove <id> to remove a self-evolution candidate."
+                return "Use /evolve remove <id> [reason] to remove a self-evolution candidate."
+            remove_parts = rest.strip().split(maxsplit=1)
+            remove_reason = remove_parts[1] if len(remove_parts) > 1 else "human-requested-removal"
             state = evolve_report(self.root).state
             try:
-                candidate = remove_evolve_candidate(rest, self.root, theme=state.theme)
+                candidate = remove_evolve_candidate(
+                    remove_parts[0],
+                    self.root,
+                    theme=state.theme,
+                    reason=remove_reason,
+                )
             except ValueError as error:
                 return str(error)
             return "Removed evolve candidate.\n\n" + "\n".join(_format_evolve_candidate(candidate))
@@ -2311,15 +2318,11 @@ class EnochApplication:
     def _propose_evolve(self, chat_id: int, *, trigger: str) -> EvolveProposal:
         proposal = propose_evolve(
             self.root,
-            brainstormer=lambda theme: generate_brainstorm_ideas(
-                theme,
-                self.root,
-                mission=self.identity.mission,
-                generator=lambda prompt: self._respond_read_only_turn(
-                    chat_id,
-                    prompt,
-                    session_key=f"{self._session_key(chat_id)}:{trigger}",
-                ),
+            mission=self.identity.mission,
+            curator=lambda prompt: self._respond_read_only_turn(
+                chat_id,
+                prompt,
+                session_key=f"{self._session_key(chat_id)}:{trigger}:curation",
             ),
         )
         event_actor = "system" if trigger == "evolve-scheduler" else "human"
@@ -2394,6 +2397,10 @@ class EnochApplication:
                 retry_of_task_id=retry_of_task_id,
                 reason=reason,
                 proposal_id=proposal_id or (proposal.proposal_id if proposal is not None else ""),
+                curation_id=(proposal.curation.id if proposal is not None and proposal.curation else ""),
+                recommendation_kind=(
+                    proposal.curation.status if proposal is not None and proposal.curation else ""
+                ),
             )
         except (OSError, ValueError):
             return None
@@ -2815,102 +2822,22 @@ class EnochApplication:
             )
             return None
         proposal = self._propose_evolve(chat_id, trigger="evolve-scheduler")
-        if claimed.mode == MODE_CO_EVOLVE:
-            if proposal.top_candidate is not None:
-                self._record_evolve_event(
-                    "skipped",
-                    event_actor="system",
-                    trigger="evolve-scheduler",
-                    proposal=proposal,
-                    candidate=proposal.top_candidate,
-                    reason="awaiting-human-approval",
-                )
-            self._safe_send_message(chat_id, "Scheduled evolve check\n\n" + _format_evolve_proposal(proposal))
-            return None
-        if claimed.mode != MODE_AUTO_EVOLVE or proposal.top_candidate is None:
-            return None
-        report = proposal.report
-        candidate = proposal.top_candidate
-        if candidate.status == "failed":
+        if proposal.top_candidate is not None:
+            wait_reason = (
+                "retry-requires-human"
+                if proposal.top_candidate.status == "failed"
+                else "awaiting-human-approval"
+            )
             self._record_evolve_event(
                 "skipped",
                 event_actor="system",
                 trigger="evolve-scheduler",
                 proposal=proposal,
-                candidate=candidate,
-                reason="retry-requires-human",
+                candidate=proposal.top_candidate,
+                reason=wait_reason,
             )
-            self._safe_send_message(
-                chat_id,
-                "Scheduled evolve check\n\n" + _format_evolve_proposal(proposal),
-            )
-            return None
-        self._record_evolve_event(
-            "selected",
-            event_actor="system",
-            trigger="evolve-scheduler",
-            proposal=proposal,
-            candidate=candidate,
-            approval_actor="agent",
-        )
-        request = _evolve_task_request(candidate, report.state.theme)
-        context = _evolve_task_context(candidate)
-        try:
-            job = enqueue_task(
-                chat_id,
-                request,
-                self.root,
-                context=context,
-                context_source="evolve-scheduler",
-                source=candidate.source,
-                initiated_by="agent",
-                event_actor="system",
-                trigger="evolve-scheduler",
-                candidate_id=candidate.id,
-                evidence_source=candidate.evidence_source or candidate.source,
-                signal_actor=candidate.signal_actor,
-                candidate_actor=candidate.candidate_actor,
-                approval_actor="agent",
-                parent_candidate_id=candidate.parent_candidate_id,
-                source_task_id=candidate.source_task_id,
-            )
-        except (OSError, ValueError):
-            self._record_evolve_event(
-                "skipped",
-                event_actor="system",
-                trigger="evolve-scheduler",
-                proposal=proposal,
-                candidate=candidate,
-                reason="queue-failed",
-            )
-            return None
-        candidate = run_evolve_candidate(candidate.id, self.root, theme=report.state.theme)
-        self._record_evolve_event(
-            "queued",
-            event_actor="system",
-            trigger="evolve-scheduler",
-            proposal=proposal,
-            candidate=candidate,
-            task_id=job.id,
-            approval_actor="agent",
-        )
-        message = _format_work_status_message(
-            WorkStatusMessage(
-                chat_id=chat_id,
-                message_id=0,
-                request=job.text,
-                started_at=time.monotonic(),
-                task_id=job.id,
-                status="queued",
-                latest_update=f"Scheduled by evolve {claimed.mode}.",
-                context=job.context,
-            )
-        )
-        message_id = self._safe_send_message_id(chat_id, message)
-        if message_id is not None:
-            self._work_status_messages[job.id] = message_id
-            record_task_status_message(job.id, message_id, self.root)
-        return job
+        self._safe_send_message(chat_id, "Scheduled evolve check\n\n" + _format_evolve_proposal(proposal))
+        return None
 
     def _run_task_job(self, job: TaskJob) -> None:
         self._run_action_job(

--- a/src/enoch/app/presentation.py
+++ b/src/enoch/app/presentation.py
@@ -201,7 +201,7 @@ def evolve_usage() -> str:
             "Use /evolve approve <id> to approve and queue a candidate as a task.",
             "Use /evolve retry <id> to queue a new task for a failed candidate.",
             "Use /evolve reconcile <id> [backfill] to verify promotion of a completed candidate.",
-            "Use /evolve remove <id> to remove a candidate from future proposals.",
+            "Use /evolve remove <id> [reason] to remove a candidate from future proposals.",
             "Use /evolve schedule <text> to let Enoch interpret common schedule text.",
         ]
     )

--- a/src/enoch/app/reporting.py
+++ b/src/enoch/app/reporting.py
@@ -471,7 +471,10 @@ def _format_counter(counts: Counter[str]) -> str:
 
 
 def _evolve_check_reason(proposal: EvolveProposal) -> str:
-    parts = [f"ranked-{len(proposal.candidates)}-candidate(s)"]
+    parts = [f"pre-ranked-{len(proposal.candidates)}-candidate(s)"]
+    if proposal.curation is not None:
+        parts.append(proposal.curation.status)
+        parts.append(f"curation-{proposal.curation.id}")
     if proposal.brainstorm_attempted:
         parts.append(f"fallback-brainstorm-added-{proposal.brainstorm_added}")
     elif proposal.brainstorm_skip_reason:
@@ -482,6 +485,9 @@ def _evolve_check_reason(proposal: EvolveProposal) -> str:
 
 
 def _evolve_skip_reason(proposal: EvolveProposal) -> str:
+    if proposal.curation is not None and proposal.curation.status == "llm":
+        if proposal.curation.remove_suggestions or proposal.new_candidates:
+            return "curation-suggestions-only"
     if proposal.brainstorm_error:
         return f"brainstorm-failed: {proposal.brainstorm_error}"
     if proposal.brainstorm_skip_reason:
@@ -496,7 +502,10 @@ def _format_evolve_proposal(proposal: EvolveProposal) -> str:
     if report.state.mode == MODE_DISABLED:
         return "Evolve is disabled. Use /evolve mode co-evolve or /evolve mode auto-evolve before proposing."
     candidate = proposal.top_candidate
-    if candidate is None:
+    curation = proposal.curation
+    if candidate is None and not (
+        curation is not None and (curation.remove_suggestions or proposal.new_candidates)
+    ):
         if proposal.brainstorm_skip_reason == "candidate-running":
             return "Enoch found no new evolve candidate because evolve work is already running."
         if proposal.brainstorm_skip_reason == "theme-not-set":
@@ -512,17 +521,52 @@ def _format_evolve_proposal(proposal: EvolveProposal) -> str:
         "Enoch proposes:",
         f"Theme: {report.state.theme or 'not set'}",
         f"Ranked {len(proposal.candidates)} actionable candidate(s) from the six evolve sources.",
+        "Deterministic ranking was used only for bounded input ordering and fallback.",
     ]
     if proposal.brainstorm_attempted:
         lines.append(f"Fallback brainstorm added {proposal.brainstorm_added} candidate(s).")
     lines.append("")
-    lines.extend(_format_evolve_candidate(candidate))
-    lines.append("")
-    if candidate.status == "failed":
-        lines.append(f"Retry with /evolve retry {candidate.id}.")
+    if curation is not None and curation.status == "llm":
+        lines.append("LLM recommended candidate:")
     else:
-        lines.append(f"Approve with /evolve approve {candidate.id}.")
-    lines.append(f"Remove with /evolve remove {candidate.id}.")
+        reason = curation.fallback_reason if curation is not None else "curator-unavailable"
+        lines.append(f"Deterministic fallback recommendation ({reason}):")
+    if candidate is None:
+        lines.append("- none")
+    else:
+        lines.extend(_format_evolve_candidate(candidate))
+        if curation is not None and curation.recommendation is not None:
+            recommendation = curation.recommendation
+            lines.extend(
+                [
+                    f"  Curation reason: {_clip_activity_text(recommendation.reason, limit=180)}",
+                    f"  Scope guidance: {_clip_activity_text(recommendation.scope_guidance, limit=180)}",
+                    f"  Risk guidance: {_clip_activity_text(recommendation.risk_guidance, limit=180)}",
+                    f"  Test guidance: {_clip_activity_text(recommendation.test_plan_guidance, limit=180)}",
+                ]
+            )
+        lines.append("")
+        if candidate.status == "failed":
+            lines.append(f"Retry with /evolve retry {candidate.id}.")
+        else:
+            lines.append(f"Approve with /evolve approve {candidate.id}.")
+        lines.append(f"Remove with /evolve remove {candidate.id}.")
+    if curation is not None and curation.remove_suggestions:
+        lines.extend(["", "LLM remove suggestions (no status changed):"])
+        for suggestion in curation.remove_suggestions:
+            lines.append(
+                f"- {suggestion.candidate_id} [{suggestion.classification}] "
+                f"{_clip_activity_text(suggestion.reason, limit=180)}"
+            )
+            lines.append(
+                f"  Human action: /evolve remove {suggestion.candidate_id} {suggestion.classification}"
+            )
+    if proposal.new_candidates:
+        lines.extend(["", "New bounded candidates suggested by LLM (brainstorming/agent provenance):"])
+        for new_candidate in proposal.new_candidates:
+            lines.extend(_format_evolve_candidate(new_candidate))
+            lines.append(f"  Human action: /evolve approve {new_candidate.id}")
+    lines.extend(["", "No recommendation or remove suggestion changes state without human action."])
     return "\n".join(lines)
 
 
@@ -541,7 +585,7 @@ def _format_evolve_report(report: EvolveReport) -> str:
             lines.append(f"- {source}: {report.counts_by_source[source]}")
     else:
         lines.append("- none")
-    lines.extend(["", "Top candidate:"])
+    lines.extend(["", "Top candidate:", "(deterministic pre-ranking; semantic selection occurs in /propose)"])
     if report.top_candidate is None:
         lines.append("- none")
     else:
@@ -610,5 +654,5 @@ def _evolve_next_action(report: EvolveReport) -> str:
     if report.top_candidate.status == "failed":
         return "propose retrying this failed candidate and wait for explicit human approval."
     if report.state.mode == MODE_AUTO_EVOLVE:
-        return "select this bounded candidate, then queue or run work only after guardrails pass."
+        return "propose this candidate and wait for explicit human approval; scheduling does not queue it."
     return "propose this candidate and wait for human approval before changing code."

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -755,7 +755,7 @@ def _help_topic_message(topic: str) -> str:
                 "/evolve approve <id> - approve and queue a self-evolution candidate",
                 "/evolve retry <id> - retry a failed self-evolution candidate as a new task",
                 "/evolve reconcile <id> [backfill] - verify promotion of a completed candidate",
-                "/evolve remove <id> - remove a self-evolution candidate",
+                "/evolve remove <id> [reason] - remove a self-evolution candidate with an audit reason",
                 "/evolve schedule <text> - let Enoch interpret common schedule text",
             ]
         )

--- a/src/enoch/evolution/core.py
+++ b/src/enoch/evolution/core.py
@@ -9,8 +9,22 @@ from typing import Callable, Iterable
 
 from enoch.backlog import BacklogItem, backlog_status
 from enoch.automatic_learning import LearningArtifact, learning_index_path
-from enoch.evolution.sources.brainstorming import BrainstormIdea, load_brainstorm_ideas
+from enoch.evolution.sources.brainstorming import (
+    BrainstormIdea,
+    brainstorm_idea,
+    load_brainstorm_ideas,
+    save_brainstorm_ideas,
+)
 from enoch.cron import CronJob, cron_status, format_cron_interval
+from enoch.evolution.curation import (
+    DEFAULT_CURATION_LIMIT,
+    CurationGenerator,
+    SemanticCuration,
+    curate_candidates,
+    deterministic_fallback,
+    record_curation,
+    with_new_candidate_ids,
+)
 from enoch.evolution.sources.experience import ExperienceRecord, load_experience_records
 from enoch.evolution.events import (
     latest_open_proposal_id,
@@ -101,6 +115,8 @@ class EvolveProposal:
     brainstorm_added: int = 0
     brainstorm_skip_reason: str = ""
     brainstorm_error: str = ""
+    curation: SemanticCuration | None = None
+    new_candidates: tuple[EvolveCandidate, ...] = ()
 
 
 def evolve_state_path(root: Path | None = None) -> Path:
@@ -348,6 +364,9 @@ def propose_evolve(
     root: Path | None = None,
     *,
     brainstormer: BrainstormFallback | None = None,
+    curator: CurationGenerator | None = None,
+    mission: str = "",
+    curation_limit: int = DEFAULT_CURATION_LIMIT,
     now: datetime | None = None,
 ) -> EvolveProposal:
     report = evolve_report(root)
@@ -381,15 +400,114 @@ def propose_evolve(
                 for candidate in report.candidates
                 if candidate.status in ACTIONABLE_CANDIDATE_STATUSES
             )
+    curation = None
+    new_candidates: tuple[EvolveCandidate, ...] = ()
+    top_candidate = candidates[0] if candidates else None
+    if report.state.mode != MODE_DISABLED:
+        bounded = _select_curation_candidates(candidates, limit=curation_limit)
+        snapshots = tuple(_candidate_curation_snapshot(candidate) for candidate in bounded)
+        if curator is None:
+            curation = deterministic_fallback(snapshots, reason="curator-unavailable")
+        else:
+            try:
+                curation = curate_candidates(
+                    mission=mission,
+                    theme=report.state.theme,
+                    candidates=snapshots,
+                    generator=curator,
+                )
+            except (OSError, RuntimeError, TimeoutError, ValueError) as curation_error:
+                reason = clean_text(str(curation_error)) or curation_error.__class__.__name__
+                curation = deterministic_fallback(snapshots, reason=reason)
+        if curation.status == "llm" and curation.new_candidates:
+            ideas = tuple(
+                brainstorm_idea(
+                    theme=report.state.theme or "mission-aligned",
+                    mission=mission,
+                    **suggestion.__dict__,
+                )
+                for suggestion in curation.new_candidates
+            )
+            save_brainstorm_ideas(ideas, root)
+            report = evolve_report(root)
+            candidates = tuple(
+                candidate
+                for candidate in report.candidates
+                if candidate.status in ACTIONABLE_CANDIDATE_STATUSES
+            )
+            new_ids = tuple(idea.id for idea in ideas)
+            new_candidates = tuple(candidate for candidate in candidates if candidate.id in new_ids)
+            curation = with_new_candidate_ids(curation, new_ids)
+        if curation.recommendation is None:
+            top_candidate = None
+        else:
+            top_candidate = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if candidate.id == curation.recommendation.candidate_id
+                ),
+                None,
+            )
+        record_curation(curation, root)
     return EvolveProposal(
         report=report,
         candidates=candidates,
-        top_candidate=candidates[0] if candidates else None,
+        top_candidate=top_candidate,
         brainstorm_attempted=attempted,
         brainstorm_added=added,
         brainstorm_skip_reason=skip_reason,
         brainstorm_error=error,
+        curation=curation,
+        new_candidates=new_candidates,
     )
+
+
+def _candidate_curation_snapshot(candidate: EvolveCandidate) -> dict[str, object]:
+    return {
+        "id": candidate.id,
+        "source": candidate.source,
+        "title": _bounded_curation_text(candidate.title),
+        "rationale": _bounded_curation_text(candidate.rationale),
+        "proposed_change": _bounded_curation_text(candidate.proposed_change),
+        "expected_benefit": _bounded_curation_text(candidate.expected_benefit),
+        "risk": _bounded_curation_text(candidate.risk),
+        "test_plan": _bounded_curation_text(candidate.test_plan),
+        "status": candidate.status,
+        "deterministic_score": candidate.score,
+        "provenance": {
+            "evidence_source": candidate.evidence_source or candidate.source,
+            "signal_actor": candidate.signal_actor,
+            "candidate_actor": candidate.candidate_actor,
+            "parent_candidate_id": candidate.parent_candidate_id,
+            "source_task_id": candidate.source_task_id,
+        },
+    }
+
+
+def _select_curation_candidates(
+    candidates: tuple[EvolveCandidate, ...],
+    *,
+    limit: int,
+) -> tuple[EvolveCandidate, ...]:
+    """Keep deterministic order while retaining source diversity in bounded context."""
+    bounded_limit = max(1, limit)
+    if len(candidates) <= bounded_limit:
+        return candidates
+    first_source_indexes: dict[str, int] = {}
+    for index, candidate in enumerate(candidates):
+        first_source_indexes.setdefault(candidate.source, index)
+    selected = set(tuple(first_source_indexes.values())[:bounded_limit])
+    for index in range(len(candidates)):
+        if len(selected) >= bounded_limit:
+            break
+        selected.add(index)
+    return tuple(candidates[index] for index in sorted(selected))
+
+
+def _bounded_curation_text(value: str, *, limit: int = 1200) -> str:
+    cleaned = clean_text(value)
+    return cleaned if len(cleaned) <= limit else cleaned[: limit - 3].rstrip() + "..."
 
 
 def _claim_auto_brainstorm(
@@ -509,6 +627,7 @@ def remove_evolve_candidate(
     theme: str = "",
     event_actor: str = "human",
     trigger: str = "/evolve remove",
+    reason: str = "human-requested-removal",
 ) -> EvolveCandidate:
     candidate = get_evolve_candidate(candidate_id, root, theme=theme)
     if candidate.status not in ACTIONABLE_CANDIDATE_STATUSES:
@@ -522,6 +641,7 @@ def remove_evolve_candidate(
         trigger=trigger,
         theme=theme,
         proposal_id=latest_open_proposal_id(removed.id, root),
+        reason=reason,
     )
     return removed
 

--- a/src/enoch/evolution/curation.py
+++ b/src/enoch/evolution/curation.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import re
+from typing import Callable, Iterable, Mapping
+from uuid import uuid4
+
+from enoch.memory.paths import clean_text, now as current_time
+from enoch.paths import enoch_home
+
+
+SCHEMA_VERSION = 1
+DEFAULT_CURATION_LIMIT = 24
+REMOVE_CLASSIFICATIONS = {
+    "duplicate",
+    "superseded",
+    "obsolete",
+    "already-resolved",
+    "context-only",
+    "not-actionable",
+}
+CurationGenerator = Callable[[str], str]
+
+_ACTION = r"(?:change|modify|edit|update|alter|rewrite|replace|delete|grant|revoke|expand|remove|bypass|automate|enable|disable|configure|deploy|merge|publish|rotate|expose)"
+_PROTECTED = r"(?:identity|mission|secret|credential|permission|access control|merge authority|auto[- ]?merge|deployment|forge settings?|daemon configuration)"
+_PROTECTED_ACTION_PATTERN = re.compile(
+    rf"(?:\b{_ACTION}\b\s+(?:(?:the|our|enoch'?s|agent'?s)\s+)?\b{_PROTECTED}\b|"
+    rf"\b{_PROTECTED}\b\s+(?:{_ACTION})(?:s|d|ing)?\b)",
+    re.IGNORECASE | re.DOTALL,
+)
+_DANGEROUS_SCOPE_PATTERN = re.compile(
+    r"\b(?:destructive|delete all|erase|wipe|drop database|sudo|chmod 777|deploy(?:ment|s|ed|ing)?|"
+    r"auto[- ]?merge|rewrite (?:the )?entire|whole repository|unbounded)\b",
+    re.IGNORECASE,
+)
+
+
+class CurationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class CandidateRecommendation:
+    candidate_id: str
+    reason: str
+    scope_guidance: str
+    risk_guidance: str
+    test_plan_guidance: str
+
+
+@dataclass(frozen=True)
+class RemoveSuggestion:
+    candidate_id: str
+    classification: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class NewCandidateSuggestion:
+    title: str
+    rationale: str
+    proposed_change: str
+    expected_benefit: str
+    risk: str
+    test_plan: str
+
+
+@dataclass(frozen=True)
+class SemanticCuration:
+    id: str
+    created_at: str
+    status: str
+    input_candidate_ids: tuple[str, ...]
+    recommendation: CandidateRecommendation | None = None
+    remove_suggestions: tuple[RemoveSuggestion, ...] = ()
+    new_candidates: tuple[NewCandidateSuggestion, ...] = ()
+    new_candidate_ids: tuple[str, ...] = ()
+    fallback_reason: str = ""
+
+
+def curation_index_path(root: Path | None = None) -> Path:
+    return enoch_home(root) / "evolve_curations.jsonl"
+
+
+def semantic_curation_prompt(
+    mission: str,
+    theme: str,
+    candidates: Iterable[Mapping[str, object]],
+) -> str:
+    payload = {
+        "mission": _clip(clean_text(mission), 2000),
+        "evolution_theme": _clip(clean_text(theme), 500),
+        "candidates": list(candidates),
+    }
+    schema = {
+        "recommended_candidate_id": "existing candidate ID or null",
+        "recommendation_reason": "required when recommending",
+        "scope_guidance": "bounded clarification for the recommendation",
+        "risk_guidance": "risk clarification for the recommendation",
+        "test_plan_guidance": "specific verification clarification",
+        "remove_suggestions": [
+            {
+                "candidate_id": "existing candidate ID",
+                "classification": "duplicate|superseded|obsolete|already-resolved|context-only|not-actionable",
+                "reason": "auditable reason",
+            }
+        ],
+        "new_candidates": [
+            {
+                "title": "short title",
+                "rationale": "why it fits mission and theme",
+                "proposed_change": "small reversible change",
+                "expected_benefit": "specific benefit",
+                "risk": "specific bounded risk",
+                "test_plan": "specific verification plan",
+            }
+        ],
+    }
+    return "\n".join(
+        [
+            "Curate Enoch's bounded self-evolution candidate pool semantically.",
+            "Return exactly one JSON object and no prose.",
+            "Recommend at most one existing candidate. Do not invent an ID.",
+            "Treat provenance as immutable evidence; never rewrite or reclassify its source or actors.",
+            "Suggest removals only; do not approve, queue, run, remove, merge, deploy, or change permissions.",
+            "New candidates must be concrete, small, reversible, and testable.",
+            "Do not propose changes to identity, mission, secrets, credentials, permissions, access control, merge authority, deployment, forge settings, daemon configuration, or destructive behavior.",
+            f"Required response schema: {json.dumps(schema, sort_keys=True)}",
+            f"Curation input: {json.dumps(payload, sort_keys=True)}",
+        ]
+    )
+
+
+def curate_candidates(
+    *,
+    mission: str,
+    theme: str,
+    candidates: Iterable[Mapping[str, object]],
+    generator: CurationGenerator,
+) -> SemanticCuration:
+    snapshots = tuple(candidates)
+    candidate_ids = tuple(clean_text(str(item.get("id") or "")) for item in snapshots)
+    known = {candidate_id: item for candidate_id, item in zip(candidate_ids, snapshots) if candidate_id}
+    response = generator(semantic_curation_prompt(mission, theme, snapshots))
+    payload = _json_object(response)
+    if not isinstance(payload, dict):
+        raise CurationError("semantic curator returned malformed JSON")
+    expected_keys = {
+        "recommended_candidate_id",
+        "recommendation_reason",
+        "scope_guidance",
+        "risk_guidance",
+        "test_plan_guidance",
+        "remove_suggestions",
+        "new_candidates",
+    }
+    if set(payload) != expected_keys:
+        raise CurationError("semantic curator returned an invalid schema")
+
+    recommendation = _recommendation(payload, known)
+    remove_suggestions = _remove_suggestions(payload.get("remove_suggestions"), known)
+    new_candidates = _new_candidates(payload.get("new_candidates"))
+    if recommendation is not None and any(
+        item.candidate_id == recommendation.candidate_id for item in remove_suggestions
+    ):
+        raise CurationError("semantic curator both recommended and suggested removing one candidate")
+    if recommendation is None and not remove_suggestions and not new_candidates:
+        raise CurationError("semantic curator returned no valid result")
+    return SemanticCuration(
+        id=_curation_id(),
+        created_at=current_time(),
+        status="llm",
+        input_candidate_ids=candidate_ids,
+        recommendation=recommendation,
+        remove_suggestions=remove_suggestions,
+        new_candidates=new_candidates,
+    )
+
+
+def deterministic_fallback(
+    candidates: Iterable[Mapping[str, object]],
+    *,
+    reason: str,
+) -> SemanticCuration:
+    snapshots = tuple(candidates)
+    ids = tuple(clean_text(str(item.get("id") or "")) for item in snapshots)
+    recommendation = None
+    for candidate in snapshots:
+        if candidate_scope_is_safe(candidate):
+            candidate_id = clean_text(str(candidate.get("id") or ""))
+            if candidate_id:
+                recommendation = CandidateRecommendation(
+                    candidate_id=candidate_id,
+                    reason="Highest deterministic pre-ranked safe candidate.",
+                    scope_guidance="Review and keep the implementation bounded before approval.",
+                    risk_guidance="Use the candidate's recorded risk and human review.",
+                    test_plan_guidance=clean_text(str(candidate.get("test_plan") or "")),
+                )
+                break
+    created_at = current_time()
+    return SemanticCuration(
+        id=_curation_id(),
+        created_at=created_at,
+        status="deterministic-fallback",
+        input_candidate_ids=ids,
+        recommendation=recommendation,
+        fallback_reason=_clip(clean_text(reason), 300),
+    )
+
+
+def with_new_candidate_ids(
+    curation: SemanticCuration,
+    candidate_ids: Iterable[str],
+) -> SemanticCuration:
+    return SemanticCuration(
+        **{
+            **curation.__dict__,
+            "new_candidate_ids": tuple(clean_text(value) for value in candidate_ids if clean_text(value)),
+        }
+    )
+
+
+def record_curation(curation: SemanticCuration, root: Path | None = None) -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        **asdict(curation),
+    }
+    path = curation_index_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def load_curations(root: Path | None = None, *, limit: int = 100) -> tuple[SemanticCuration, ...]:
+    path = curation_index_path(root)
+    if not path.exists() or limit <= 0:
+        return ()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ()
+    items: list[SemanticCuration] = []
+    for line in reversed(lines):
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        item = _curation_from_json(raw)
+        if item is not None:
+            items.append(item)
+        if len(items) >= limit:
+            break
+    items.reverse()
+    return tuple(items)
+
+
+def candidate_scope_is_safe(candidate: Mapping[str, object]) -> bool:
+    text = " ".join(
+        clean_text(str(candidate.get(field) or ""))
+        for field in ("title", "proposed_change")
+    )
+    return not _unsafe_scope(text)
+
+
+def _recommendation(
+    payload: Mapping[str, object],
+    known: Mapping[str, Mapping[str, object]],
+) -> CandidateRecommendation | None:
+    raw_id = payload.get("recommended_candidate_id")
+    if raw_id is None:
+        return None
+    candidate_id = clean_text(str(raw_id))
+    if not candidate_id or candidate_id not in known:
+        raise CurationError("semantic curator recommended an unknown candidate ID")
+    fields = {
+        "reason": _required_text(payload, "recommendation_reason"),
+        "scope_guidance": _required_text(payload, "scope_guidance"),
+        "risk_guidance": _required_text(payload, "risk_guidance"),
+        "test_plan_guidance": _required_text(payload, "test_plan_guidance"),
+    }
+    guidance = " ".join(
+        fields[key] for key in ("scope_guidance", "risk_guidance", "test_plan_guidance")
+    )
+    if not candidate_scope_is_safe(known[candidate_id]) or _unsafe_scope(guidance):
+        raise CurationError("semantic curator recommended protected or dangerous scope")
+    return CandidateRecommendation(candidate_id=candidate_id, **fields)
+
+
+def _remove_suggestions(
+    raw_items: object,
+    known: Mapping[str, Mapping[str, object]],
+) -> tuple[RemoveSuggestion, ...]:
+    if not isinstance(raw_items, list):
+        raise CurationError("remove_suggestions must be a JSON array")
+    suggestions: list[RemoveSuggestion] = []
+    seen: set[str] = set()
+    for raw in raw_items[:20]:
+        if not isinstance(raw, dict) or set(raw) != {"candidate_id", "classification", "reason"}:
+            raise CurationError("remove suggestion has an invalid schema")
+        candidate_id = clean_text(str(raw.get("candidate_id") or ""))
+        classification = clean_text(str(raw.get("classification") or "")).lower()
+        reason = _required_text(raw, "reason")
+        if candidate_id not in known:
+            raise CurationError("semantic curator suggested removing an unknown candidate ID")
+        if classification not in REMOVE_CLASSIFICATIONS:
+            raise CurationError("semantic curator returned an invalid removal classification")
+        if candidate_id not in seen:
+            suggestions.append(RemoveSuggestion(candidate_id, classification, reason))
+            seen.add(candidate_id)
+    return tuple(suggestions)
+
+
+def _new_candidates(raw_items: object) -> tuple[NewCandidateSuggestion, ...]:
+    if not isinstance(raw_items, list):
+        raise CurationError("new_candidates must be a JSON array")
+    expected = {"title", "rationale", "proposed_change", "expected_benefit", "risk", "test_plan"}
+    suggestions: list[NewCandidateSuggestion] = []
+    for raw in raw_items[:3]:
+        if not isinstance(raw, dict) or set(raw) != expected:
+            raise CurationError("new candidate has an invalid schema")
+        fields = {field: _required_text(raw, field) for field in expected}
+        if len(fields["title"]) > 160 or any(len(value) > 1000 for value in fields.values()):
+            raise CurationError("new candidate exceeds bounded field limits")
+        if _unsafe_scope(" ".join(fields.values())):
+            raise CurationError("new candidate has protected or dangerous scope")
+        suggestions.append(NewCandidateSuggestion(**fields))
+    return tuple(suggestions)
+
+
+def _required_text(payload: Mapping[str, object], key: str) -> str:
+    value = clean_text(str(payload.get(key) or ""))
+    if not value:
+        raise CurationError(f"semantic curator omitted {key}")
+    if len(value) > 1000:
+        raise CurationError(f"semantic curator exceeded the {key} limit")
+    return value
+
+
+def _unsafe_scope(text: str) -> bool:
+    return bool(_PROTECTED_ACTION_PATTERN.search(text) or _DANGEROUS_SCOPE_PATTERN.search(text))
+
+
+def _json_object(response: object) -> object:
+    if not isinstance(response, str):
+        return None
+    stripped = response.strip()
+    fenced = re.fullmatch(r"```(?:json)?\s*(.*?)```", stripped, re.IGNORECASE | re.DOTALL)
+    if fenced:
+        stripped = fenced.group(1).strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+
+def _curation_id() -> str:
+    return "curation-" + uuid4().hex
+
+
+def _clip(value: str, limit: int) -> str:
+    return value if len(value) <= limit else value[: limit - 3].rstrip() + "..."
+
+
+def _curation_from_json(raw: object) -> SemanticCuration | None:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        recommendation_raw = raw.get("recommendation")
+        recommendation = (
+            CandidateRecommendation(**recommendation_raw)
+            if isinstance(recommendation_raw, dict)
+            else None
+        )
+        remove = tuple(
+            RemoveSuggestion(**item)
+            for item in raw.get("remove_suggestions", [])
+            if isinstance(item, dict)
+        )
+        new = tuple(
+            NewCandidateSuggestion(**item)
+            for item in raw.get("new_candidates", [])
+            if isinstance(item, dict)
+        )
+        return SemanticCuration(
+            id=clean_text(str(raw.get("id") or "")),
+            created_at=str(raw.get("created_at") or ""),
+            status=clean_text(str(raw.get("status") or "")),
+            input_candidate_ids=tuple(str(item) for item in raw.get("input_candidate_ids", [])),
+            recommendation=recommendation,
+            remove_suggestions=remove,
+            new_candidates=new,
+            new_candidate_ids=tuple(str(item) for item in raw.get("new_candidate_ids", [])),
+            fallback_reason=clean_text(str(raw.get("fallback_reason") or "")),
+        )
+    except (TypeError, ValueError):
+        return None

--- a/src/enoch/evolution/events.py
+++ b/src/enoch/evolution/events.py
@@ -100,6 +100,8 @@ class EvolveEvent:
     mode: str
     theme: str
     proposal_id: str = ""
+    curation_id: str = ""
+    recommendation_kind: str = ""
     candidate_id: str = ""
     task_id: int | None = None
     source: str = ""
@@ -148,6 +150,8 @@ def record_evolve_event(
     retry_of_task_id: int | None = None,
     reason: str = "",
     proposal_id: str = "",
+    curation_id: str = "",
+    recommendation_kind: str = "",
     pr_url: str = "",
     merge_commit: str = "",
     authoritative_branch: str = "",
@@ -268,6 +272,8 @@ def record_evolve_event(
         mode=clean_text(mode).lower(),
         theme=clean_text(theme),
         proposal_id=normalized_proposal_id,
+        curation_id=clean_text(curation_id),
+        recommendation_kind=clean_text(recommendation_kind).lower(),
         candidate_id=candidate_id,
         task_id=normalized_task_id,
         source=source,
@@ -437,6 +443,8 @@ def close_open_proposals(
                 ),
                 reason=reason,
                 proposal_id=proposal.proposal_id,
+                curation_id=proposal.curation_id,
+                recommendation_kind=proposal.recommendation_kind,
             )
         )
     return tuple(closed)
@@ -522,6 +530,8 @@ def _event_from_line(line: str) -> EvolveEvent | None:
         mode=clean_text(str(raw.get("mode") or "")).lower(),
         theme=clean_text(str(raw.get("theme") or "")),
         proposal_id=proposal_id,
+        curation_id=clean_text(str(raw.get("curation_id") or "")),
+        recommendation_kind=clean_text(str(raw.get("recommendation_kind") or "")).lower(),
         candidate_id=candidate_id,
         task_id=task_id,
         source=source,

--- a/src/enoch/evolution/sources/brainstorming.py
+++ b/src/enoch/evolution/sources/brainstorming.py
@@ -59,6 +59,42 @@ def generate_brainstorm_ideas(
     return ideas
 
 
+def save_brainstorm_ideas(
+    ideas: tuple[BrainstormIdea, ...],
+    root: Path | None = None,
+) -> tuple[BrainstormIdea, ...]:
+    """Persist already validated agent-origin ideas without changing provenance."""
+    if ideas:
+        _append_ideas(ideas, root)
+    return ideas
+
+
+def brainstorm_idea(
+    *,
+    theme: str,
+    mission: str,
+    title: str,
+    rationale: str,
+    proposed_change: str,
+    expected_benefit: str,
+    risk: str,
+    test_plan: str,
+    created_at: str = "",
+) -> BrainstormIdea:
+    return BrainstormIdea(
+        id=_idea_id(clean_text(theme), clean_text(title)),
+        theme=clean_text(theme),
+        mission=clean_text(mission),
+        title=clean_text(title),
+        rationale=clean_text(rationale),
+        proposed_change=clean_text(proposed_change),
+        expected_benefit=clean_text(expected_benefit),
+        risk=clean_text(risk),
+        test_plan=clean_text(test_plan),
+        created_at=created_at or current_time(),
+    )
+
+
 def load_brainstorm_ideas(
     root: Path | None = None,
     *,

--- a/src/enoch/identity.yaml
+++ b/src/enoch/identity.yaml
@@ -42,7 +42,7 @@ skills:
     version: 0.2.0
     path: src/enoch/skills/learn
   - name: evolve
-    version: 0.5.0
+    version: 0.6.0
     path: src/enoch/skills/evolve
   - name: teach
     version: 0.1.0

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -4,13 +4,13 @@
 
 Use this skill when Enoch should reason about her next small self-evolution step.
 
-The evolve skill is a selection loop, not a generic task runner. It collects possible improvements, ranks them against the current evolution theme, and proposes the best bounded next step.
+The evolve skill is a selection loop, not a generic task runner. It collects possible improvements, deterministically pre-ranks them, and asks the reasoning engine to semantically curate a bounded candidate pool against the current mission and evolution theme.
 
 ## Modes
 
 - `disabled`: do not collect, rank, or propose self-evolution candidates.
 - `co-evolve`: collect and rank candidates, then wait for human approval before changing code.
-- `auto-evolve`: select bounded candidates under guardrails; do not merge self-evolution changes.
+- `auto-evolve`: schedule semantic proposal checks under guardrails; still require human approval before queueing or removing candidates, and never merge self-evolution changes.
 
 The default mode is `co-evolve`.
 
@@ -25,19 +25,30 @@ Enoch collects exactly six semantic candidate sources:
 - **learning** from skills explicitly inspected with `/learn`, recorded in `.enoch/learning/peers.jsonl`; and
 - **brainstorming** from bounded, structured LLM ideas generated under the current mission and evolution theme.
 
-The theme is ranking pressure, not a seventh source. `/evolve brainstorm` requires a non-empty theme, asks the reasoning engine for a small JSON list, validates the result, and persists only structured candidates in `.enoch/evolve_brainstorms.jsonl`.
+The theme is semantic curation context and deterministic pre-ranking pressure, not a seventh source. `/evolve brainstorm` requires a non-empty theme, asks the reasoning engine for a small JSON list, validates the result, and persists only structured candidates in `.enoch/evolve_brainstorms.jsonl`.
 
-`/propose` first refreshes and ranks all six sources. If no actionable candidate
-exists and a theme is set, it runs one bounded fallback brainstorm and ranks
-again. Automatic fallback attempts have a per-theme 24-hour cooldown persisted
-in `.enoch/evolve_brainstorm_fallback.json`; explicit `/evolve brainstorm`
-remains available during the cooldown.
+`/propose` refreshes all six sources, applies deterministic pre-ranking, and
+passes a bounded set of structured candidate fields and provenance to semantic
+curation. The curator may recommend one existing ID with narrower scope, risk,
+and test guidance; suggest duplicate, superseded, obsolete, already-resolved,
+context-only, or not-actionable candidates for removal; and suggest up to three
+new bounded candidates. New suggestions are persisted with
+`brainstorming`/`agent` provenance and never masquerade as human feedback.
+
+Semantic curation is stored separately in `.enoch/evolve_curations.jsonl`. It
+references raw candidate IDs and immutable provenance instead of rewriting raw
+evidence. Deterministic ranking remains only for bounded context ordering and an
+explicitly labelled fallback when the reasoning engine is unavailable, times
+out, returns malformed JSON, or produces no valid result. The legacy empty-pool
+brainstorm fallback remains available to direct callers, while the application
+proposal flow uses semantic curation for both existing and newly suggested work.
 
 Candidates are persisted in `.enoch/evolve_candidates.json` so Enoch can remember whether a candidate is available, running, done, failed, cancelled, or removed. Normal candidate views retain failed candidates as retryable and hide done, cancelled, and removed candidates.
 
 Evolution decisions are appended to `.enoch/evolve_events.jsonl`. The funnel
 records checks, proposals, selections, queueing, terminal outcomes, skips, and
-removals. Candidate provenance separates `evidence_source`, `signal_actor`, and
+human removals. Proposal events link `curation_id` and `recommendation_kind` to
+the separate curation journal. Candidate provenance separates `evidence_source`, `signal_actor`, and
 `candidate_actor`; execution records `approval_actor`, while `event_actor` and
 `trigger` identify who caused each lifecycle decision. `parent_candidate_id`
 and `source_task_id` preserve causal links for candidates learned from prior
@@ -53,10 +64,9 @@ When the scheduler is due:
 
 - `disabled` mode advances the schedule and takes no action.
 - `co-evolve` mode runs the same proposal selection as `/propose` and sends that proposal to the locked chat-provider conversation.
-- `auto-evolve` mode runs the same proposal selection as `/propose` and turns
-  its top new candidate into a queued task for review-oriented implementation.
-  Failed candidates are proposed for explicit human retry instead of being
-  retried automatically.
+- `auto-evolve` mode runs the same proposal selection as `/propose`, sends it to
+  the locked conversation, and waits for explicit human approval. It does not
+  queue new candidates, retry failures, or apply remove suggestions automatically.
 
 Proposal selection considers candidates whose status is `candidate` or `failed`. Running candidates are not proposed again.
 Scheduled co-evolve and auto-evolve checks use the same empty-candidate fallback
@@ -111,7 +121,17 @@ workflows, recurring jobs, and skill-work artifacts become evolve candidates.
 
 Evolve candidates should be small, testable, reversible, and aligned with Enoch's mission and current theme.
 
-Enoch must require human direction before changing identity, mission, secrets, permission boundaries, forge settings, daemon configuration, merge behavior, destructive operations, or large architecture.
+All curator output must pass strict JSON schema, known-ID, bounded-field,
+test-plan, protected-scope, and dangerous-action validation. Unknown IDs and
+suggestions that change identity, mission, secrets, credentials, permissions,
+access control, merge authority, deployment, forge settings, daemon
+configuration, destructive behavior, or large architecture are rejected.
+
+The reasoning engine only recommends. It cannot approve, queue, run, retry,
+remove, merge, change the mission, or alter permissions. `/evolve approve`,
+`/evolve retry`, and `/evolve remove` are explicit human state-change entries.
+Removal records status, human actor, reason, and event while preserving the raw
+candidate and provenance in the candidate store and append-only journals.
 
 ## Commands
 
@@ -127,7 +147,7 @@ Enoch must require human direction before changing identity, mission, secrets, p
 - `/evolve approve <id>`
 - `/evolve retry <id>`
 - `/evolve reconcile <id> [backfill]`
-- `/evolve remove <id>`
+- `/evolve remove <id> [reason]`
 - `/evolve schedule <text>`
 - `/evolve schedule once a day`
 - `/evolve schedule every <interval>`

--- a/src/enoch/skills/evolve/skill.yaml
+++ b/src/enoch/skills/evolve/skill.yaml
@@ -1,6 +1,6 @@
 name: evolve
-version: 0.5.0
-summary: Collect, rank, and propose bounded self-evolution candidates under human-visible guardrails.
+version: 0.6.0
+summary: Semantically curate and propose bounded self-evolution candidates under human approval.
 owner: Enoch
 status: active
 mode: co-evolution
@@ -9,6 +9,7 @@ capabilities:
   state: src/enoch/evolution/core.py
   scheduler: src/enoch/evolution/core.py
   event_journal: src/enoch/evolution/events.py
+  semantic_curation: src/enoch/evolution/curation.py
   candidate_collection:
     - src/enoch/backlog.py
     - src/enoch/evolution/sources/feedback.py
@@ -28,12 +29,14 @@ permissions:
       - .enoch/learning/artifacts.jsonl
       - .enoch/learning/peers.jsonl
       - .enoch/evolve_events.jsonl
+      - .enoch/evolve_curations.jsonl
       - .agent/lineage_inbox.json
     write:
       - .enoch/evolve.json
       - .enoch/evolve_candidates.json
       - .enoch/evolve_brainstorms.jsonl
       - .enoch/evolve_events.jsonl
+      - .enoch/evolve_curations.jsonl
   git:
     merge: false
 validation:

--- a/tests/test_enoch_evolve_curation.py
+++ b/tests/test_enoch_evolve_curation.py
@@ -1,0 +1,372 @@
+from pathlib import Path
+import json
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from enoch.evolution.core import (
+    EvolveCandidate,
+    EvolveReport,
+    EvolveState,
+    collect_evolve_candidates,
+    load_evolve_candidates,
+    propose_evolve,
+    remove_evolve_candidate,
+)
+from enoch.evolution.curation import load_curations
+from enoch.evolution.events import load_evolve_events
+from enoch.tasks.queue import task_queue_status
+from enoch.logs import log_conversation_turn
+
+
+class EnochEvolveCurationTests(unittest.TestCase):
+    def test_six_sources_enter_bounded_curation_with_unchanged_provenance(self) -> None:
+        candidates = tuple(_candidate(source, index) for index, source in enumerate(_sources(), start=1))
+        report = EvolveReport(
+            state=EvolveState(theme="auditable OSS evolution"),
+            candidates=candidates,
+            top_candidate=candidates[0],
+            counts_by_source={source: 1 for source in _sources()},
+        )
+        prompts = []
+
+        def curate(prompt: str) -> str:
+            prompts.append(prompt)
+            return _response(recommended_candidate_id=candidates[-1].id)
+
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            from unittest.mock import patch
+
+            with patch("enoch.evolution.core.evolve_report", return_value=report):
+                proposal = propose_evolve(root, mission="Evolve safely", curator=curate)
+
+        payload = _prompt_input(prompts[0])
+        self.assertEqual({item["source"] for item in payload["candidates"]}, set(_sources()))
+        provenance = {item["source"]: item["provenance"] for item in payload["candidates"]}
+        for candidate in candidates:
+            self.assertEqual(provenance[candidate.source]["evidence_source"], candidate.evidence_source)
+            self.assertEqual(provenance[candidate.source]["signal_actor"], candidate.signal_actor)
+            self.assertEqual(provenance[candidate.source]["candidate_actor"], candidate.candidate_actor)
+        self.assertEqual(proposal.top_candidate.id, candidates[-1].id)
+        self.assertEqual(candidates, report.candidates)
+
+    def test_bounded_curation_retains_one_candidate_from_each_source(self) -> None:
+        candidates = tuple(_candidate("backlog", index, score=100 - index) for index in range(20))
+        candidates += tuple(
+            _candidate(source, index, score=1)
+            for index, source in enumerate(_sources()[1:], start=20)
+        )
+        report = EvolveReport(
+            state=EvolveState(theme="auditable OSS evolution"),
+            candidates=candidates,
+            top_candidate=candidates[0],
+            counts_by_source={source: 1 for source in _sources()},
+        )
+        prompts = []
+
+        with TemporaryDirectory() as temp:
+            from unittest.mock import patch
+
+            with patch("enoch.evolution.core.evolve_report", return_value=report):
+                propose_evolve(
+                    Path(temp),
+                    curator=lambda prompt: prompts.append(prompt) or _response(),
+                    curation_limit=6,
+                )
+
+        payload = _prompt_input(prompts[0])
+        self.assertEqual(len(payload["candidates"]), 6)
+        self.assertEqual({item["source"] for item in payload["candidates"]}, set(_sources()))
+
+    def test_context_only_feedback_is_suggested_for_removal_not_execution(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            article = (
+                "This essay is background context, not an implementation request. "
+                "Actually, it describes how long-running human-agent systems may learn over time. "
+                + "It discusses context, judgment, and verification as general concepts. " * 60
+            )
+            log_conversation_turn(chat_id=42, message=article, reply="Thanks for the context.", root=root)
+            candidate = next(
+                item for item in collect_evolve_candidates(root) if item.source == "feedback"
+            )
+
+            proposal = propose_evolve(
+                root,
+                mission="Evolve safely",
+                curator=lambda _prompt: _response(
+                    remove=[
+                        {
+                            "candidate_id": candidate.id,
+                            "classification": "context-only",
+                            "reason": "This is conceptual background, not an explicit improvement request.",
+                        }
+                    ]
+                ),
+            )
+
+            stored = load_evolve_candidates(root, include_inactive=True)
+            curation = load_curations(root)[0]
+
+        self.assertIsNone(proposal.top_candidate)
+        self.assertEqual(curation.remove_suggestions[0].classification, "context-only")
+        self.assertEqual(stored[0].status, "candidate")
+
+    def test_duplicate_and_resolved_suggestions_are_auditable_but_do_not_remove(self) -> None:
+        first = _candidate("backlog", 1)
+        second = _candidate("experience", 2)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (first, second))
+            proposal = propose_evolve(
+                root,
+                curator=lambda _prompt: _response(
+                    remove=[
+                        {"candidate_id": first.id, "classification": "duplicate", "reason": "Same bounded change."},
+                        {"candidate_id": second.id, "classification": "already-resolved", "reason": "Tests show it is fixed."},
+                    ]
+                ),
+            )
+
+            statuses = {item.id: item.status for item in load_evolve_candidates(root, include_inactive=True)}
+
+        self.assertEqual(
+            [item.classification for item in proposal.curation.remove_suggestions],
+            ["duplicate", "already-resolved"],
+        )
+        self.assertEqual(statuses, {first.id: "candidate", second.id: "candidate"})
+
+    def test_llm_recommends_existing_candidate_without_state_change(self) -> None:
+        first = _candidate("backlog", 1, score=100)
+        second = _candidate("learning", 2, score=1)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (first, second))
+            proposal = propose_evolve(
+                root,
+                curator=lambda _prompt: _response(recommended_candidate_id=second.id),
+            )
+
+            stored = load_evolve_candidates(root, include_inactive=True)
+            queue = task_queue_status(root)
+
+        self.assertEqual(proposal.top_candidate.id, second.id)
+        self.assertEqual(proposal.curation.status, "llm")
+        self.assertTrue(all(item.status == "candidate" for item in stored))
+        self.assertEqual(queue.pending_count, 0)
+
+    def test_valid_new_candidate_uses_brainstorming_agent_provenance(self) -> None:
+        existing = _candidate("backlog", 1)
+        new = {
+            "title": "Verify curation journal loading",
+            "rationale": "Auditability needs a bounded loader check.",
+            "proposed_change": "Add a focused loader validation test.",
+            "expected_benefit": "Keeps curation metadata inspectable.",
+            "risk": "One small test may need fixture maintenance.",
+            "test_plan": "Run the focused curation test module.",
+        }
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (existing,))
+            proposal = propose_evolve(
+                root,
+                mission="Evolve safely",
+                curator=lambda _prompt: _response(new=[new]),
+            )
+
+            candidates = load_evolve_candidates(root, include_inactive=True)
+
+        self.assertEqual(len(proposal.new_candidates), 1)
+        suggested = proposal.new_candidates[0]
+        self.assertEqual(suggested.source, "brainstorming")
+        self.assertEqual(suggested.evidence_source, "brainstorming")
+        self.assertEqual(suggested.signal_actor, "agent")
+        self.assertEqual(suggested.candidate_actor, "agent")
+        self.assertEqual({item.status for item in candidates}, {"candidate"})
+
+    def test_invalid_outputs_use_explicit_deterministic_fallback(self) -> None:
+        candidate = _candidate("backlog", 1)
+        cases = {
+            "malformed": "not-json",
+            "non-string": None,
+            "unknown-id": _response(recommended_candidate_id="feedback-unknown"),
+            "protected-guidance": _response(
+                recommended_candidate_id=candidate.id,
+                scope="Modify the mission to permit this work.",
+            ),
+            "dangerous-new": _response(
+                new=[
+                    {
+                        "title": "Rewrite the entire repository",
+                        "rationale": "Broad cleanup.",
+                        "proposed_change": "Rewrite the entire repository at once.",
+                        "expected_benefit": "Consistency.",
+                        "risk": "Large blast radius.",
+                        "test_plan": "Run tests.",
+                    }
+                ]
+            ),
+            "protected-new": _response(
+                new=[
+                    {
+                        "title": "Delete the identity file",
+                        "rationale": "Avoid a configuration step.",
+                        "proposed_change": "Delete the identity file.",
+                        "expected_benefit": "Less configuration.",
+                        "risk": "Identity would be lost.",
+                        "test_plan": "Run tests.",
+                    }
+                ]
+            ),
+            "missing-test-plan": json.dumps(
+                {
+                    "recommended_candidate_id": None,
+                    "recommendation_reason": "",
+                    "scope_guidance": "",
+                    "risk_guidance": "",
+                    "test_plan_guidance": "",
+                    "remove_suggestions": [],
+                    "new_candidates": [
+                        {
+                            "title": "Incomplete suggestion",
+                            "rationale": "Missing required verification.",
+                            "proposed_change": "Add one helper.",
+                            "expected_benefit": "Less duplication.",
+                            "risk": "Small maintenance cost.",
+                        }
+                    ],
+                }
+            ),
+        }
+        for label, response in cases.items():
+            with self.subTest(label=label), TemporaryDirectory() as temp:
+                root = Path(temp)
+                _write_candidates(root, (candidate,))
+                proposal = propose_evolve(root, curator=lambda _prompt, value=response: value)
+                self.assertEqual(proposal.curation.status, "deterministic-fallback")
+                self.assertEqual(proposal.top_candidate.id, candidate.id)
+
+    def test_protected_raw_candidate_is_not_recommended_even_by_fallback(self) -> None:
+        candidate = _candidate(
+            "backlog",
+            1,
+            title="Change the mission and deploy automatically",
+        )
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (candidate,))
+            proposal = propose_evolve(
+                root,
+                curator=lambda _prompt: _response(recommended_candidate_id=candidate.id),
+            )
+
+        self.assertEqual(proposal.curation.status, "deterministic-fallback")
+        self.assertIsNone(proposal.top_candidate)
+
+    def test_timeout_and_empty_result_use_fallback(self) -> None:
+        candidate = _candidate("backlog", 1)
+        for label, curator in (
+            ("timeout", lambda _prompt: (_ for _ in ()).throw(TimeoutError("timed out"))),
+            ("empty", lambda _prompt: _response()),
+        ):
+            with self.subTest(label=label), TemporaryDirectory() as temp:
+                root = Path(temp)
+                _write_candidates(root, (candidate,))
+                proposal = propose_evolve(root, curator=curator)
+                self.assertEqual(proposal.curation.status, "deterministic-fallback")
+                self.assertEqual(proposal.top_candidate.id, candidate.id)
+                self.assertTrue(proposal.curation.fallback_reason)
+
+    def test_only_human_remove_entry_changes_status_and_records_reason(self) -> None:
+        candidate = _candidate("feedback", 1)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (candidate,))
+            propose_evolve(
+                root,
+                curator=lambda _prompt: _response(
+                    remove=[
+                        {"candidate_id": candidate.id, "classification": "not-actionable", "reason": "No concrete change."}
+                    ]
+                ),
+            )
+            before = load_evolve_candidates(root, include_inactive=True)[0]
+            removed = remove_evolve_candidate(candidate.id, root, reason="not-actionable: No concrete change")
+            event = load_evolve_events(root, candidate_id=candidate.id)[-1]
+
+        self.assertEqual(before.status, "candidate")
+        self.assertEqual(removed.status, "removed")
+        self.assertEqual(event.event_actor, "human")
+        self.assertEqual(event.reason, "not-actionable: No concrete change")
+
+
+def _sources() -> tuple[str, ...]:
+    return ("backlog", "feedback", "experience", "inheritance", "learning", "brainstorming")
+
+
+def _candidate(source: str, index: int, *, title: str = "", score: int = 10) -> EvolveCandidate:
+    signal_actor = "human" if source in {"backlog", "feedback", "learning"} else "agent"
+    if source == "experience":
+        signal_actor = "system"
+    return EvolveCandidate(
+        id=f"{source}-{index}",
+        source=source,
+        title=title or f"Bounded {source} improvement {index}",
+        rationale="A small repository improvement is supported by evidence.",
+        proposed_change="Add one focused validation path.",
+        expected_benefit="Improves reliability.",
+        risk="Small maintenance cost.",
+        test_plan="Run one focused unit test and doctor.",
+        evidence_source=source,
+        signal_actor=signal_actor,
+        candidate_actor="agent",
+        score=score,
+    )
+
+
+def _response(
+    *,
+    recommended_candidate_id: str | None = None,
+    remove: list[dict[str, str]] | None = None,
+    new: list[dict[str, str]] | None = None,
+    scope: str = "Limit the change to one focused module.",
+) -> str:
+    return json.dumps(
+        {
+            "recommended_candidate_id": recommended_candidate_id,
+            "recommendation_reason": "Best mission-aligned bounded change." if recommended_candidate_id else "",
+            "scope_guidance": scope if recommended_candidate_id else "",
+            "risk_guidance": "Keep the change reversible and reviewable." if recommended_candidate_id else "",
+            "test_plan_guidance": "Run focused tests and doctor." if recommended_candidate_id else "",
+            "remove_suggestions": remove or [],
+            "new_candidates": new or [],
+        }
+    )
+
+
+def _prompt_input(prompt: str) -> dict[str, object]:
+    line = next(value for value in prompt.splitlines() if value.startswith("Curation input: "))
+    return json.loads(line.removeprefix("Curation input: "))
+
+
+def _write_candidates(root: Path, candidates: tuple[EvolveCandidate, ...]) -> None:
+    path = root / ".enoch" / "evolve_candidates.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "candidates": [candidate.__dict__ for candidate in candidates],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enoch_evolve_events.py
+++ b/tests/test_enoch_evolve_events.py
@@ -184,6 +184,8 @@ class EnochEvolveEventTests(unittest.TestCase):
                 trigger="/propose",
                 mode="co-evolve",
                 candidate=candidate,
+                curation_id="curation-123",
+                recommendation_kind="llm",
             )
             open_before = load_open_proposals(root)
             closed = close_open_proposals(
@@ -199,6 +201,8 @@ class EnochEvolveEventTests(unittest.TestCase):
             )
 
         self.assertTrue(proposed.proposal_id.startswith("proposal-"))
+        self.assertEqual(proposed.curation_id, "curation-123")
+        self.assertEqual(proposed.recommendation_kind, "llm")
         self.assertEqual(open_before, (proposed,))
         self.assertEqual(open_after, "")
         self.assertEqual(closed[0].proposal_id, proposed.proposal_id)

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -2307,10 +2307,12 @@ class EnochTelegramTests(unittest.TestCase):
             _handle_update(bot, _message_update(chat_id=42, text="/propose"))
             candidates = load_evolve_candidates(root)
             events = load_evolve_events(root)
+            queued = task_queue_status(root)
 
         reply = client.sent[0][1]
         self.assertIn("Enoch proposes:", reply)
         self.assertIn("Ranked 1 actionable candidate(s) from the six evolve sources.", reply)
+        self.assertIn("Deterministic fallback recommendation", reply)
         self.assertIn("backlog-1 [candidate backlog] improve Telegram work UX", reply)
         self.assertIn("Approve with /evolve approve backlog-1.", reply)
         self.assertIn("Remove with /evolve remove backlog-1.", reply)
@@ -2320,6 +2322,49 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertEqual(events[-1].trigger, "/propose")
         self.assertEqual(events[-1].candidate_id, "backlog-1")
         self.assertTrue(events[-1].proposal_id.startswith("proposal-"))
+        self.assertTrue(events[-1].curation_id.startswith("curation-"))
+        self.assertEqual(events[-1].recommendation_kind, "deterministic-fallback")
+
+    def test_propose_displays_llm_recommendation_and_remove_suggestions_without_mutation(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "context-only background note", root, priority="p0")
+            add_backlog_item(42, "add bounded curation coverage", root, priority="p1")
+            response = json.dumps(
+                {
+                    "recommended_candidate_id": "backlog-2",
+                    "recommendation_reason": "This is the clearest bounded code change.",
+                    "scope_guidance": "Limit the work to curation tests.",
+                    "risk_guidance": "Avoid broad refactors.",
+                    "test_plan_guidance": "Run focused tests and doctor.",
+                    "remove_suggestions": [
+                        {
+                            "candidate_id": "backlog-1",
+                            "classification": "context-only",
+                            "reason": "The note does not request an implementation change.",
+                        }
+                    ],
+                    "new_candidates": [],
+                }
+            )
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochApplication(load_identity(), root, client)
+
+            with patch.object(bot, "_respond_read_only_turn", return_value=response):
+                _handle_update(bot, _message_update(chat_id=42, text="/propose"))
+            candidates = load_evolve_candidates(root)
+            events = load_evolve_events(root)
+            queued = task_queue_status(root)
+
+        reply = client.sent[0][1]
+        self.assertIn("LLM recommended candidate:", reply)
+        self.assertIn("backlog-2 [candidate backlog]", reply)
+        self.assertIn("LLM remove suggestions (no status changed):", reply)
+        self.assertIn("backlog-1 [context-only]", reply)
+        self.assertEqual({candidate.status for candidate in candidates}, {"candidate"})
+        self.assertEqual(queued.pending_count, 0)
+        self.assertEqual(events[-1].recommendation_kind, "llm")
+        self.assertTrue(events[-1].curation_id.startswith("curation-"))
 
     def test_repeated_proposal_marks_previous_one_no_action(self) -> None:
         with TemporaryDirectory() as temp:
@@ -2369,18 +2414,26 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertEqual([event.event for event in events], ["proposed", "removed"])
         self.assertEqual(events[0].proposal_id, events[1].proposal_id)
 
-    def test_propose_fallback_brainstorms_when_no_candidate_exists(self) -> None:
+    def test_propose_curator_suggests_bounded_candidate_when_pool_is_empty(self) -> None:
         response = json.dumps(
-            [
+            {
+                "recommended_candidate_id": None,
+                "recommendation_reason": "",
+                "scope_guidance": "",
+                "risk_guidance": "",
+                "test_plan_guidance": "",
+                "remove_suggestions": [],
+                "new_candidates": [
                 {
-                    "title": "Improve fallback observability",
+                    "title": "Improve curation observability",
                     "rationale": "No stronger candidate exists.",
-                    "proposed_change": "Expose fallback brainstorm outcomes.",
+                    "proposed_change": "Expose semantic curation outcomes.",
                     "expected_benefit": "Makes proposals easier to audit.",
                     "risk": "Adds output.",
                     "test_plan": "Add proposal tests.",
                 }
-            ]
+                ],
+            }
         )
         with TemporaryDirectory() as temp:
             root = Path(temp)
@@ -2392,11 +2445,12 @@ class EnochTelegramTests(unittest.TestCase):
                 _handle_update(bot, _message_update(chat_id=42, text="/propose"))
             candidates = load_evolve_candidates(root)
 
-        self.assertIn("Fallback brainstorm added 1 candidate(s).", client.sent[0][1])
-        self.assertIn("[candidate brainstorming] Improve fallback observability", client.sent[0][1])
+        self.assertIn("New bounded candidates suggested by LLM", client.sent[0][1])
         self.assertEqual(candidates[0].source, "brainstorming")
+        self.assertEqual(candidates[0].signal_actor, "agent")
+        self.assertIn("[candidate brainstorming] Improve curation observability", client.sent[0][1])
         self.assertEqual(candidates[0].initiated_by, "agent")
-        self.assertEqual(respond.call_args.kwargs["session_key"], "telegram:42:propose-fallback")
+        self.assertEqual(respond.call_args.kwargs["session_key"], "telegram:42:propose-fallback:curation")
 
     def test_evolve_can_list_and_remove_candidates(self) -> None:
         with TemporaryDirectory() as temp:
@@ -3007,7 +3061,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertEqual(events[-1].reason, "awaiting-human-approval")
         self.assertEqual(events[-1].proposal_id, events[-2].proposal_id)
 
-    def test_due_evolve_schedule_auto_mode_queues_top_candidate(self) -> None:
+    def test_due_evolve_schedule_auto_mode_still_requires_human_approval(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
             add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
@@ -3025,33 +3079,23 @@ class EnochTelegramTests(unittest.TestCase):
             report = evolve_report(root)
             events = load_evolve_events(root)
 
-        self.assertIsNotNone(job)
-        self.assertEqual(queued.pending_count, 1)
-        self.assertIn("Evolve candidate backlog-1", queued.pending[0].text)
-        self.assertEqual(queued.pending[0].context_source, "evolve-scheduler")
-        self.assertEqual(queued.pending[0].source, "backlog")
-        self.assertEqual(queued.pending[0].initiated_by, "agent")
-        self.assertEqual(queued.pending[0].candidate_id, "backlog-1")
-        self.assertEqual(queued.pending[0].evidence_source, "backlog")
-        self.assertEqual(queued.pending[0].signal_actor, "human")
-        self.assertEqual(queued.pending[0].candidate_actor, "agent")
-        self.assertEqual(queued.pending[0].approval_actor, "agent")
-        self.assertEqual(report.top_candidate.status, "running")
-        self.assertIn("Latest update: Scheduled by evolve auto-evolve.", client.sent[0][1])
+        self.assertIsNone(job)
+        self.assertEqual(queued.pending_count, 0)
+        self.assertEqual(report.top_candidate.status, "candidate")
+        self.assertIn("Scheduled evolve check", client.sent[0][1])
+        self.assertIn("without human action", client.sent[0][1].lower())
         self.assertEqual(
             [event.event for event in events],
-            ["checked", "proposed", "selected", "queued"],
+            ["checked", "proposed", "skipped"],
         )
         self.assertTrue(all(event.event_actor == "system" for event in events))
         self.assertEqual(events[-1].trigger, "evolve-scheduler")
-        self.assertEqual(events[-1].task_id, queued.pending[0].id)
-        self.assertEqual(events[-1].signal_actor, "human")
-        self.assertEqual(events[-1].candidate_actor, "agent")
-        self.assertEqual(events[-1].approval_actor, "agent")
+        self.assertEqual(events[-1].reason, "awaiting-human-approval")
+        self.assertEqual(events[-1].task_id, None)
         proposal_ids = {
             event.proposal_id
             for event in events
-            if event.event in {"proposed", "selected", "queued"}
+            if event.event in {"proposed", "skipped"}
         }
         self.assertEqual(len(proposal_ids), 1)
 
@@ -3104,26 +3148,35 @@ class EnochTelegramTests(unittest.TestCase):
             bot = EnochApplication(load_identity(), root, client)
 
             first = bot._run_due_evolve_schedule()
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
             set_evolve_schedule(60, root, now=datetime(2020, 1, 1, tzinfo=timezone.utc))
             second = bot._run_due_evolve_schedule()
             queued = task_queue_status(root)
 
-        self.assertIsNotNone(first)
+        self.assertIsNone(first)
         self.assertIsNone(second)
         self.assertEqual(queued.pending_count, 1)
 
-    def test_due_auto_evolve_schedule_brainstorms_when_no_candidate_exists(self) -> None:
+    def test_due_auto_evolve_schedule_suggests_new_candidate_without_queueing(self) -> None:
         response = json.dumps(
-            [
+            {
+                "recommended_candidate_id": None,
+                "recommendation_reason": "",
+                "scope_guidance": "",
+                "risk_guidance": "",
+                "test_plan_guidance": "",
+                "remove_suggestions": [],
+                "new_candidates": [
                 {
-                    "title": "Improve scheduled fallback",
+                    "title": "Improve scheduled curation",
                     "rationale": "The scheduled proposal had no candidate.",
-                    "proposed_change": "Add bounded scheduled fallback coverage.",
+                    "proposed_change": "Add bounded scheduled curation coverage.",
                     "expected_benefit": "Keeps scheduled evolution useful.",
                     "risk": "The idea is speculative.",
                     "test_plan": "Add scheduler tests.",
                 }
-            ]
+                ],
+            }
         )
         with TemporaryDirectory() as temp:
             root = Path(temp)
@@ -3136,29 +3189,17 @@ class EnochTelegramTests(unittest.TestCase):
             with patch.object(bot, "_respond_read_only_turn", return_value=response) as respond:
                 job = bot._run_due_evolve_schedule()
             queued = task_queue_status(root)
-            events = load_task_events(root, task_id=queued.pending[0].id)
-            evolve_events = load_evolve_events(root, task_id=queued.pending[0].id)
-            candidate_id = load_evolve_candidates(root)[0].id
-            _handle_update(bot, _message_update(update_id=2, chat_id=42, text="/experience"))
+            candidate = load_evolve_candidates(root)[0]
+            evolve_events = load_evolve_events(root)
 
-        self.assertIsNotNone(job)
-        self.assertEqual(queued.pending[0].source, "brainstorming")
-        self.assertEqual(queued.pending[0].initiated_by, "agent")
-        self.assertEqual(queued.pending[0].candidate_id, candidate_id)
-        self.assertEqual(events[0].event_actor, "system")
-        self.assertEqual(events[0].trigger, "evolve-scheduler")
-        self.assertEqual(evolve_events[0].event, "queued")
-        self.assertEqual(evolve_events[0].event_actor, "system")
-        self.assertEqual(evolve_events[0].candidate_initiated_by, "agent")
-        experience_reply = client.sent[-1][1]
-        self.assertIn("Evolution statistics:", experience_reply)
-        self.assertIn("Queued: 1 (autonomous 1, human-approved 0)", experience_reply)
-        self.assertIn("Queued signal actors: agent 1, human 0, system 0", experience_reply)
-        self.assertIn("Queued candidate actors: agent 1, human 0, system 0", experience_reply)
-        self.assertIn("Queued approval actors: agent 1, human 0, system 0", experience_reply)
-        self.assertIn("queued [system]", experience_reply)
-        self.assertIn("candidate by agent", experience_reply)
-        self.assertEqual(respond.call_args.kwargs["session_key"], "telegram:42:evolve-scheduler")
+        self.assertIsNone(job)
+        self.assertEqual(queued.pending_count, 0)
+        self.assertEqual(candidate.source, "brainstorming")
+        self.assertEqual(candidate.initiated_by, "agent")
+        self.assertEqual(candidate.signal_actor, "agent")
+        self.assertEqual([event.event for event in evolve_events], ["checked", "skipped"])
+        self.assertIn("New bounded candidates suggested by LLM", client.sent[0][1])
+        self.assertEqual(respond.call_args.kwargs["session_key"], "telegram:42:evolve-scheduler:curation")
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")


### PR DESCRIPTION
## Summary

- Add semantic LLM curation over a bounded, source-diverse pool from all six evolve candidate sources while retaining deterministic pre-ranking for ordering and fallback.
- Validate strict curator output, known IDs, test plans, bounded scope, and protected actions; persist curation metadata separately without rewriting raw candidate provenance.
- Show LLM recommendations, remove suggestions, new agent-origin brainstorming candidates, and explicitly labelled deterministic fallback in proposal reporting.
- Keep approval, retry, removal, queueing, execution, and merge authority human-governed; scheduled auto-evolve checks now propose without changing candidate or task state.

## Safety and auditability

- New LLM candidates retain brainstorming/agent provenance.
- Remove suggestions remain suggestions until an explicit human remove command records status, reason, actor, and event.
- Unknown IDs, malformed responses, missing verification, protected scope, and dangerous proposals are rejected.
- Curation and proposal events are linked by curation ID and recommendation kind.

## Validation

- `python -m unittest discover -s tests` — 568 passed.
- `python -m unittest discover -s libraries/launchd/tests` — 4 passed.
- `python -m unittest discover -s libraries/systemd/tests` — 4 passed.
- `python -m enoch.cli doctor` — passed.
