### PR TITLE
Unify the Telegram command registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,19 @@ bin/enoch-daemon start
 
 Then open the bot in Telegram and send `/status`.
 
+Use `/help` to see every Telegram command. Use `/help <command>` for detailed
+usage and subcommands, for example `/help task` or `/help worktree`. `/start`
+only shows this getting-started guidance inside Telegram; it does not start or
+restart the local daemon. Core commands use the canonical singular forms shown
+by `/help`; plural aliases such as `/tasks` and `/worktrees` are not registered.
+
 Use `/worktree` to inspect task worktrees that Enoch preserved for debugging.
 `/worktree show <task-id>` reports the branch, path, linked task records, and
-changed files. A clean inactive task worktree can be removed with `/worktree
-cleanup <task-id>`. Permanently deleting a dirty inactive worktree requires the
-explicit `/worktree discard <task-id> force` command; Enoch refuses to remove a
-worktree still used by a queued, running, or paused task.
+changed files. `/worktree cleanup <task-id>` removes only a clean inactive
+worktree and will keep a local branch that Git considers unmerged. `/worktree
+discard <task-id> force` permanently removes an inactive worktree, all of its
+uncommitted changes, and its local branch. Enoch refuses both operations while
+the worktree is still used by a queued, running, paused, or retrying task.
 
 ## Codex configuration
 

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -9,7 +9,7 @@ import re
 import signal
 import threading
 import time
-from typing import Any
+from typing import Any, Callable
 from uuid import uuid4
 
 from enoch.backlog import (
@@ -241,8 +241,11 @@ from enoch.tasks.queue import (
 )
 from enoch.tasks.events import TASK_SOURCES
 from enoch.commands import (
+    CoreCommand,
     action_lock_message as _format_action_lock_message,
     config_command,
+    core_command,
+    core_command_names,
     doctor_command,
     help_message as _help_message,
     identity_summary,
@@ -337,39 +340,6 @@ _CURRENT_REGRESSION_SIGNALS: ContextVar[tuple[TaskRegressionSignal, ...]] = Cont
     "enoch_regression_signals",
     default=(),
 )
-_CORE_COMMANDS = {
-    "start",
-    "help",
-    "ancestors",
-    "inherit",
-    "mission",
-    "skills",
-    "learn",
-    "do",
-    "task",
-    "queue",
-    "tasks",
-    "stop",
-    "backlog",
-    "backlogs",
-    "cron",
-    "crons",
-    "feedback",
-    "experience",
-    "propose",
-    "evolve",
-    "config",
-    "self",
-    "status",
-    "doctor",
-    "worktree",
-    "worktrees",
-    "pr",
-    "update",
-    "restart",
-}
-
-
 def _load_provider_cursor(name: str, root: Path | None = None) -> Cursor | None:
     return load_channel_cursor(name, root)
 
@@ -550,72 +520,17 @@ class EnochApplication:
                 provider_name=_chat_provider_name(self.client),
             )
             profile_command = self.profile.command(command) if command else None
+            registered_command = core_command(command) if command else None
             if profile_command is not None:
                 reply = self._run_profile_command(profile_command, event, command, argument)
