### PR TITLE
Add task worktree management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ bin/enoch-daemon start
 
 Then open the bot in Telegram and send `/status`.
 
+Use `/worktree` to inspect task worktrees that Enoch preserved for debugging.
+`/worktree show <task-id>` reports the branch, path, linked task records, and
+changed files. A clean inactive task worktree can be removed with `/worktree
+cleanup <task-id>`. Permanently deleting a dirty inactive worktree requires the
+explicit `/worktree discard <task-id> force` command; Enoch refuses to remove a
+worktree still used by a queued, running, or paused task.
+
 ## Codex configuration
 
 Enoch has her own local runtime configuration in `.enoch/config.yaml`. For the

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -252,6 +252,7 @@ from enoch.commands import (
     pr_usage,
     skills_command,
     status_message,
+    worktree_usage,
 )
 from enoch.tasks.config import format_task_timeout, task_timeout_seconds
 from enoch.tasks.failures import (
@@ -261,9 +262,13 @@ from enoch.tasks.failures import (
 )
 from enoch.tasks.worktree import (
     TaskWorktree,
+    TaskWorktreeState,
+    list_task_worktrees,
     prepare_existing_branch_worktree,
     prepare_task_worktree,
+    remove_managed_task_worktree,
     remove_task_worktree,
+    task_worktree_state,
 )
 from enoch.operations.update_tools import (
     authoritative_branch_name as _authoritative_branch_name,
@@ -357,6 +362,8 @@ _CORE_COMMANDS = {
     "self",
     "status",
     "doctor",
+    "worktree",
+    "worktrees",
     "pr",
     "update",
     "restart",
@@ -594,6 +601,8 @@ class EnochApplication:
                 reply = self._status(chat_id)
             elif command == "/doctor":
                 reply = self._doctor()
+            elif command in {"/worktree", "/worktrees"}:
+                reply = self._worktree(chat_id, argument)
             elif command == "/pr":
                 reply = self._pr(chat_id, argument)
             elif command == "/update":
@@ -3325,6 +3334,69 @@ class EnochApplication:
             format_doctor=_format_doctor_result,
         )
 
+    def _worktree(self, chat_id: ConversationId, argument: str) -> str:
+        parts = argument.split()
+        if not parts or (len(parts) == 1 and parts[0].lower() == "list"):
+            try:
+                states = list_task_worktrees(self.root)
+            except VcsError as error:
+                return f"Enoch could not list task worktrees: {error}"
+            return _format_task_worktrees(states, self.root)
+
+        action = parts[0].lower()
+        if action == "show" and len(parts) == 2:
+            task_id = _positive_task_id(parts[1])
+            if task_id is None:
+                return worktree_usage()
+            try:
+                state = task_worktree_state(self.root, task_id)
+            except VcsError as error:
+                return f"Enoch could not inspect task #{task_id} worktree: {error}"
+            if state is None:
+                return f"Task #{task_id} has no registered task worktree."
+            return _format_task_worktree(state, self.root)
+
+        cleanup = action == "cleanup" and len(parts) == 2
+        discard = action == "discard" and len(parts) == 3 and parts[2].lower() == "force"
+        if not cleanup and not discard:
+            return worktree_usage()
+        task_id = _positive_task_id(parts[1])
+        if task_id is None:
+            return worktree_usage()
+        if not self._action_allowed():
+            return self._action_lock_message()
+        try:
+            state = task_worktree_state(self.root, task_id)
+        except VcsError as error:
+            return f"Enoch could not inspect task #{task_id} worktree: {error}"
+        if state is None:
+            return f"Task #{task_id} has no registered task worktree."
+        active = _active_tasks_for_worktree(state, self.root)
+        if active:
+            labels = ", ".join(f"#{job.id} [{job.status}]" for job in active)
+            return (
+                f"Enoch will not remove task #{task_id} worktree because it is still "
+                f"used by {labels}."
+            )
+        try:
+            result = remove_managed_task_worktree(
+                self.root,
+                task_id,
+                discard=discard,
+            )
+        except VcsError as error:
+            return f"Enoch could not remove task #{task_id} worktree: {error}"
+        _record_system_event(
+            "task_worktree_discarded" if discard else "task_worktree_cleaned",
+            self.root,
+            details={
+                "task_id": task_id,
+                "path": str(state.path),
+                "branch": state.branch,
+            },
+        )
+        return result
+
     def _pr(self, chat_id: int, argument: str) -> str:
         parts = argument.split()
         if not parts or (len(parts) == 1 and parts[0].lower() == "list"):
@@ -4028,6 +4100,78 @@ def _task_by_id(task_id: int, root: Path) -> TaskJob | None:
     if status.running is not None:
         jobs.append(status.running)
     return next((job for job in jobs if job.id == task_id), None)
+
+
+def _format_task_worktrees(states: tuple[TaskWorktreeState, ...], root: Path) -> str:
+    if not states:
+        return "Task worktrees: none"
+    lines = [f"Task worktrees ({len(states)}):"]
+    for state in states:
+        condition = "unknown" if state.inspection_error else ("clean" if state.clean else "dirty")
+        branch = state.branch or "(unknown branch)"
+        linked = _tasks_for_worktree(state, root)
+        tasks = ", ".join(f"#{job.id} [{job.status}]" for job in linked) or "no recent task record"
+        lines.extend(
+            [
+                f"- task path #{state.task_id} [{condition}] {branch}",
+                f"  Tasks: {tasks}",
+                f"  Path: {state.path}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _format_task_worktree(state: TaskWorktreeState, root: Path) -> str:
+    condition = "unknown" if state.inspection_error else ("clean" if state.clean else "dirty")
+    linked = _tasks_for_worktree(state, root)
+    tasks = ", ".join(f"#{job.id} [{job.status}]" for job in linked) or "none in recent queue history"
+    lines = [
+        f"Task worktree #{state.task_id}",
+        f"Status: {condition}",
+        f"Branch: {state.branch or '(unknown)'}",
+        f"Path: {state.path}",
+        f"Linked tasks: {tasks}",
+    ]
+    if state.changed_files:
+        lines.extend(["Changed files:", *(f"- {path}" for path in state.changed_files)])
+    if state.inspection_error:
+        lines.append(f"Inspection error: {state.inspection_error}")
+    return "\n".join(lines)
+
+
+def _tasks_for_worktree(state: TaskWorktreeState, root: Path) -> tuple[TaskJob, ...]:
+    status = task_queue_status(root)
+    jobs = [*status.pending, *status.paused, *status.history]
+    if status.running is not None:
+        jobs.append(status.running)
+    state_path = state.path.resolve()
+    linked = []
+    for job in jobs:
+        same_path = False
+        if job.worktree_path:
+            try:
+                same_path = Path(job.worktree_path).expanduser().resolve() == state_path
+            except OSError:
+                same_path = False
+        if same_path or (state.branch and job.branch_name == state.branch):
+            linked.append(job)
+    return tuple(sorted(linked, key=lambda job: job.id))
+
+
+def _active_tasks_for_worktree(state: TaskWorktreeState, root: Path) -> tuple[TaskJob, ...]:
+    return tuple(
+        job
+        for job in _tasks_for_worktree(state, root)
+        if job.status in {"pending", "running", "paused", "retrying"}
+    )
+
+
+def _positive_task_id(value: str) -> int | None:
+    try:
+        task_id = int(value.lstrip("#"))
+    except ValueError:
+        return None
+    return task_id if task_id > 0 else None
 
 
 def _codex_pause_warning(task_id: int, reason: str) -> str:

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -692,6 +692,7 @@ def help_message(topic: str = "", *, chat_provider: str = "chat") -> str:
             "System:",
             "/config - show or update local system settings",
             "/doctor - run local health checks",
+            "/worktree - inspect and manage isolated task worktrees",
             "/pr - list and manage pull requests",
             "/update - update from the authoritative repository, run doctor, and restart if safe",
             "/restart - restart Enoch's chat daemon from the locked conversation",
@@ -763,6 +764,8 @@ def _help_topic_message(topic: str) -> str:
         return config_usage("/")
     if topic == "pr":
         return pr_usage("/")
+    if topic in {"worktree", "worktrees"}:
+        return worktree_usage("/")
     topics = {
         "start": "/start - start Enoch and point to /help",
         "self": "/self - show Enoch's identity, role, ancestor, and mission",
@@ -802,6 +805,21 @@ def pr_usage(prefix: str = "/") -> str:
             f"{prefix}pr show <PR number or PR URL> - inspect one pull request",
             f"{prefix}pr merge <PR number or PR URL> - inspect and merge exactly that PR",
             "A merge target is required; Enoch will not infer one from the current branch or conversation.",
+        ]
+    )
+
+
+def worktree_usage(prefix: str = "/") -> str:
+    return "\n".join(
+        [
+            "Worktree commands:",
+            f"{prefix}worktree - list isolated task worktrees and their branches",
+            f"{prefix}worktree show <task-id> - inspect one task worktree",
+            f"{prefix}worktree cleanup <task-id> - remove a clean inactive task worktree",
+            (
+                f"{prefix}worktree discard <task-id> force - permanently delete an inactive "
+                "task worktree, its uncommitted changes, and its local branch"
+            ),
         ]
     )
 

--- a/src/enoch/providers/vcs.py
+++ b/src/enoch/providers/vcs.py
@@ -222,9 +222,19 @@ class GitVersionControlProvider:
         args.extend([str(path), start_point or branch])
         self._output(args, root, f"Could not create workspace for {branch}.")
 
-    def remove_workspace(self, path: Path, root: Path | None = None) -> None:
+    def remove_workspace(
+        self,
+        path: Path,
+        root: Path | None = None,
+        *,
+        force: bool = False,
+    ) -> None:
+        args = ["worktree", "remove"]
+        if force:
+            args.append("--force")
+        args.append(str(path))
         self._output(
-            ["worktree", "remove", str(path)],
+            args,
             root,
             f"Could not remove workspace {path}.",
         )

--- a/src/enoch/tasks/worktree.py
+++ b/src/enoch/tasks/worktree.py
@@ -8,6 +8,7 @@ import re
 from enoch.vcs_tools import (
     VcsError,
     branch_exists,
+    changed_files,
     create_workspace,
     current_branch,
     delete_branch,
@@ -24,10 +25,27 @@ class TaskWorktree:
     created: bool
 
 
+@dataclass(frozen=True)
+class TaskWorktreeState:
+    task_id: int
+    path: Path
+    branch: str
+    changed_files: tuple[str, ...] = ()
+    inspection_error: str = ""
+
+    @property
+    def clean(self) -> bool:
+        return not self.changed_files and not self.inspection_error
+
+
 def task_worktree_path(control_root: Path, task_id: int) -> Path:
     resolved = control_root.resolve()
     instance_key = sha256(str(resolved).encode("utf-8")).hexdigest()[:10]
     return resolved.parent / ".enoch-task-worktrees" / f"{resolved.name}-{instance_key}" / f"task-{task_id}"
+
+
+def task_worktree_root(control_root: Path) -> Path:
+    return task_worktree_path(control_root, 0).parent
 
 
 def task_branch_name(
@@ -41,6 +59,73 @@ def task_branch_name(
     request_slug = _slug(request)[:32] or "work"
     identity = sha256(f"{resident_branch}\0{created_at}\0{task_id}".encode("utf-8")).hexdigest()[:8]
     return f"enoch/{owner}-task-{task_id}-{identity}-{request_slug}"
+
+
+def list_task_worktrees(control_root: Path) -> tuple[TaskWorktreeState, ...]:
+    namespace = task_worktree_root(control_root)
+    states: list[TaskWorktreeState] = []
+    for path in workspace_paths(control_root):
+        task_id = _task_id_from_path(path, namespace)
+        if task_id is None:
+            continue
+        try:
+            branch = current_branch(path)
+            files = tuple(sorted(changed_files(path)))
+            error = ""
+        except (VcsError, OSError) as exc:
+            branch = ""
+            files = ()
+            error = str(exc)
+        states.append(
+            TaskWorktreeState(
+                task_id=task_id,
+                path=path,
+                branch=branch,
+                changed_files=files,
+                inspection_error=error,
+            )
+        )
+    return tuple(sorted(states, key=lambda state: state.task_id))
+
+
+def task_worktree_state(control_root: Path, task_id: int) -> TaskWorktreeState | None:
+    return next(
+        (state for state in list_task_worktrees(control_root) if state.task_id == task_id),
+        None,
+    )
+
+
+def remove_managed_task_worktree(
+    control_root: Path,
+    task_id: int,
+    *,
+    discard: bool = False,
+) -> str:
+    state = task_worktree_state(control_root, task_id)
+    if state is None:
+        raise VcsError(f"Task #{task_id} has no registered task worktree.")
+    if not discard and not state.clean:
+        detail = (
+            f"changed files: {', '.join(state.changed_files)}"
+            if state.changed_files
+            else f"inspection failed: {state.inspection_error}"
+        )
+        raise VcsError(
+            f"Task #{task_id} worktree is not clean ({detail}). "
+            f"Inspect it with /worktree show {task_id}. "
+            f"To permanently discard it, use /worktree discard {task_id} force."
+        )
+
+    remove_workspace(state.path, control_root, force=discard)
+    messages = [f"Removed task #{task_id} worktree {state.path}."]
+    if state.branch:
+        try:
+            delete_branch(state.branch, control_root, force=discard)
+        except VcsError as error:
+            messages.append(f"Kept local branch {state.branch}: {error}")
+        else:
+            messages.append(f"Deleted local branch {state.branch}.")
+    return "\n".join(messages)
 
 
 def prepare_task_worktree(
@@ -134,3 +219,17 @@ def remove_task_worktree(
 
 def _slug(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def _task_id_from_path(path: Path, namespace: Path) -> int | None:
+    try:
+        relative = path.resolve().relative_to(namespace.resolve())
+    except ValueError:
+        return None
+    if len(relative.parts) != 1:
+        return None
+    match = re.fullmatch(r"task-(\d+)", relative.name)
+    if match is None:
+        return None
+    task_id = int(match.group(1))
+    return task_id if task_id > 0 else None

--- a/src/enoch/vcs_tools.py
+++ b/src/enoch/vcs_tools.py
@@ -204,12 +204,30 @@ def create_workspace(
         raise VcsError(result.stderr or result.stdout or f"Could not create workspace for {branch}.")
 
 
-def remove_workspace(path: Path, root: Path | None = None) -> None:
+def remove_workspace(
+    path: Path,
+    root: Path | None = None,
+    *,
+    force: bool = False,
+) -> None:
     provider = load_provider("vcs", root)
     if hasattr(provider, "remove_workspace"):
-        provider.remove_workspace(path, root)
+        if force:
+            try:
+                provider.remove_workspace(path, root, force=True)
+            except TypeError as error:
+                raise VcsError(
+                    f"VCS provider {getattr(provider, 'name', 'unknown')} does not "
+                    "support forced worktree removal."
+                ) from error
+        else:
+            provider.remove_workspace(path, root)
         return
-    result = run_git(["worktree", "remove", str(path)], root)
+    args = ["worktree", "remove"]
+    if force:
+        args.append("--force")
+    args.append(str(path))
+    result = run_git(args, root)
     if result.returncode != 0:
         raise VcsError(result.stderr or result.stdout or f"Could not remove workspace {path}.")
 

--- a/tests/test_enoch_task_worktree.py
+++ b/tests/test_enoch_task_worktree.py
@@ -9,13 +9,81 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from enoch.tasks.worktree import (
+    list_task_worktrees,
     prepare_existing_branch_worktree,
     prepare_task_worktree,
+    remove_managed_task_worktree,
     remove_task_worktree,
+    task_worktree_state,
 )
+from enoch.vcs_tools import VcsError
 
 
 class TaskWorktreeTests(unittest.TestCase):
+    def test_lists_task_worktrees_with_branch_and_changed_files(self) -> None:
+        with TemporaryDirectory() as temp:
+            _source, resident = _create_agent_worktree(Path(temp))
+            task = prepare_task_worktree(
+                resident,
+                7,
+                "update task behavior",
+                start_point="main",
+                resident_branch="agent/enoch-gary",
+            )
+            (task.path / "README.md").write_text("task draft\n", encoding="utf-8")
+
+            states = list_task_worktrees(resident)
+
+            self.assertEqual(len(states), 1)
+            self.assertEqual(states[0].task_id, 7)
+            self.assertEqual(states[0].path, task.path)
+            self.assertEqual(states[0].branch, task.branch)
+            self.assertEqual(states[0].changed_files, ("README.md",))
+            self.assertFalse(states[0].clean)
+
+            remove_managed_task_worktree(resident, 7, discard=True)
+
+    def test_cleanup_refuses_dirty_worktree_without_explicit_discard(self) -> None:
+        with TemporaryDirectory() as temp:
+            source, resident = _create_agent_worktree(Path(temp))
+            task = prepare_task_worktree(
+                resident,
+                8,
+                "update task behavior",
+                start_point="main",
+            )
+            (task.path / "README.md").write_text("task draft\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(VcsError, r"/worktree discard 8 force"):
+                remove_managed_task_worktree(resident, 8)
+
+            self.assertTrue(task.path.exists())
+            result = remove_managed_task_worktree(resident, 8, discard=True)
+            self.assertIn("Removed task #8 worktree", result)
+            self.assertFalse(task.path.exists())
+            self.assertEqual(_git(source, "branch", "--list", task.branch), "")
+
+    def test_cleanup_removes_clean_worktree_without_forcing_unmerged_branch(self) -> None:
+        with TemporaryDirectory() as temp:
+            source, resident = _create_agent_worktree(Path(temp))
+            task = prepare_task_worktree(
+                resident,
+                9,
+                "update task behavior",
+                start_point="main",
+            )
+
+            state = task_worktree_state(resident, 9)
+            self.assertIsNotNone(state)
+            assert state is not None
+            self.assertTrue(state.clean)
+
+            result = remove_managed_task_worktree(resident, 9)
+
+            self.assertIn("Removed task #9 worktree", result)
+            self.assertFalse(task.path.exists())
+            self.assertEqual(_git(source, "branch", "--list", task.branch), "")
+
     def test_task_worktree_isolated_from_dirty_resident_checkout(self) -> None:
         with TemporaryDirectory() as temp:
             source, resident = _create_agent_worktree(Path(temp))

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -73,7 +73,7 @@ from enoch.tasks.queue import (
     task_queue_status,
 )
 from enoch.tasks.events import load_task_events
-from enoch.tasks.worktree import TaskWorktree
+from enoch.tasks.worktree import TaskWorktree, TaskWorktreeState
 from enoch.app.core import (
     EnochApplication,
     ShutdownRequested,
@@ -758,6 +758,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertNotIn("/evolve schedule cron '30 9 * * *' - run evolve with a cron-style daily schedule", client.sent[0][1])
         self.assertIn("/update", client.sent[0][1])
         self.assertIn("/config - show or update local system settings", client.sent[0][1])
+        self.assertIn("/worktree - inspect and manage isolated task worktrees", client.sent[0][1])
         self.assertNotIn("/resume", client.sent[0][1])
         self.assertIn("/restart - restart Enoch's chat daemon from the locked conversation", client.sent[0][1])
         self.assertNotIn("/shutdown", client.sent[0][1])
@@ -877,6 +878,153 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/pr show <PR number or PR URL>", client.sent[1][1])
         self.assertIn("/pr merge <PR number or PR URL>", client.sent[1][1])
         self.assertIn("will not infer one", client.sent[1][1])
+
+    def test_help_lists_worktree_commands(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+
+        _handle_update(bot, _message_update(chat_id=42, text="/help worktree"))
+
+        reply = client.sent[0][1]
+        self.assertIn("Worktree commands:", reply)
+        self.assertIn("/worktree - list isolated task worktrees", reply)
+        self.assertIn("/worktree show <task-id>", reply)
+        self.assertIn("/worktree cleanup <task-id>", reply)
+        self.assertIn("/worktree discard <task-id> force", reply)
+
+    @patch("enoch.app.core.list_task_worktrees")
+    def test_worktree_lists_branch_path_and_linked_task(
+        self,
+        list_task_worktrees: MagicMock,
+    ) -> None:
+        path = ROOT.parent / ".enoch-task-worktrees" / "enoch-test" / "task-7"
+        list_task_worktrees.return_value = (
+            TaskWorktreeState(
+                task_id=7,
+                path=path,
+                branch="enoch/main-task-7-example",
+                changed_files=("README.md",),
+            ),
+        )
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+
+        _handle_update(bot, _message_update(chat_id=42, text="/worktrees"))
+
+        reply = client.sent[0][1]
+        self.assertIn("Task worktrees (1):", reply)
+        self.assertIn("task path #7 [dirty] enoch/main-task-7-example", reply)
+        self.assertIn(str(path), reply)
+
+    @patch("enoch.app.core.task_worktree_state")
+    def test_worktree_show_includes_changed_files(
+        self,
+        task_worktree_state: MagicMock,
+    ) -> None:
+        task_worktree_state.return_value = TaskWorktreeState(
+            task_id=7,
+            path=ROOT.parent / "task-7",
+            branch="enoch/main-task-7-example",
+            changed_files=("README.md", "src/enoch/app/core.py"),
+        )
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+
+        _handle_update(bot, _message_update(chat_id=42, text="/worktree show 7"))
+
+        reply = client.sent[0][1]
+        self.assertIn("Task worktree #7", reply)
+        self.assertIn("Status: dirty", reply)
+        self.assertIn("- README.md", reply)
+        self.assertIn("- src/enoch/app/core.py", reply)
+
+    @patch("enoch.app.core.remove_managed_task_worktree")
+    @patch("enoch.app.core.task_worktree_state")
+    def test_worktree_cleanup_requires_locked_chat(
+        self,
+        task_worktree_state: MagicMock,
+        remove_managed_task_worktree: MagicMock,
+    ) -> None:
+        task_worktree_state.return_value = TaskWorktreeState(
+            task_id=7,
+            path=ROOT.parent / "task-7",
+            branch="enoch/main-task-7-example",
+        )
+        client = FakeTelegramClient()
+        bot = EnochApplication(load_identity(), ROOT, client)
+
+        _handle_update(bot, _message_update(chat_id=42, text="/worktree cleanup 7"))
+
+        self.assertIn("Telegram is locked to one conversation", client.sent[0][1])
+        task_worktree_state.assert_not_called()
+        remove_managed_task_worktree.assert_not_called()
+
+    @patch("enoch.app.core._active_tasks_for_worktree")
+    @patch("enoch.app.core.remove_managed_task_worktree")
+    @patch("enoch.app.core.task_worktree_state")
+    def test_worktree_cleanup_refuses_worktree_used_by_active_retry(
+        self,
+        task_worktree_state: MagicMock,
+        remove_managed_task_worktree: MagicMock,
+        active_tasks_for_worktree: MagicMock,
+    ) -> None:
+        state = TaskWorktreeState(
+            task_id=7,
+            path=ROOT.parent / "task-7",
+            branch="enoch/main-task-7-example",
+        )
+        task_worktree_state.return_value = state
+        active_tasks_for_worktree.return_value = (
+            TaskJob(
+                id=8,
+                chat_id=42,
+                text="retry task",
+                created_at="2026-07-23T00:00:00+00:00",
+                status="pending",
+                parent_task_id=7,
+                worktree_path=str(state.path),
+                branch_name=state.branch,
+            ),
+        )
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+
+        _handle_update(bot, _message_update(chat_id=42, text="/worktree cleanup 7"))
+
+        self.assertIn("still used by #8 [pending]", client.sent[0][1])
+        remove_managed_task_worktree.assert_not_called()
+
+    @patch("enoch.app.core._record_system_event")
+    @patch("enoch.app.core._active_tasks_for_worktree", return_value=())
+    @patch("enoch.app.core.remove_managed_task_worktree")
+    @patch("enoch.app.core.task_worktree_state")
+    def test_worktree_discard_requires_explicit_force_and_removes_inactive_worktree(
+        self,
+        task_worktree_state: MagicMock,
+        remove_managed_task_worktree: MagicMock,
+        _active_tasks_for_worktree: MagicMock,
+        _record_system_event: MagicMock,
+    ) -> None:
+        state = TaskWorktreeState(
+            task_id=7,
+            path=ROOT.parent / "task-7",
+            branch="enoch/main-task-7-example",
+            changed_files=("README.md",),
+        )
+        task_worktree_state.return_value = state
+        remove_managed_task_worktree.return_value = "Removed task #7 worktree."
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+
+        _handle_update(bot, _message_update(chat_id=42, text="/worktree discard 7"))
+        _handle_update(
+            bot,
+            _message_update(update_id=2, chat_id=42, text="/worktree discard 7 force"),
+        )
+
+        self.assertIn("/worktree discard <task-id> force", client.sent[0][1])
+        remove_managed_task_worktree.assert_called_once_with(ROOT, 7, discard=True)
+        self.assertEqual(client.sent[1][1], "Removed task #7 worktree.")
 
     @patch("enoch.app.core.list_open_pull_requests")
     def test_pr_lists_open_pull_requests(


### PR DESCRIPTION
## Summary
- add `/worktree` and `/worktrees` commands to list isolated task worktrees with branch, path, linked task status, and changed files
- add safe cleanup for clean inactive worktrees and explicit force-discard for dirty inactive worktrees
- prevent cleanup while a worktree is referenced by pending, running, paused, or retrying work
- document the command surface and extend forced-removal support in the Git VCS provider

## Safety
- mutation commands require a locked chat conversation
- dirty worktrees require the exact `discard <task-id> force` form
- only Enoch task worktrees in the instance-specific namespace are manageable
- clean cleanup preserves an unmerged local branch if Git refuses safe deletion

## Validation
- `python -m unittest discover -s tests` — 590 tests passed
- `bin/enoch doctor` — passed
- `git diff --check` — passed