-            elif command == "/start":
-                reply = "Use /help to see available commands."
-            elif command == "/help":
-                reply = self._help(argument)
-            elif command == "/ancestors":
-                reply = self._ancestors(chat_id, text)
-            elif command == "/inherit":
-                reply = self._inherit(chat_id, text)
-            elif command == "/mission":
-                reply = self._mission(text)
-            elif command == "/skills":
-                reply = self._skills(text)
-            elif command == "/learn":
-                reply = self._learn(chat_id, text)
-            elif command == "/do":
-                reply = self._do(chat_id, work_text)
-            elif command == "/task":
-                reply = self._task(chat_id, work_text)
-            elif command in {"/queue", "/tasks"}:
-                reply = _format_tasks_report(self.root)
-            elif command == "/stop":
-                reply = self._stop_running_job()
-            elif command in {"/backlog", "/backlogs"}:
-                reply = self._backlog(chat_id, work_text)
-            elif command in {"/cron", "/crons"}:
-                reply = self._cron(chat_id, work_text)
-            elif command == "/feedback":
-                reply = _format_feedback_report(self.root)
-            elif command == "/experience":
-                reply = _format_experience_report(self.root)
-            elif command == "/propose":
-                reply = _format_evolve_proposal(
-                    self._propose_evolve(chat_id, trigger="propose-fallback")
+            elif registered_command is not None:
+                reply = self._run_core_command(
+                    registered_command,
+                    event,
+                    text=text,
+                    argument=argument,
+                    work_text=work_text,
                 )
-            elif command == "/evolve":
-                reply = self._evolve(chat_id, argument)
-            elif command == "/config":
-                reply = config_command(
-                    text,
-                    self.root,
-                    runtime=self.runtime,
-                    active_profile_name=self.profile.name,
-                )
-            elif command == "/self":
-                reply = identity_summary(self.identity, self.root)
-            elif command == "/status":
-                reply = self._status(chat_id)
-            elif command == "/doctor":
-                reply = self._doctor()
-            elif command in {"/worktree", "/worktrees"}:
-                reply = self._worktree(chat_id, argument)
-            elif command == "/pr":
-                reply = self._pr(chat_id, argument)
-            elif command == "/update":
-                reply = self._update()
-                self._queue_session_sync(
-                    chat_id,
-                    _activity_sync_note(
-                        "User ran /update.",
-                        f"Result: {_clip_activity_text(reply)}",
-                    ),
-                )
-            elif command == "/restart":
-                reply = self._restart_from_chat()
             else:
                 reply = self._natural(chat_id, text)
 
@@ -648,7 +563,7 @@ class EnochApplication:
                 name
                 for spec in self.profile.commands
                 for name in (spec.name, *spec.aliases)
-                if name in _CORE_COMMANDS
+                if name in core_command_names()
             }
         )
         if conflicts:
@@ -674,6 +589,89 @@ class EnochApplication:
             ),
         ]
         return "\n\n".join([core_help, "\n".join(profile_help)])
+
+    def _run_core_command(
+        self,
+        spec: CoreCommand,
+        event: ChatEvent,
+        *,
+        text: str,
+        argument: str,
+        work_text: str,
+    ) -> str:
+        handlers = self._core_command_handlers(
+            event,
+            text=text,
+            argument=argument,
+            work_text=work_text,
+        )
+        handler = handlers.get(spec.handler)
+        if handler is None:
+            raise RuntimeError(
+                f"Core command /{spec.name} has unknown handler {spec.handler!r}."
+            )
+        return handler()
+
+    def _core_command_handlers(
+        self,
+        event: ChatEvent,
+        *,
+        text: str,
+        argument: str,
+        work_text: str,
+    ) -> dict[str, Callable[[], str]]:
+        chat_id = event.conversation_id
+        return {
+            "start": lambda: "\n".join(
+                [
+                    "Enoch is ready.",
+                    "Use /help to see every command.",
+                    "Use /help <command> for detailed usage and subcommands.",
+                ]
+            ),
+            "help": lambda: self._help(argument),
+            "ancestors": lambda: self._ancestors(chat_id, text),
+            "inherit": lambda: self._inherit(chat_id, text),
+            "mission": lambda: self._mission(text),
+            "skills": lambda: self._skills(text),
+            "learn": lambda: self._learn(chat_id, text),
+            "do": lambda: self._do(chat_id, work_text),
+            "task": lambda: self._task(chat_id, work_text),
+            "queue": lambda: _format_tasks_report(self.root),
+            "stop": self._stop_running_job,
+            "backlog": lambda: self._backlog(chat_id, work_text),
+            "cron": lambda: self._cron(chat_id, work_text),
+            "feedback": lambda: _format_feedback_report(self.root),
+            "experience": lambda: _format_experience_report(self.root),
+            "propose": lambda: _format_evolve_proposal(
+                self._propose_evolve(chat_id, trigger="propose-fallback")
+            ),
+            "evolve": lambda: self._evolve(chat_id, argument),
+            "config": lambda: config_command(
+                text,
+                self.root,
+                runtime=self.runtime,
+                active_profile_name=self.profile.name,
+            ),
+            "self": lambda: identity_summary(self.identity, self.root),
+            "status": lambda: self._status(chat_id),
+            "doctor": self._doctor,
+            "worktree": lambda: self._worktree(chat_id, argument),
+            "pr": lambda: self._pr(chat_id, argument),
+            "update": lambda: self._update_from_chat(chat_id),
+            "restart": self._restart_from_chat,
+        }
+
+    def _update_from_chat(self, chat_id: ConversationId) -> str:
+        reply = self._update()
+        self._queue_session_sync(
+            chat_id,
+            _activity_sync_note(
+                "User ran /update.",
+                f"Result: {_clip_activity_text(reply)}",
+            ),
+        )
+        return reply
 
     def _run_profile_command(
         self,
@@ -2252,8 +2250,6 @@ class EnochApplication:
 
     def _backlog(self, chat_id: int, text: str) -> str:
         command, argument = _parse_chat_command(text)
-        if command == "/backlogs":
-            return _format_backlog_report(self.root)
         if command != "/backlog":
             return _backlog_usage()
         if not argument:
@@ -2735,8 +2731,6 @@ class EnochApplication:
 
     def _cron(self, chat_id: int, text: str) -> str:
         command, argument = _parse_chat_command(text)
-        if command == "/crons":
-            return _format_cron_report(self.root)
         if command != "/cron":
             return _cron_usage()
         if not argument:

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 import re
 import shlex
@@ -56,6 +57,30 @@ DoctorFn = Callable[[Path], ImmuneResult]
 ResolveLineageFn = Callable[[Path], LineageResolution]
 RefreshLineageFn = Callable[..., LineageInboxReport]
 FormatDoctorFn = Callable[[ImmuneResult], str]
+CommandUsageFn = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class CoreCommand:
+    name: str
+    handler: str
+    section: str
+    synopsis: str
+    summary: str
+    usage: CommandUsageFn | None = None
+
+    @property
+    def command(self) -> str:
+        return f"/{self.name}"
+
+    def summary_line(self, prefix: str = "/") -> str:
+        synopsis = f" {self.synopsis}" if self.synopsis else ""
+        return f"{prefix}{self.name}{synopsis} - {self.summary}"
+
+    def usage_message(self, prefix: str = "/") -> str:
+        if self.usage is not None:
+            return self.usage(prefix)
+        return self.summary_line(prefix)
 
 
 def status_message(
@@ -651,55 +676,50 @@ def doctor_command(
 
 
 def help_message(topic: str = "", *, chat_provider: str = "chat") -> str:
+    del chat_provider
     normalized_topic = _normalize_help_topic(topic)
     if normalized_topic:
-        topic_message = _help_topic_message(normalized_topic)
-        if topic_message:
-            return topic_message
-        return f"No help found for /{normalized_topic}.\nUse /help to see available commands."
-    return "\n".join(
+        command = core_command(normalized_topic)
+        if command is not None:
+            return command.usage_message("/")
+        return "\n".join(
+            [
+                f"No help found for /{normalized_topic}.",
+                "Use /help to see every command.",
+                "Use /help <command> for detailed usage and subcommands.",
+            ]
+        )
+
+    lines = [
+        "Enoch commands:",
+        "",
+        "Use /help <command> for detailed usage and subcommands.",
+        "Example: /help worktree",
+    ]
+    standalone = [command for command in CORE_COMMANDS if not command.section]
+    if standalone:
+        lines.extend(["", *(command.summary_line("/") for command in standalone)])
+    sections = tuple(dict.fromkeys(command.section for command in CORE_COMMANDS if command.section))
+    for section in sections:
+        lines.extend(
+            [
+                "",
+                f"{section}:",
+                *(
+                    command.summary_line("/")
+                    for command in CORE_COMMANDS
+                    if command.section == section
+                ),
+            ]
+        )
+    lines.extend(
         [
-            "Enoch commands:",
-            "/help - show this command list",
             "",
-            "Common:",
-            "/self - show Enoch's identity, role, ancestor, and mission",
-            "/mission [text] - show or update Enoch's mission",
-            "/status - show identity, model, local state, and chat setup",
-            "",
-            "Work:",
-            "/do <request> - run work now instead of queueing it",
-            "/task <request> - queue background work for Enoch",
-            "/queue - show running, queued, and recent task history",
-            "/stop - stop the currently running task",
-            "/backlog [p0|p1|p2] <request> - save deferred work for idle time",
-            "/cron - show scheduled jobs",
-            "",
-            "Inherit:",
-            "/ancestors - show ancestor chain and ancestor skills",
-            "/inherit - show inheritable direct-parent changes",
-            "",
-            "Learn:",
-            "/skills [agent-or-path] - show declared skills",
-            "/learn <skill> from <agent> - adapt a published skill from another agent",
-            "",
-            "Evolve:",
-            "/feedback - show feedback signals available to self-evolution",
-            "/experience - show task provenance statistics and evolution candidates",
-            "/propose - rank all evolve sources and propose the strongest candidate",
-            "/evolve - show self-evolution mode, theme, and top candidate",
-            "",
-            "System:",
-            "/config - show or update local system settings",
-            "/doctor - run local health checks",
-            "/worktree - inspect and manage isolated task worktrees",
-            "/pr - list and manage pull requests",
-            "/update - update from the authoritative repository, run doctor, and restart if safe",
-            "/restart - restart Enoch's chat daemon from the locked conversation",
-            "",
-            "For repository changes, say the request naturally. Enoch will publish completed edits for review automatically.",
+            "For repository changes, say the request naturally. "
+            "Enoch will publish completed edits for review automatically.",
         ]
     )
+    return "\n".join(lines)
 
 
 def _normalize_help_topic(topic: str) -> str:
@@ -708,93 +728,6 @@ def _normalize_help_topic(topic: str) -> str:
         return ""
     first = stripped.split(maxsplit=1)[0]
     return first.lstrip("/")
-
-
-def _help_topic_message(topic: str) -> str:
-    if topic == "help":
-        return "\n".join(
-            [
-                "Help commands:",
-                "/help - show all commands",
-                "/help <command> - show usage for one command",
-            ]
-        )
-    if topic == "ancestors":
-        return lineage_usage("/", command_name="ancestors")
-    if topic == "inherit":
-        return lineage_usage("/", command_name="inherit")
-    if topic in {"backlog", "backlogs"}:
-        return "\n".join(
-            [
-                "Backlog commands:",
-                "/backlog [p0|p1|p2] <request> - save deferred work",
-                "/backlog remove <id> - remove a pending backlog item",
-                "/backlog priority <id> p0|p1|p2 - reprioritize a pending backlog item",
-                "/backlog promote <id> - move a pending backlog item into the active task queue",
-            ]
-        )
-    if topic in {"cron", "crons"}:
-        return "\n".join(
-            [
-                "Cron commands:",
-                "/cron every <interval> <request> - schedule recurring work",
-                "Intervals can be like 10m, 2h, or 1d.",
-                "/cron cancel <id> - cancel a scheduled job",
-                "/cron - show scheduled jobs",
-            ]
-        )
-    if topic == "evolve":
-        return "\n".join(
-            [
-                "Evolve commands:",
-                "/evolve - show self-evolution mode, theme, and top candidate",
-                "/evolve mode <mode> - set self-evolution behavior",
-                "Modes: disabled, co-evolve, auto-evolve.",
-                "/evolve theme [text] - show or set the current self-evolution theme",
-                "/evolve brainstorm - generate bounded candidates under the current theme",
-                "/evolve list - show current self-evolution candidates",
-                "/evolve approve <id> - approve and queue a self-evolution candidate",
-                "/evolve retry <id> - retry a failed self-evolution candidate as a new task",
-                "/evolve reconcile <id> [backfill] - verify promotion of a completed candidate",
-                "/evolve remove <id> [reason] - remove a self-evolution candidate with an audit reason",
-                "/evolve schedule <text> - let Enoch interpret common schedule text",
-            ]
-        )
-    if topic == "config":
-        return config_usage("/")
-    if topic == "pr":
-        return pr_usage("/")
-    if topic in {"worktree", "worktrees"}:
-        return worktree_usage("/")
-    topics = {
-        "start": "/start - start Enoch and point to /help",
-        "self": "/self - show Enoch's identity, role, ancestor, and mission",
-        "status": "/status - show identity, model, local state, and chat setup",
-        "mission": "/mission [text] - show Enoch's mission or update it with new text",
-        "do": "/do <request> - run work now instead of queueing it",
-        "task": "\n".join(
-            [
-                "Task commands:",
-                "/task <request> - queue background work for Enoch",
-                "/task cancel <id> - cancel a queued background task",
-                "/task resume <id|all> - continue paused tasks with the same ids",
-                "/task retry <id> - retry a failed task as a new linked task",
-            ]
-        ),
-        "queue": "/queue - show running, queued, and recent task history",
-        "tasks": "/queue - show running, queued, and recent task history",
-        "stop": "/stop - stop the currently running /do or /task job",
-        "feedback": "/feedback - show feedback signals available to self-evolution",
-        "experience": "/experience - show task provenance statistics and evolution candidates",
-        "propose": "/propose - rank all evolve sources and propose the strongest candidate",
-        "skills": "/skills [agent-or-path] - show declared skills",
-        "learn": "/learn <skill> from <agent> - adapt a published skill from another Our-Ark agent",
-        "doctor": "/doctor - run local health checks",
-        "update": "/update - update from the authoritative repository, run doctor, and restart if safe",
-        "restart": "/restart - restart Enoch's chat daemon from the locked conversation",
-        "thinking": thinking_usage("/"),
-    }
-    return topics.get(topic, "")
 
 
 def pr_usage(prefix: str = "/") -> str:
@@ -815,7 +748,10 @@ def worktree_usage(prefix: str = "/") -> str:
             "Worktree commands:",
             f"{prefix}worktree - list isolated task worktrees and their branches",
             f"{prefix}worktree show <task-id> - inspect one task worktree",
-            f"{prefix}worktree cleanup <task-id> - remove a clean inactive task worktree",
+            (
+                f"{prefix}worktree cleanup <task-id> - remove only a clean inactive "
+                "worktree; keep an unmerged local branch"
+            ),
             (
                 f"{prefix}worktree discard <task-id> force - permanently delete an inactive "
                 "task worktree, its uncommitted changes, and its local branch"
@@ -838,3 +774,253 @@ def action_lock_message(chat_provider: str = "chat") -> str:
 def _provider_label(name: str) -> str:
     cleaned = " ".join(part for part in re.split(r"[-_]", name.strip()) if part)
     return cleaned.title() or "Chat"
+
+
+def _help_usage(prefix: str) -> str:
+    return "\n".join(
+        [
+            "Help commands:",
+            f"{prefix}help - show every command",
+            f"{prefix}help <command> - show detailed usage and subcommands",
+            f"Example: {prefix}help worktree",
+        ]
+    )
+
+
+def _start_usage(prefix: str) -> str:
+    return "\n".join(
+        [
+            f"{prefix}start - show getting-started guidance",
+            "This is a Telegram onboarding command. It does not start or restart the Enoch daemon.",
+        ]
+    )
+
+
+def _task_usage(prefix: str) -> str:
+    command = f"{prefix}task"
+    return "\n".join(
+        [
+            "Task commands:",
+            f"{command} <request> - queue background work for Enoch",
+            f"{command} cancel <id> - cancel a queued background task",
+            f"{command} resume <id|all> - continue paused tasks with the same ids",
+            f"{command} retry <id> - retry a failed task as a new linked task",
+        ]
+    )
+
+
+def _backlog_help_usage(prefix: str) -> str:
+    command = f"{prefix}backlog"
+    return "\n".join(
+        [
+            "Backlog commands:",
+            f"{command} [p0|p1|p2] <request> - save deferred work",
+            f"{command} remove <id> - remove a pending backlog item",
+            f"{command} priority <id> p0|p1|p2 - reprioritize a pending backlog item",
+            f"{command} promote <id> - move a pending backlog item into the active task queue",
+        ]
+    )
+
+
+def _cron_help_usage(prefix: str) -> str:
+    command = f"{prefix}cron"
+    return "\n".join(
+        [
+            "Cron commands:",
+            f"{command} every <interval> <request> - schedule recurring work",
+            "Intervals can be like 10m, 2h, or 1d.",
+            f"{command} cancel <id> - cancel a scheduled job",
+            f"{command} - show scheduled jobs",
+        ]
+    )
+
+
+def _evolve_help_usage(prefix: str) -> str:
+    command = f"{prefix}evolve"
+    return "\n".join(
+        [
+            "Evolve commands:",
+            f"{command} - show self-evolution mode, theme, and top candidate",
+            f"{command} mode <mode> - set self-evolution behavior",
+            "Modes: disabled, co-evolve, auto-evolve.",
+            f"{command} theme [text] - show or set the current self-evolution theme",
+            f"{command} brainstorm - generate bounded candidates under the current theme",
+            f"{command} list - show current self-evolution candidates",
+            f"{command} approve <id> - approve and queue a self-evolution candidate",
+            f"{command} retry <id> - retry a failed self-evolution candidate as a new task",
+            f"{command} reconcile <id> [backfill] - verify promotion of a completed candidate",
+            f"{command} remove <id> [reason] - remove a self-evolution candidate with an audit reason",
+            f"{command} schedule <text> - let Enoch interpret common schedule text",
+        ]
+    )
+
+
+CORE_COMMANDS = (
+    CoreCommand("help", "help", "", "", "show this command list", _help_usage),
+    CoreCommand(
+        "start",
+        "start",
+        "Common",
+        "",
+        "show getting-started guidance",
+        _start_usage,
+    ),
+    CoreCommand(
+        "self",
+        "self",
+        "Common",
+        "",
+        "show Enoch's identity, role, ancestor, and mission",
+    ),
+    CoreCommand(
+        "mission",
+        "mission",
+        "Common",
+        "[text]",
+        "show or update Enoch's mission",
+    ),
+    CoreCommand(
+        "status",
+        "status",
+        "Common",
+        "",
+        "show identity, model, local state, and chat setup",
+    ),
+    CoreCommand("do", "do", "Work", "<request>", "run work now instead of queueing it"),
+    CoreCommand(
+        "task",
+        "task",
+        "Work",
+        "<request>",
+        "queue background work for Enoch",
+        _task_usage,
+    ),
+    CoreCommand(
+        "queue",
+        "queue",
+        "Work",
+        "",
+        "show running, queued, and recent task history",
+    ),
+    CoreCommand("stop", "stop", "Work", "", "stop the currently running task"),
+    CoreCommand(
+        "backlog",
+        "backlog",
+        "Work",
+        "[p0|p1|p2] <request>",
+        "save deferred work for idle time",
+        _backlog_help_usage,
+    ),
+    CoreCommand("cron", "cron", "Work", "", "show scheduled jobs", _cron_help_usage),
+    CoreCommand(
+        "ancestors",
+        "ancestors",
+        "Inherit",
+        "",
+        "show ancestor chain and ancestor skills",
+        lambda prefix: lineage_usage(prefix, command_name="ancestors"),
+    ),
+    CoreCommand(
+        "inherit",
+        "inherit",
+        "Inherit",
+        "",
+        "show inheritable direct-parent changes",
+        lambda prefix: lineage_usage(prefix, command_name="inherit"),
+    ),
+    CoreCommand(
+        "skills",
+        "skills",
+        "Learn",
+        "[agent-or-path]",
+        "show declared skills",
+    ),
+    CoreCommand(
+        "learn",
+        "learn",
+        "Learn",
+        "<skill> from <agent>",
+        "adapt a published skill from another agent",
+    ),
+    CoreCommand(
+        "feedback",
+        "feedback",
+        "Evolve",
+        "",
+        "show feedback signals available to self-evolution",
+    ),
+    CoreCommand(
+        "experience",
+        "experience",
+        "Evolve",
+        "",
+        "show task provenance statistics and evolution candidates",
+    ),
+    CoreCommand(
+        "propose",
+        "propose",
+        "Evolve",
+        "",
+        "rank all evolve sources and propose the strongest candidate",
+    ),
+    CoreCommand(
+        "evolve",
+        "evolve",
+        "Evolve",
+        "",
+        "show self-evolution mode, theme, and top candidate",
+        _evolve_help_usage,
+    ),
+    CoreCommand(
+        "config",
+        "config",
+        "System",
+        "",
+        "show or update local system settings",
+        config_usage,
+    ),
+    CoreCommand("doctor", "doctor", "System", "", "run local health checks"),
+    CoreCommand(
+        "worktree",
+        "worktree",
+        "System",
+        "",
+        "inspect and manage isolated task worktrees",
+        worktree_usage,
+    ),
+    CoreCommand(
+        "pr",
+        "pr",
+        "System",
+        "",
+        "list and manage pull requests",
+        pr_usage,
+    ),
+    CoreCommand(
+        "update",
+        "update",
+        "System",
+        "",
+        "update from the authoritative repository, run doctor, and restart if safe",
+    ),
+    CoreCommand(
+        "restart",
+        "restart",
+        "System",
+        "",
+        "restart Enoch's chat daemon from the locked conversation",
+    ),
+)
+
+_CORE_COMMAND_INDEX = {command.name: command for command in CORE_COMMANDS}
+if len(_CORE_COMMAND_INDEX) != len(CORE_COMMANDS):
+    raise RuntimeError("Core command registry contains duplicate command names.")
+
+
+def core_command(name: str) -> CoreCommand | None:
+    normalized = name.strip().lower().lstrip("/")
+    return _CORE_COMMAND_INDEX.get(normalized)
+
+
+def core_command_names() -> frozenset[str]:
+    return frozenset(_CORE_COMMAND_INDEX)

--- a/tests/test_enoch_command_registry.py
+++ b/tests/test_enoch_command_registry.py
@@ -1,0 +1,51 @@
+import unittest
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from enoch.commands import CORE_COMMANDS, core_command, core_command_names, help_message
+
+
+class CoreCommandRegistryTests(unittest.TestCase):
+    def test_registry_is_the_source_for_command_names_and_help(self) -> None:
+        names = tuple(command.name for command in CORE_COMMANDS)
+
+        self.assertEqual(len(names), len(set(names)))
+        self.assertEqual(core_command_names(), frozenset(names))
+
+        overview = help_message()
+        for command in CORE_COMMANDS:
+            with self.subTest(command=command.name):
+                self.assertIs(core_command(command.name), command)
+                self.assertIs(core_command(command.command), command)
+                self.assertIn(command.summary_line(), overview)
+                self.assertEqual(
+                    help_message(command.name),
+                    command.usage_message(),
+                )
+
+    def test_removed_aliases_and_stale_thinking_help_are_not_registered(self) -> None:
+        for name in ("tasks", "backlogs", "crons", "worktrees", "thinking"):
+            with self.subTest(command=name):
+                self.assertIsNone(core_command(name))
+                self.assertIn(
+                    f"No help found for /{name}.",
+                    help_message(name),
+                )
+
+    def test_help_overview_prominently_explains_detailed_help(self) -> None:
+        overview = help_message()
+
+        self.assertIn(
+            "Use /help <command> for detailed usage and subcommands.",
+            overview,
+        )
+        self.assertIn("Example: /help worktree", overview)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -20,6 +20,7 @@ from enoch.automatic_learning import learning_index_path
 from enoch.backlog import add_backlog_item, backlog_status
 from enoch.config import read_section
 from enoch.command_surface import checktree as _checktree
+from enoch.commands import CORE_COMMANDS
 from enoch.cron import add_cron_job, cron_status
 from enoch.evolution.core import (
     MODE_AUTO_EVOLVE,
@@ -683,7 +684,16 @@ class EnochTelegramTests(unittest.TestCase):
 
         _handle_update(bot, _message_update(chat_id=42, text="/start"))
 
-        self.assertEqual(client.sent[0][1], "Use /help to see available commands.")
+        self.assertEqual(
+            client.sent[0][1],
+            "\n".join(
+                [
+                    "Enoch is ready.",
+                    "Use /help to see every command.",
+                    "Use /help <command> for detailed usage and subcommands.",
+                ]
+            ),
+        )
 
     def test_help_lists_safe_commands(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -693,6 +703,9 @@ class EnochTelegramTests(unittest.TestCase):
 
         reply = client.sent[0][1]
         self.assertLess(reply.index("/help - show this command list"), reply.index("Common:"))
+        self.assertIn("Use /help <command> for detailed usage and subcommands.", reply)
+        self.assertIn("Example: /help worktree", reply)
+        self.assertIn("/start - show getting-started guidance", reply)
         self.assertLess(reply.index("Common:"), reply.index("Work:"))
         self.assertLess(reply.index("Work:"), reply.index("/do <request>"))
         self.assertLess(reply.index("Work:"), reply.index("Inherit:"))
@@ -763,6 +776,24 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/restart - restart Enoch's chat daemon from the locked conversation", client.sent[0][1])
         self.assertNotIn("/shutdown", client.sent[0][1])
         self.assertIn("say the request naturally", client.sent[0][1])
+
+    def test_every_registered_core_command_has_a_dispatch_handler(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+        event = telegram_event(_message_update(chat_id=42, text="/help"))
+        assert event is not None
+
+        handlers = bot._core_command_handlers(
+            event,
+            text="/help",
+            argument="",
+            work_text="/help",
+        )
+
+        self.assertEqual(
+            set(handlers),
+            {command.handler for command in CORE_COMMANDS},
+        )
 
     def test_help_config_shows_only_config_commands(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -857,10 +888,8 @@ class EnochTelegramTests(unittest.TestCase):
 
         _handle_update(bot, _message_update(chat_id=42, text="/help resume"))
 
-        self.assertEqual(
-            client.sent[0][1],
-            "No help found for /resume.\nUse /help to see available commands.",
-        )
+        self.assertIn("No help found for /resume.", client.sent[0][1])
+        self.assertIn("/help <command>", client.sent[0][1])
 
     def test_help_lists_pr_and_explains_its_subcommands(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -909,7 +938,7 @@ class EnochTelegramTests(unittest.TestCase):
         client = FakeTelegramClient(allowed_chat_id=42)
         bot = EnochApplication(load_identity(), ROOT, client)
 
-        _handle_update(bot, _message_update(chat_id=42, text="/worktrees"))
+        _handle_update(bot, _message_update(chat_id=42, text="/worktree"))
 
         reply = client.sent[0][1]
         self.assertIn("Task worktrees (1):", reply)
@@ -1245,16 +1274,15 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertNotIn("/task resolve", reply)
         self.assertNotIn("Enoch Telegram commands:", reply)
 
-    def test_help_topic_supports_work_command_aliases(self) -> None:
+    def test_help_topic_rejects_removed_work_command_aliases(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
         bot = EnochApplication(load_identity(), ROOT, client)
 
         _handle_update(bot, _message_update(chat_id=42, text="/help /crons"))
 
         reply = client.sent[0][1]
-        self.assertIn("Cron commands:", reply)
-        self.assertIn("/cron every <interval> <request>", reply)
-        self.assertIn("/cron cancel <id>", reply)
+        self.assertIn("No help found for /crons.", reply)
+        self.assertIn("/help <command>", reply)
 
     def test_help_queue_shows_canonical_queue_command(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -1336,7 +1364,8 @@ class EnochTelegramTests(unittest.TestCase):
 
         _handle_update(bot, _message_update(chat_id=42, text="/help /debug"))
 
-        self.assertEqual(client.sent[0][1], "No help found for /debug.\nUse /help to see available commands.")
+        self.assertIn("No help found for /debug.", client.sent[0][1])
+        self.assertIn("/help <command>", client.sent[0][1])
 
     def test_help_shutdown_reports_removed_command(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -1344,7 +1373,8 @@ class EnochTelegramTests(unittest.TestCase):
 
         _handle_update(bot, _message_update(chat_id=42, text="/help shutdown"))
 
-        self.assertEqual(client.sent[0][1], "No help found for /shutdown.\nUse /help to see available commands.")
+        self.assertIn("No help found for /shutdown.", client.sent[0][1])
+        self.assertIn("/help <command>", client.sent[0][1])
 
     def test_help_topic_reports_unknown_command(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -1352,7 +1382,8 @@ class EnochTelegramTests(unittest.TestCase):
 
         _handle_update(bot, _message_update(chat_id=42, text="/help nope"))
 
-        self.assertEqual(client.sent[0][1], "No help found for /nope.\nUse /help to see available commands.")
+        self.assertIn("No help found for /nope.", client.sent[0][1])
+        self.assertIn("/help <command>", client.sent[0][1])
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")
@@ -1858,8 +1889,10 @@ class EnochTelegramTests(unittest.TestCase):
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")
-    def test_tasks_command_remains_a_hidden_queue_alias(
+    @patch("enoch.app.core.respond", return_value="That is not a registered command.")
+    def test_removed_plural_aliases_report_unknown_command(
         self,
+        respond: MagicMock,
         _log_conversation_turn: MagicMock,
         _update_memory: MagicMock,
     ) -> None:
@@ -1868,9 +1901,23 @@ class EnochTelegramTests(unittest.TestCase):
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/tasks"))
+            for update_id, command in enumerate(
+                ("/tasks", "/backlogs", "/crons", "/worktrees"),
+                start=1,
+            ):
+                _handle_update(
+                    bot,
+                    _message_update(
+                        update_id=update_id,
+                        chat_id=42,
+                        text=command,
+                    ),
+                )
 
-        self.assertIn("Running: none", client.sent[0][1])
+        self.assertEqual(respond.call_count, 4)
+        self.assertTrue(
+            all("That is not a registered command." in sent[1] for sent in client.sent)
+        )
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")
@@ -4053,6 +4100,19 @@ class EnochTelegramTests(unittest.TestCase):
         respond.assert_called_once()
         self.assertNotIn("reasoning_effort", read_section("codex", root))
         self.assertIn("Thinking config is managed locally.", client.sent[0][1])
+
+    def test_help_thinking_reports_removed_command(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+
+        _handle_update(bot, _message_update(chat_id=42, text="/help thinking"))
+        _handle_update(
+            bot,
+            _message_update(update_id=2, chat_id=42, text="/help config"),
+        )
+
+        self.assertIn("No help found for /thinking.", client.sent[0][1])
+        self.assertIn("/config reasoning-effort", client.sent[1][1])
 
     def test_ancestors_reports_missing_parent(self) -> None:
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- replace separate Telegram routing, help, and core-command conflict lists with one `CoreCommand` registry
- generate top-level and command-specific help from registry metadata
- route canonical core commands through registry handler keys and test complete handler coverage
- prominently document `/help <command>` and clarify `/start`
- remove the hidden plural aliases `/tasks`, `/backlogs`, `/crons`, and `/worktrees`
- remove stale `/help thinking` while preserving the valid admin CLI `thinking` command and `/config reasoning-effort`
- clarify safe worktree cleanup versus destructive force-discard behavior

## Root cause
Core command recognition, summaries, detailed usage, aliases, and profile-conflict checks were maintained separately, allowing routing and documentation to drift. The registry now owns those command-facing properties, with regression tests enforcing registry/help parity.

## Validation
- `python -m unittest discover -s tests` — 595 tests passed
- `bin/enoch doctor` — passed
- `git diff --check` — passed