### PR TITLE
Harden durable agent workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,14 @@ jobs:
         run: python -m pip install --disable-pip-version-check --require-hashes -r .github/requirements/test-build.txt
 
       - name: Run unit and hermetic E2E tests
-        run: python -m unittest discover -s tests
+        run: python -m unittest discover -s tests -t .
 
-      - name: Run service provider tests
+      - name: Run provider library tests
         run: |
+          python -m unittest discover -s libraries/github/tests
           python -m unittest discover -s libraries/launchd/tests
+          python -m unittest discover -s libraries/provider-kit/tests
+          python -m unittest discover -s libraries/skill-catalog/tests
           python -m unittest discover -s libraries/systemd/tests
+          python -m unittest discover -s libraries/telegram/tests
+          python -m unittest discover -s libraries/telegram-vision/tests

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Configure and start the local Enoch instance:
 ```bash
 cd /path/to/your/enoch-instance
 
-bin/enoch setup-token <token>
-bin/enoch setup-chat <your-chat-id>
+bin/enoch setup token <token>
+bin/enoch setup chat <your-chat-id>
 bin/enoch-daemon start
 ```
 
@@ -219,13 +219,16 @@ profile currently running.
 
 Core package boundaries and dependency direction are documented in
 [`docs/architecture.md`](docs/architecture.md).
+Durable chat receipts, publication stages, scheduler claims, and corruption
+behavior are documented in
+[`docs/workflow-reliability.md`](docs/workflow-reliability.md).
 
 ## Testing
 
 Run the unit and hermetic evolution E2E tests with:
 
 ```bash
-python -m unittest discover -s tests
+python -m unittest discover -s tests -t .
 ```
 
 The E2E design and covered workflows are documented in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,8 @@ and validation boundary.
 | Package | Responsibility |
 | --- | --- |
 | `enoch.app` | Provider-neutral event loop, command orchestration, parsing, and presentation |
+| `enoch.app.inbox` | Durable chat receipts, redelivery suppression, and poison-event attempts |
+| `enoch.state` | Corruption-safe JSON loading, atomic writes, and interprocess transactions |
 | `enoch.tasks` | Task queue state, audit events, failure policy, configuration, and isolated worktrees |
 | `enoch.evolution` | Evolution state, candidate collection and ranking, event history, and governed lifecycle |
 | `enoch.evolution.sources` | Feedback, experience, and brainstorming evidence adapters |
@@ -34,6 +36,10 @@ provider contracts. Infrastructure libraries implement those contracts and do
 not become imports in domain code. Provider-specific configuration and setup
 remain owned by each implementation. `enoch.app.core` composes the domains;
 domain packages must not import the application orchestrator.
+
+Workflow decisions cross the application boundary as typed outcomes. Human
+presentation text is rendered from those outcomes and is not parsed to decide
+whether a task succeeded, should retry, or completed publication.
 
 Portable task flows use semantic provider operations rather than parsing Git,
 GitHub, Telegram, or service-manager commands. Compatibility escape hatches may

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -74,8 +74,8 @@ def create_profile(root=None):
     )
 ```
 
-Command names are lowercase chat-command identifiers. A profile may define
-aliases, but it cannot shadow Enoch's core commands. Profile command failures
+Command names are lowercase chat-command identifiers. Profiles cannot define
+aliases or shadow Enoch's core commands, keeping `/help` authoritative. Profile command failures
 are reported to the conversation and system log; prompt and lifecycle hook
 failures are logged without stopping the daemon.
 
@@ -112,7 +112,7 @@ profile change is activated only after restarting Enoch.
 embed Enoch can instead pass `profile=` directly to `EnochApplication` or use
 `register_profile()` for static registration.
 
-The current contract is `PROFILE_API_VERSION = 1`. A profile must declare that
+The current contract is `PROFILE_API_VERSION = 2`. A profile must declare that
 version (the default) and Enoch rejects unsupported versions at startup rather
 than guessing compatibility.
 

--- a/docs/workflow-reliability.md
+++ b/docs/workflow-reliability.md
@@ -1,0 +1,46 @@
+# Workflow reliability
+
+Enoch treats chat delivery, task execution, publication, and scheduling as
+durable workflows rather than one uninterrupted function call.
+
+## Chat inbox
+
+Each normalized chat event receives a stable receipt under the configured
+channel. A completed receipt stores the response before the provider cursor is
+advanced, so redelivery after a restart does not repeat the command. Task,
+backlog, and cron creation also use the receipt as an idempotency key.
+
+Unexpected handler failures remain retryable for three deliveries. After the
+third failure, Enoch records and acknowledges the poison event and sends a
+bounded diagnostic response instead of repeatedly crashing the daemon.
+
+## Task publication
+
+Task results use `WorkOutcome`, separating status, failure code, retryability,
+artifacts, and completed stages from chat presentation text. Publication
+persists `validated`, `committed`, `pushed`, and `pr_opened` stages.
+
+If push, PR creation, or cleanup fails, the task retains its worktree, branch,
+commit, and last completed stage. Automatic retry resumes at that boundary
+instead of running the coding agent again. GitHub publication also reconciles
+an already-created open PR after an ambiguous `gh pr create` failure.
+
+## Scheduled occurrences
+
+Cron and evolve schedules use claim-and-ack. Claiming a due occurrence does not
+advance its next-run time. Task creation or the evolve check must first
+succeed; only then does Enoch acknowledge the claim and advance the schedule.
+After a crash, the same claim is returned and its idempotency key prevents a
+duplicate task.
+
+## State safety
+
+All replace-style JSON writes use a unique sibling temporary file, `fsync`, and
+an atomic rename. Read-modify-write stores use shared thread and process locks.
+Existing malformed JSON or invalid top-level structures raise
+`StateCorruptionError`; Enoch preserves the original file instead of silently
+replacing it with empty state.
+
+The core test runner redirects resident-checkout state into an isolated
+temporary directory. Tests using their own temporary repositories continue to
+use those repositories' local `.enoch` state.

--- a/libraries/github/src/our_ark_github/workflow.py
+++ b/libraries/github/src/our_ark_github/workflow.py
@@ -91,6 +91,7 @@ def prepare_local_publish(
     root: Path | None = None,
     allow_protected_branch: bool = False,
     allowed_files: list[str] | tuple[str, ...] | None = None,
+    validation_result: object | None = None,
 ) -> LocalPublishResult:
     message = commit_message.strip()
     if not message:
@@ -114,7 +115,7 @@ def prepare_local_publish(
         raise PublishError("No local changes to publish.")
 
     diff = diff_summary(root)
-    doctor = run_immune_system(root)
+    doctor = validation_result or run_immune_system(root)
     if not doctor.passed:
         raise PublishError(f"Doctor failed: {doctor.diagnosis.summary}")
 
@@ -219,6 +220,38 @@ def create_pull_request(
     )
     if result.returncode != 0:
         note = result.stderr.strip() or result.stdout.strip() or "GitHub CLI could not create the PR."
+        if "already exists" in note.lower():
+            existing = subprocess.run(
+                [
+                    gh,
+                    "pr",
+                    "view",
+                    branch,
+                    "--json",
+                    "url,title,body,isDraft,state",
+                ],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if existing.returncode == 0:
+                try:
+                    existing_data = json.loads(existing.stdout)
+                except json.JSONDecodeError:
+                    existing_data = {}
+                existing_url = str(existing_data.get("url") or "").strip()
+                if existing_url and str(existing_data.get("state") or "OPEN").upper() == "OPEN":
+                    return PullRequestResult(
+                        branch=branch,
+                        title=str(existing_data.get("title") or pr_title),
+                        body=str(existing_data.get("body") or pr_body),
+                        created=True,
+                        url=existing_url,
+                        fallback_url=fallback_url,
+                        note="Reused the existing open pull request for this branch.",
+                        draft=bool(existing_data.get("isDraft", draft)),
+                    )
         return PullRequestResult(
             branch=branch,
             title=pr_title,

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -61,6 +61,7 @@ from enoch.evolution.core import (
     MODE_DISABLED,
     EvolveCandidate,
     EvolveProposal,
+    acknowledge_evolve_schedule,
     cancel_evolve_candidate_for_task,
     claim_due_evolve_schedule,
     collect_experience_candidates,
@@ -214,6 +215,7 @@ from enoch.runtime import (
 )
 from enoch.tasks.queue import (
     TaskJob,
+    TaskAlreadyExists,
     TaskRetryError,
     begin_direct_task,
     begin_next_task,
@@ -228,6 +230,7 @@ from enoch.tasks.queue import (
     regress_task,
     recover_interrupted_task,
     record_task_result,
+    record_task_publish_state,
     record_task_runtime_result,
     record_task_status_message,
     record_task_worktree,
@@ -285,6 +288,15 @@ from enoch.app.models import (
     TaskContextSnapshot,
     TaskDeadline,
     WorkStatusMessage,
+    WorkOutcome,
+)
+from enoch.app.inbox import (
+    InboxReceipt,
+    acknowledge_event,
+    begin_event,
+    complete_event,
+    fail_event,
+    mark_reply_sent,
 )
 from enoch.app.parsing import (
     backlog_item_id as _backlog_item_id,
@@ -336,6 +348,7 @@ NO_EXTRA_TASK_CONTEXT = "No extra context needed."
 _CURRENT_WORK_STATUS: ContextVar[WorkStatusMessage | None] = ContextVar("enoch_work_status", default=None)
 _CURRENT_TASK_ID: ContextVar[int | None] = ContextVar("enoch_task_id", default=None)
 _CURRENT_TASK_WORKER_ID: ContextVar[str] = ContextVar("enoch_task_worker_id", default="")
+_CURRENT_EVENT_KEY: ContextVar[str] = ContextVar("enoch_event_key", default="")
 _CURRENT_REGRESSION_SIGNALS: ContextVar[tuple[TaskRegressionSignal, ...]] = ContextVar(
     "enoch_regression_signals",
     default=(),
@@ -442,7 +455,9 @@ class EnochApplication:
         while True:
             try:
                 self.run_once()
-            except (OSError, ChatProviderError) as error:
+            except ShutdownRequested:
+                raise
+            except Exception as error:
                 print(f"Enoch {provider_label(self.channel_name)} polling error: {error}")
                 time.sleep(5)
 
@@ -498,12 +513,51 @@ class EnochApplication:
     def handle_event(self, event: ChatEvent) -> None:
         chat_id = event.conversation_id
         message_id = event.message_id
-        text = event.text.strip()
         if not self._chat_allowed(chat_id):
             self._remember_update_offset(event.cursor)
             return
 
-        self._safe_send_read_ack(chat_id, message_id)
+        receipt = begin_event(self.channel_name, event, self.root)
+        if receipt.completed:
+            self._finish_chat_event(event, receipt)
+            return
+
+        event_token = _CURRENT_EVENT_KEY.set(receipt.key)
+        try:
+            reply, logged_input = self._dispatch_chat_event(event)
+            receipt = complete_event(
+                self.channel_name,
+                receipt.key,
+                self.root,
+                reply=reply,
+                logged_input=logged_input,
+            )
+        except Exception as error:
+            failed = fail_event(self.channel_name, receipt.key, str(error), self.root)
+            print(
+                f"Enoch could not process {self.channel_name} update "
+                f"{receipt.key[:12]} (attempt {failed.attempts}/3): {error}"
+            )
+            if not failed.exhausted:
+                return
+            receipt = complete_event(
+                self.channel_name,
+                receipt.key,
+                self.root,
+                reply=(
+                    "Enoch skipped this update after three failed processing attempts. "
+                    f"The failure was recorded for debugging: {type(error).__name__}."
+                ),
+                logged_input=event.text.strip(),
+            )
+        finally:
+            _CURRENT_EVENT_KEY.reset(event_token)
+        self._finish_chat_event(event, receipt)
+
+    def _dispatch_chat_event(self, event: ChatEvent) -> tuple[str, str]:
+        chat_id = event.conversation_id
+        text = event.text.strip()
+        self._safe_send_read_ack(chat_id, event.message_id)
         self.runtime.reset_usage()
         image = select_image_attachment(event.attachments)
         logged_input = text
@@ -512,37 +566,59 @@ class EnochApplication:
             logged_input = f"[{provider_label(self.channel_name)} image]" + (
                 f" {text}" if text else ""
             )
-        else:
-            command, argument = _parse_chat_command(text)
-            work_text = _with_replied_text_context(
-                text,
-                event.replied_text,
-                provider_name=_chat_provider_name(self.client),
-            )
-            profile_command = self.profile.command(command) if command else None
-            registered_command = core_command(command) if command else None
-            if profile_command is not None:
-                reply = self._run_profile_command(profile_command, event, command, argument)
-            elif registered_command is not None:
-                reply = self._run_core_command(
-                    registered_command,
-                    event,
-                    text=text,
-                    argument=argument,
-                    work_text=work_text,
-                )
-            else:
-                reply = self._natural(chat_id, text)
+            return reply, logged_input
 
-        send_error = self._safe_send_message(chat_id, reply) if reply else ""
-        logged_reply = reply
-        if send_error:
-            logged_reply = "\n\n".join(
-                [reply, f"{provider_label(self.channel_name)} send failed: {send_error}"]
+        command, argument = _parse_chat_command(text)
+        work_text = _with_replied_text_context(
+            text,
+            event.replied_text,
+            provider_name=_chat_provider_name(self.client),
+        )
+        profile_command = self.profile.command(command) if command else None
+        registered_command = core_command(command) if command else None
+        if profile_command is not None:
+            reply = self._run_profile_command(profile_command, event, command, argument)
+        elif registered_command is not None:
+            reply = self._run_core_command(
+                registered_command,
+                event,
+                text=text,
+                argument=argument,
+                work_text=work_text,
             )
-        self._record_turn(chat_id, logged_input, logged_reply)
-        self._flush_session_syncs()
+        else:
+            reply = self._natural(chat_id, text)
+        return reply, logged_input
+
+    def _finish_chat_event(self, event: ChatEvent, receipt: InboxReceipt) -> None:
+        if not receipt.reply_sent:
+            send_error = (
+                self._safe_send_message(event.conversation_id, receipt.reply)
+                if receipt.reply
+                else ""
+            )
+            if send_error:
+                _record_system_event(
+                    "chat_reply_failed",
+                    self.root,
+                    status="failed",
+                    details={
+                        "provider": self.channel_name,
+                        "chat_id": event.conversation_id,
+                        "message_id": event.message_id,
+                        "error": send_error,
+                    },
+                )
+                return
+            self._record_turn(
+                event.conversation_id,
+                receipt.logged_input,
+                receipt.reply,
+            )
+            self._flush_session_syncs()
+            mark_reply_sent(self.channel_name, receipt.key, self.root)
         self._remember_update_offset(event.cursor)
+        acknowledge_event(self.channel_name, receipt.key, self.root)
         if self._restart_after_reply:
             self._restart_after_reply = False
             _schedule_daemon_restart(self.root)
@@ -560,10 +636,9 @@ class EnochApplication:
     def _validate_profile_commands(self) -> None:
         conflicts = sorted(
             {
-                name
+                spec.name
                 for spec in self.profile.commands
-                for name in (spec.name, *spec.aliases)
-                if name in core_command_names()
+                if spec.name in core_command_names()
             }
         )
         if conflicts:
@@ -680,7 +755,11 @@ class EnochApplication:
         command: str,
         argument: str,
     ) -> str:
+        enqueue_index = 0
+
         def queue(request: str, context: str) -> TaskJob:
+            nonlocal enqueue_index
+            enqueue_index += 1
             return enqueue_task(
                 event.conversation_id,
                 request,
@@ -691,6 +770,9 @@ class EnochApplication:
                 initiated_by="human",
                 event_actor="human",
                 trigger=command,
+                idempotency_key=_event_idempotency_key(
+                    f"profile:{self.profile.name}:{command}:{enqueue_index}"
+                ),
                 **self._profile_task_options(),
             )
 
@@ -1005,7 +1087,13 @@ class EnochApplication:
                 self.root,
                 context=context,
                 context_source=context_source,
+                idempotency_key=_event_idempotency_key("direct"),
                 **self._profile_task_options(),
+            )
+        except TaskAlreadyExists as duplicate:
+            return (
+                f"Task #{duplicate.job.id} was already accepted for this chat update "
+                f"and is {duplicate.job.status}."
             )
         except RuntimeError:
             running = task_queue_status(self.root).running
@@ -1063,7 +1151,13 @@ class EnochApplication:
                 initiated_by=initiated_by,
                 event_actor=initiated_by,
                 trigger=trigger,
+                idempotency_key=_event_idempotency_key(f"inline:{trigger}"),
                 **self._profile_task_options(),
+            )
+        except TaskAlreadyExists as duplicate:
+            return (
+                f"Task #{duplicate.job.id} was already accepted for this chat update "
+                f"and is {duplicate.job.status}."
             )
         except RuntimeError:
             return "Enoch cannot start that work while another task is running."
@@ -1101,20 +1195,27 @@ class EnochApplication:
         failure: TaskFailure | None = None
         regression_signals: tuple[TaskRegressionSignal, ...] = ()
         try:
-            reply = self._run_direct_work(
-                chat_id,
-                request,
-                session_key=session_key,
-                execution=execution,
+            outcome = _coerce_work_outcome(
+                self._run_direct_work(
+                    chat_id,
+                    request,
+                    session_key=session_key,
+                    execution=execution,
+                )
             )
+            reply = outcome.message
             reply = self._capture_task_regression_signals(reply)
             if deadline.expired.is_set():
                 reply = _task_timeout_message(deadline.timeout_seconds)
                 completed_status = "failed"
                 failure = classify_task_failure(reply)
-            elif _work_reply_failed(reply):
+            elif outcome.failed:
                 completed_status = "failed"
-                failure = classify_task_failure(reply)
+                failure = TaskFailure(
+                    code=outcome.code or "unknown_failure",
+                    failure_class=outcome.failure_class or "permanent",
+                    retryable=outcome.retryable,
+                )
         except AgentRuntimeAccessUnavailable as error:
             reply = _codex_pause_warning(job.id, str(error))
             completed_status = "paused"
@@ -1219,6 +1320,7 @@ class EnochApplication:
                 self.root,
                 context=context,
                 context_source=context_source,
+                idempotency_key=_event_idempotency_key("direct-next"),
                 **self._profile_task_options(),
             )
         except (OSError, ValueError):
@@ -1289,19 +1391,27 @@ class EnochApplication:
         context: str = "",
         session_key: str,
         execution: RuntimeExecutionControl | None = None,
-    ) -> str:
+    ) -> WorkOutcome:
         self._raise_if_current_task_cancelled()
         forge_maintenance = _forge_maintenance_request(request)
         if forge_maintenance is not None:
             reply = self._run_forge_maintenance(forge_maintenance)
             self._raise_if_current_task_cancelled()
-            return reply
+            return WorkOutcome.completed(reply)
 
         publish_branch = _existing_branch_publish_request(request)
         if publish_branch is not None:
             reply = self._publish_existing_branch(chat_id, publish_branch)
             self._raise_if_current_task_cancelled()
-            return reply
+            if reply.strip().lower().startswith("enoch could not"):
+                failure = classify_task_failure(reply)
+                return WorkOutcome.failure(
+                    reply,
+                    code=failure.code,
+                    failure_class=failure.failure_class,
+                    retryable=failure.retryable,
+                )
+            return WorkOutcome.completed(reply)
 
         try:
             sandbox = _action_sandbox(self.root)
@@ -1312,7 +1422,6 @@ class EnochApplication:
                 f"Enoch prepared isolated worktree {work_root} on branch "
                 f"{task_worktree.branch} from the latest task base."
             )
-            before_action = _worktree_snapshot(work_root)
             self._send_step_update(chat_id, "Working.")
             runtime_result = invoke_runtime_action(
                 self.runtime,
@@ -1355,7 +1464,6 @@ class EnochApplication:
             memory_note = self._save_memory_requests(memory_result.requests)
             _record_direct_action(request, result, self.root)
             action_files = tuple(sorted(_changed_files_or_empty(work_root)))
-            after_action = _worktree_snapshot(work_root)
         except AgentRuntimeCancelled:
             raise
         except AgentRuntimeTimedOut:
@@ -1363,7 +1471,14 @@ class EnochApplication:
         except AgentRuntimeAccessUnavailable:
             raise
         except (AgentRuntimeError, TypeError, VcsError, OSError) as error:
-            return f"Enoch could not complete the requested work yet: {error}"
+            message = f"Enoch could not complete the requested work yet: {error}"
+            failure = classify_task_failure(message)
+            return WorkOutcome.failure(
+                message,
+                code=failure.code,
+                failure_class=failure.failure_class,
+                retryable=failure.retryable,
+            )
 
         parts = [branch_note, result or "Enoch completed the requested work.", memory_note]
         if not action_files:
@@ -1377,7 +1492,10 @@ class EnochApplication:
                 parts.append(cleanup)
             except VcsError as error:
                 parts.append(f"Enoch could not clean up the task worktree: {error}")
-            return "\n\n".join(part for part in parts if part)
+            return WorkOutcome.completed(
+                "\n\n".join(part for part in parts if part),
+                completed_stages=("edited",),
+            )
 
         self._send_step_update(chat_id, "Running doctor.")
         self._raise_if_current_task_cancelled()
@@ -1390,20 +1508,36 @@ class EnochApplication:
                 f"I did not open a PR because doctor failed. Task worktree {work_root} "
                 "was preserved for inspection."
             )
-            return "\n\n".join(part for part in parts if part)
+            return WorkOutcome.failure(
+                "\n\n".join(part for part in parts if part),
+                code="validation_failed",
+                failure_class="permanent",
+                retryable=False,
+                completed_stages=("edited",),
+            )
 
         self._raise_if_current_task_cancelled()
-        parts.append(
+        self._record_current_publish_stage("validated")
+        publish_outcome = _coerce_work_outcome(
             self._publish_feature_pr(
                 chat_id,
                 request,
                 action_files,
                 work_root=work_root,
                 task_worktree=task_worktree,
+                validation_result=doctor,
             )
         )
         self._raise_if_current_task_cancelled()
-        return "\n\n".join(part for part in parts if part)
+        return replace(
+            publish_outcome,
+            message="\n\n".join(
+                part for part in [*parts, publish_outcome.message] if part
+            ),
+            completed_stages=tuple(
+                dict.fromkeys(("edited", "validated", *publish_outcome.completed_stages))
+            ),
+        )
 
     def _prepare_task_worktree(self, request: str) -> TaskWorktree:
         task_id = _CURRENT_TASK_ID.get()
@@ -1587,46 +1721,129 @@ class EnochApplication:
         *,
         work_root: Path | None = None,
         task_worktree: TaskWorktree | None = None,
-    ) -> str:
+        validation_result: ImmuneResult | None = None,
+        resume_job: TaskJob | None = None,
+    ) -> WorkOutcome:
         publish_root = work_root or self.root
         outputs: list[str] = []
         summaries: list[str] = []
+        stage = resume_job.publish_stage if resume_job is not None else ""
+        commit_sha = resume_job.commit_sha if resume_job is not None else ""
+        remote_branch = resume_job.remote_branch if resume_job is not None else ""
+        pr_url = resume_job.pr_url if resume_job is not None else ""
+        pushed_remotely = (
+            resume_job.published_remotely if resume_job is not None else False
+        )
+        completed_stages = [
+            candidate
+            for candidate in ("committed", "pushed", "pr_opened")
+            if candidate == stage
+            or (
+                stage == "pushed"
+                and candidate == "committed"
+            )
+            or (
+                stage == "pr_opened"
+                and candidate in {"committed", "pushed"}
+            )
+        ]
         try:
-            self._send_step_update(chat_id, "Committing the change.")
-            commit = prepare_local_publish(
-                feature_title(request),
-                root=publish_root,
-                allowed_files=allowed_files,
-            )
-            outputs.append(_format_publish_result(commit))
-            summaries.append(_publish_summary(commit))
-            self._send_step_update(chat_id, f"Committed {commit.commit_sha}.")
+            if stage not in {"committed", "pushed", "pr_opened"}:
+                self._send_step_update(chat_id, "Committing the change.")
+                commit = prepare_local_publish(
+                    feature_title(request),
+                    root=publish_root,
+                    allowed_files=allowed_files,
+                    validation_result=validation_result,
+                )
+                commit_sha = commit.commit_sha
+                remote_branch = commit.branch
+                outputs.append(_format_publish_result(commit))
+                summaries.append(_publish_summary(commit))
+                completed_stages.append("committed")
+                self._record_current_publish_stage(
+                    "committed",
+                    commit_sha=commit_sha,
+                    remote_branch=remote_branch,
+                )
+                self._send_step_update(chat_id, f"Committed {commit.commit_sha}.")
+                stage = "committed"
+            else:
+                outputs.append(
+                    f"Resuming publish workflow after commit {commit_sha or 'unknown'}."
+                )
 
-            self._send_step_update(chat_id, "Handing off the branch to the configured forge.")
-            pushed = push_current_branch(root=publish_root)
-            outputs.append(_format_remote_publish_result(pushed))
-            summaries.append(_remote_publish_summary(pushed))
-            self._send_step_update(
-                chat_id,
-                (
-                    f"Pushed branch {pushed.branch}."
-                    if pushed.pushed
-                    else f"Kept branch {pushed.branch} locally."
-                ),
-            )
+            if stage not in {"pushed", "pr_opened"}:
+                self._send_step_update(
+                    chat_id,
+                    "Handing off the branch to the configured forge.",
+                )
+                pushed = push_current_branch(root=publish_root)
+                remote_branch = pushed.branch
+                pushed_remotely = pushed.pushed
+                outputs.append(_format_remote_publish_result(pushed))
+                summaries.append(_remote_publish_summary(pushed))
+                completed_stages.append("pushed")
+                self._record_current_publish_stage(
+                    "pushed",
+                    commit_sha=commit_sha,
+                    remote_branch=remote_branch,
+                    published_remotely=pushed_remotely,
+                )
+                self._send_step_update(
+                    chat_id,
+                    (
+                        f"Pushed branch {pushed.branch}."
+                        if pushed.pushed
+                        else f"Kept branch {pushed.branch} locally."
+                    ),
+                )
+                stage = "pushed"
 
-            self._send_step_update(chat_id, "Preparing the review handoff.")
-            pr = _create_pull_request_for_current_task(
-                publish_root,
-                self.root,
-                forge=self.forge,
-            )
-            outputs.append(_format_pr_result(pr))
-            summaries.append(_pr_summary(pr))
-            if pr.url:
-                self._update_work_status(_pr_step_update(pr), pr_url=pr.url)
-                _record_current_task_result("\n\n".join(outputs), self.root)
-            self._send_step_update(chat_id, _pr_step_update(pr))
+            if stage != "pr_opened":
+                self._send_step_update(chat_id, "Preparing the review handoff.")
+                pr = _create_pull_request_for_current_task(
+                    publish_root,
+                    self.root,
+                    forge=self.forge,
+                )
+                outputs.append(_format_pr_result(pr))
+                summaries.append(_pr_summary(pr))
+                self._send_step_update(chat_id, _pr_step_update(pr))
+                if bool(getattr(self.forge, "supports_remote_review", True)) and (
+                    not pr.created or not pr.url
+                ):
+                    detail = pr.note or pr.fallback_url or "the forge did not return a PR URL"
+                    failure = (
+                        "Enoch pushed the task branch but could not open its pull request. "
+                        f"The worktree and branch were preserved for retry. {detail}"
+                    )
+                    self._send_step_update(chat_id, failure)
+                    return WorkOutcome.failure(
+                        "\n\n".join([*outputs, failure]),
+                        status="publish_incomplete",
+                        code="pr_creation_failed",
+                        failure_class="transient",
+                        retryable=True,
+                        completed_stages=tuple(dict.fromkeys(completed_stages)),
+                        commit_sha=commit_sha,
+                        remote_branch=remote_branch,
+                    )
+                pr_url = pr.url or ""
+                if pr_url:
+                    completed_stages.append("pr_opened")
+                    self._record_current_publish_stage(
+                        "pr_opened",
+                        commit_sha=commit_sha,
+                        remote_branch=remote_branch,
+                        pr_url=pr_url,
+                        published_remotely=pushed_remotely,
+                    )
+                    self._update_work_status(_pr_step_update(pr), pr_url=pr_url)
+                    _record_current_task_result("\n\n".join(outputs), self.root)
+                    stage = "pr_opened"
+            elif pr_url:
+                outputs.append(f"Pull request already opened: {pr_url}")
 
             resident_branch = self._resident_branch_name()
             if task_worktree is not None:
@@ -1634,23 +1851,23 @@ class EnochApplication:
                 handoff = remove_task_worktree(
                     self.root,
                     task_worktree,
-                    delete_local_branch=pushed.pushed,
-                    force_delete_branch=pushed.pushed,
+                    delete_local_branch=pushed_remotely,
+                    force_delete_branch=pushed_remotely,
                 )
             else:
                 self._send_step_update(chat_id, f"Returning local checkout to {resident_branch}.")
                 handoff = self._return_to_resident_after_handoff(
-                    published_remotely=pushed.pushed,
+                    published_remotely=pushed_remotely,
                 )
             outputs.append(handoff)
             summaries.append(handoff)
             self._send_step_update(chat_id, f"Resident checkout remains on {resident_branch}.")
-            if pr.url:
+            if pr_url:
                 self._queue_session_sync(
                     chat_id,
                     repository_handoff_note(
-                        pr.branch,
-                        pr.url,
+                        remote_branch,
+                        pr_url,
                         resident_branch,
                         self._authoritative_branch_name(),
                     ),
@@ -1658,11 +1875,28 @@ class EnochApplication:
         except (VcsError, ForgeProviderError) as error:
             failure = f"Enoch could not publish this edit as a pull request: {error}"
             self._send_step_update(chat_id, failure)
-            return "\n\n".join([*outputs, failure]) if outputs else failure
+            classified = classify_task_failure(failure)
+            publish_started = bool(completed_stages)
+            return WorkOutcome.failure(
+                "\n\n".join([*outputs, failure]) if outputs else failure,
+                status="publish_incomplete" if publish_started else "failed",
+                code=(
+                    classified.code
+                    if classified.code != "unknown_failure"
+                    else "publish_failed"
+                ),
+                failure_class=(
+                    "transient" if publish_started else classified.failure_class
+                ),
+                retryable=publish_started or classified.retryable,
+                completed_stages=tuple(dict.fromkeys(completed_stages)),
+                commit_sha=commit_sha,
+                remote_branch=remote_branch,
+            )
 
         action = (
             f"published edit as pull request: {request}"
-            if pr.created
+            if pr_url
             else f"committed edit to local branch: {request}"
         )
         _record_direct_action(action, "\n\n".join(summaries), self.root)
@@ -1675,7 +1909,62 @@ class EnochApplication:
                 f"Result: {_clip_activity_text(reply)}",
             ),
         )
-        return reply
+        return WorkOutcome.completed(
+            reply,
+            completed_stages=tuple(dict.fromkeys(completed_stages)),
+            commit_sha=commit_sha,
+            remote_branch=remote_branch,
+            pr_url=pr_url,
+        )
+
+    def _record_current_publish_stage(
+        self,
+        stage: str,
+        *,
+        commit_sha: str = "",
+        remote_branch: str = "",
+        pr_url: str = "",
+        published_remotely: bool | None = None,
+    ) -> None:
+        task_id = _CURRENT_TASK_ID.get()
+        worker_id = _CURRENT_TASK_WORKER_ID.get()
+        if task_id is None or not worker_id:
+            return
+        recorded = record_task_publish_state(
+            task_id,
+            worker_id,
+            self.root,
+            stage=stage,
+            commit_sha=commit_sha,
+            remote_branch=remote_branch,
+            pr_url=pr_url,
+            published_remotely=published_remotely,
+        )
+        if recorded is None:
+            raise VcsError(
+                f"Task #{task_id} lost its execution lease while recording publish stage {stage}."
+            )
+
+    def _resume_task_publish(self, job: TaskJob) -> WorkOutcome:
+        if not job.worktree_path or not job.branch_name:
+            return WorkOutcome.failure(
+                f"Task #{job.id} cannot resume publishing because its worktree metadata is missing.",
+                code="worktree_precondition",
+            )
+        worktree = TaskWorktree(
+            task_id=job.id,
+            path=Path(job.worktree_path),
+            branch=job.branch_name,
+            created=False,
+        )
+        return self._publish_feature_pr(
+            job.chat_id,
+            job.text,
+            (),
+            work_root=worktree.path,
+            task_worktree=worktree,
+            resume_job=job,
+        )
 
     def _return_to_resident_after_handoff(self, *, published_remotely: bool = True) -> str:
         branch = current_branch(self.root)
@@ -1927,6 +2216,7 @@ class EnochApplication:
                 self.root,
                 context=snapshot.context,
                 context_source=snapshot.source,
+                idempotency_key=_event_idempotency_key("task"),
                 **self._profile_task_options(),
             )
         except (OSError, ValueError):
@@ -2060,6 +2350,7 @@ class EnochApplication:
                 initiated_by="human",
                 event_actor="human",
                 trigger=trigger,
+                idempotency_key=_event_idempotency_key(f"paused:{trigger}"),
                 **self._profile_task_options(),
             )
             paused = pause_task(
@@ -2309,6 +2600,7 @@ class EnochApplication:
                 priority=priority,
                 context=snapshot.context,
                 context_source=snapshot.source,
+                idempotency_key=_event_idempotency_key("backlog-add"),
             )
         except (OSError, ValueError):
             return "Enoch could not add that backlog item."
@@ -2549,6 +2841,9 @@ class EnochApplication:
                 approval_actor="human",
                 parent_candidate_id=candidate.parent_candidate_id,
                 source_task_id=candidate.source_task_id,
+                idempotency_key=_event_idempotency_key(
+                    f"evolve-approve:{candidate.id}"
+                ),
                 **self._profile_task_options(),
             )
         except (OSError, ValueError):
@@ -2617,6 +2912,9 @@ class EnochApplication:
                 approval_actor="human",
                 parent_candidate_id=candidate.parent_candidate_id,
                 source_task_id=candidate.source_task_id,
+                idempotency_key=_event_idempotency_key(
+                    f"evolve-retry:{candidate.id}"
+                ),
                 **self._profile_task_options(),
             )
         except (OSError, ValueError):
@@ -2769,6 +3067,7 @@ class EnochApplication:
                 self.root,
                 context=snapshot.context,
                 context_source=snapshot.source,
+                idempotency_key=_event_idempotency_key("cron-add"),
             )
         except (OSError, ValueError):
             return "Enoch could not schedule that cron job."
@@ -2835,6 +3134,7 @@ class EnochApplication:
             initiated_by="human",
             event_actor=event_actor,
             trigger=trigger,
+            idempotency_key=f"backlog:{item.id}",
             **self._profile_task_options(),
         )
         promoted = promote_backlog_item(item.id, self.root, promoted_task_id=job.id)
@@ -2872,11 +3172,17 @@ class EnochApplication:
                     initiated_by="human",
                     event_actor="system",
                     trigger=f"cron:{cron.id}",
+                    idempotency_key=f"cron:{cron.id}:{cron.claim_id}",
                     **self._profile_task_options(),
                 )
             except (OSError, ValueError):
                 continue
-            record_cron_task(cron.id, job.id, self.root)
+            record_cron_task(
+                cron.id,
+                job.id,
+                self.root,
+                claim_id=cron.claim_id,
+            )
             jobs.append(job)
             message = self._format_work_status(
                 WorkStatusMessage(
@@ -2914,6 +3220,10 @@ class EnochApplication:
                 trigger="evolve-scheduler",
                 reason="chat-not-locked",
             )
+            acknowledge_evolve_schedule(
+                claimed.schedule_claim_id,
+                self.root,
+            )
             return None
         if claimed.mode == MODE_DISABLED:
             self._record_evolve_event(
@@ -2927,6 +3237,10 @@ class EnochApplication:
                 event_actor="system",
                 trigger="evolve-scheduler",
                 reason="mode-disabled",
+            )
+            acknowledge_evolve_schedule(
+                claimed.schedule_claim_id,
+                self.root,
             )
             return None
         proposal = self._propose_evolve(chat_id, trigger="evolve-scheduler")
@@ -2945,6 +3259,10 @@ class EnochApplication:
                 reason=wait_reason,
             )
         self._safe_send_message(chat_id, "Scheduled evolve check\n\n" + _format_evolve_proposal(proposal))
+        acknowledge_evolve_schedule(
+            claimed.schedule_claim_id,
+            self.root,
+        )
         return None
 
     def _run_task_job(self, job: TaskJob) -> None:
@@ -3033,27 +3351,41 @@ class EnochApplication:
         failure: TaskFailure | None = None
         regression_signals: tuple[TaskRegressionSignal, ...] = ()
         try:
-            if task_result_has_pull_request(job.result):
+            if job.publish_stage in {"committed", "pushed", "pr_opened"}:
+                outcome = self._resume_task_publish(job)
+            elif task_result_has_pull_request(job.result):
                 reply = job.result
+                outcome = WorkOutcome.completed(reply)
             elif not self._action_allowed():
                 reply = self._action_lock_message()
-                completed_status = "failed"
-            else:
-                reply = self._run_direct_work(
-                    job.chat_id,
-                    job.text,
-                    context=_task_worker_context(job),
-                    session_key=session_key,
-                    execution=execution,
+                outcome = WorkOutcome.failure(
+                    reply,
+                    code="action_locked",
+                    failure_class="permanent",
                 )
+            else:
+                outcome = _coerce_work_outcome(
+                    self._run_direct_work(
+                        job.chat_id,
+                        job.text,
+                        context=_task_worker_context(job),
+                        session_key=session_key,
+                        execution=execution,
+                    )
+                )
+            reply = outcome.message
             reply = self._capture_task_regression_signals(reply)
             if deadline.expired.is_set():
                 reply = _task_timeout_message(deadline.timeout_seconds)
                 completed_status = "failed"
                 failure = classify_task_failure(reply)
-            elif _work_reply_failed(reply):
+            elif outcome.failed:
                 completed_status = "failed"
-                failure = classify_task_failure(reply)
+                failure = TaskFailure(
+                    code=outcome.code or "unknown_failure",
+                    failure_class=outcome.failure_class or "permanent",
+                    retryable=outcome.retryable,
+                )
         except AgentRuntimeAccessUnavailable as error:
             reply = _codex_pause_warning(job.id, str(error))
             completed_status = "paused"
@@ -3583,6 +3915,14 @@ def _chat_provider_name(client: object) -> str:
     return name or "chat"
 
 
+def _event_idempotency_key(purpose: str) -> str:
+    event_key = _CURRENT_EVENT_KEY.get().strip()
+    normalized_purpose = " ".join(purpose.split())
+    if not event_key or not normalized_purpose:
+        return ""
+    return f"chat:{event_key}:{normalized_purpose}"
+
+
 def _action_sandbox(_root: Path) -> str:
     return ACTION_SANDBOX_FULL_ACCESS
 
@@ -3593,13 +3933,6 @@ def _sandbox_description(sandbox: str) -> str:
     if sandbox == ACTION_SANDBOX_FULL_ACCESS:
         return "working with full filesystem access"
     return "thinking in read-only mode"
-
-
-def _worktree_snapshot(root: Path) -> str:
-    try:
-        return diff_summary(root)
-    except VcsError:
-        return ""
 
 
 def _changed_files_or_empty(root: Path) -> tuple[str, ...]:
@@ -3648,6 +3981,21 @@ def _work_reply_failed(reply: str) -> bool:
         or "i did not open a pr because doctor failed" in normalized
         or "doctor failed:" in normalized
     )
+
+
+def _coerce_work_outcome(value: WorkOutcome | str) -> WorkOutcome:
+    if isinstance(value, WorkOutcome):
+        return value
+    message = str(value)
+    if _work_reply_failed(message):
+        failure = classify_task_failure(message)
+        return WorkOutcome.failure(
+            message,
+            code=failure.code,
+            failure_class=failure.failure_class,
+            retryable=failure.retryable,
+        )
+    return WorkOutcome.completed(message)
 
 
 def _start_task_deadline(

--- a/src/enoch/app/inbox.py
+++ b/src/enoch/app/inbox.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from enoch.memory.paths import atomic_write, now as current_time
+from enoch.paths import enoch_home
+from enoch.providers.contracts import ChatEvent, Cursor
+from enoch.state import StateCorruptionError, file_transaction, load_json_object
+
+
+SCHEMA_VERSION = 1
+MAX_EVENT_ATTEMPTS = 3
+
+
+@dataclass(frozen=True)
+class InboxReceipt:
+    key: str
+    status: str
+    attempts: int
+    cursor: Cursor | None
+    reply: str = ""
+    logged_input: str = ""
+    reply_sent: bool = False
+    error: str = ""
+
+    @property
+    def completed(self) -> bool:
+        return self.status in {"completed", "acknowledged"}
+
+    @property
+    def exhausted(self) -> bool:
+        return self.attempts >= MAX_EVENT_ATTEMPTS
+
+
+def inbox_path(provider: str, root: Path | None = None) -> Path:
+    safe_provider = "".join(
+        character if character.isalnum() or character in "._-" else "-"
+        for character in provider.strip().lower()
+    ).strip("-.") or "chat"
+    return enoch_home(root) / "channels" / safe_provider / "inbox.json"
+
+
+def event_key(provider: str, event: ChatEvent) -> str:
+    identity = {
+        "provider": provider.strip().lower() or "chat",
+        "cursor": event.cursor,
+        "conversation_id": event.conversation_id,
+        "message_id": event.message_id,
+        "text": event.text,
+        "replied_text": event.replied_text,
+        "attachments": [
+            {
+                "kind": attachment.kind,
+                "file_id": attachment.file_id,
+                "filename": attachment.filename,
+            }
+            for attachment in event.attachments
+        ],
+    }
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def begin_event(
+    provider: str,
+    event: ChatEvent,
+    root: Path | None = None,
+) -> InboxReceipt:
+    path = inbox_path(provider, root)
+    key = event_key(provider, event)
+    with file_transaction(path):
+        data = _load_inbox(path)
+        receipts = data["events"]
+        existing = _receipt(key, receipts.get(key))
+        if existing is not None and existing.completed:
+            return existing
+        attempts = (existing.attempts if existing is not None else 0) + 1
+        receipt = InboxReceipt(
+            key=key,
+            status="processing",
+            attempts=attempts,
+            cursor=event.cursor,
+        )
+        receipts[key] = _receipt_to_json(receipt)
+        _write_inbox(path, data)
+        return receipt
+
+
+def complete_event(
+    provider: str,
+    key: str,
+    root: Path | None = None,
+    *,
+    reply: str,
+    logged_input: str,
+) -> InboxReceipt:
+    return _update_receipt(
+        provider,
+        key,
+        root,
+        status="completed",
+        reply=reply,
+        logged_input=logged_input,
+        error="",
+    )
+
+
+def mark_reply_sent(
+    provider: str,
+    key: str,
+    root: Path | None = None,
+) -> InboxReceipt:
+    return _update_receipt(provider, key, root, reply_sent=True)
+
+
+def acknowledge_event(
+    provider: str,
+    key: str,
+    root: Path | None = None,
+) -> InboxReceipt:
+    return _update_receipt(provider, key, root, status="acknowledged")
+
+
+def fail_event(
+    provider: str,
+    key: str,
+    error: str,
+    root: Path | None = None,
+) -> InboxReceipt:
+    return _update_receipt(
+        provider,
+        key,
+        root,
+        status="failed",
+        error=" ".join(error.split())[:2000],
+    )
+
+
+def _update_receipt(
+    provider: str,
+    key: str,
+    root: Path | None,
+    **changes: Any,
+) -> InboxReceipt:
+    path = inbox_path(provider, root)
+    with file_transaction(path):
+        data = _load_inbox(path)
+        existing = _receipt(key, data["events"].get(key))
+        if existing is None:
+            raise StateCorruptionError(path, f"missing inbox receipt {key}")
+        values = {**existing.__dict__, **changes}
+        receipt = InboxReceipt(**values)
+        data["events"][key] = _receipt_to_json(receipt)
+        _write_inbox(path, data)
+        return receipt
+
+
+def _load_inbox(path: Path) -> dict[str, Any]:
+    data = load_json_object(
+        path,
+        default_factory=lambda: {"schema_version": SCHEMA_VERSION, "events": {}},
+    )
+    events = data.get("events")
+    if not isinstance(events, dict):
+        raise StateCorruptionError(path, "expected events to be an object")
+    for key, raw in events.items():
+        if not isinstance(key, str) or _receipt(key, raw) is None:
+            raise StateCorruptionError(path, "found an invalid inbox receipt")
+    return {"schema_version": SCHEMA_VERSION, "events": events}
+
+
+def _write_inbox(path: Path, data: dict[str, Any]) -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": current_time(),
+        "events": data["events"],
+    }
+    atomic_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _receipt(key: str, raw: object) -> InboxReceipt | None:
+    if not isinstance(raw, dict):
+        return None
+    status = str(raw.get("status") or "")
+    if status not in {"processing", "completed", "failed", "acknowledged"}:
+        return None
+    attempts = _positive_int(raw.get("attempts"))
+    cursor = raw.get("cursor")
+    if isinstance(cursor, bool) or not isinstance(cursor, (int, str, type(None))):
+        cursor = None
+    return InboxReceipt(
+        key=key,
+        status=status,
+        attempts=attempts,
+        cursor=cursor,
+        reply=str(raw.get("reply") or ""),
+        logged_input=str(raw.get("logged_input") or ""),
+        reply_sent=bool(raw.get("reply_sent", False)),
+        error=str(raw.get("error") or ""),
+    )
+
+
+def _receipt_to_json(receipt: InboxReceipt) -> dict[str, Any]:
+    return {
+        "status": receipt.status,
+        "attempts": receipt.attempts,
+        "cursor": receipt.cursor,
+        "reply": receipt.reply,
+        "logged_input": receipt.logged_input,
+        "reply_sent": receipt.reply_sent,
+        "error": receipt.error,
+    }
+
+
+def _positive_int(value: object) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, parsed)

--- a/src/enoch/app/models.py
+++ b/src/enoch/app/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import threading
+from typing import Literal
 
 from enoch.providers.contracts import ConversationId, MessageId
 
@@ -59,3 +60,74 @@ class TaskDeadline:
     def _expire(self) -> None:
         self.expired.set()
         self.cancellation_event.set()
+
+
+WorkOutcomeStatus = Literal["completed", "failed", "publish_incomplete"]
+
+
+@dataclass(frozen=True)
+class WorkOutcome:
+    """Structured task result; presentation text is never used as control flow."""
+
+    status: WorkOutcomeStatus
+    message: str
+    code: str = ""
+    failure_class: str = ""
+    retryable: bool = False
+    completed_stages: tuple[str, ...] = ()
+    commit_sha: str = ""
+    remote_branch: str = ""
+    pr_url: str = ""
+
+    @property
+    def failed(self) -> bool:
+        return self.status != "completed"
+
+    def __str__(self) -> str:
+        return self.message
+
+    def __contains__(self, value: object) -> bool:
+        return isinstance(value, str) and value in self.message
+
+    @classmethod
+    def completed(
+        cls,
+        message: str,
+        *,
+        completed_stages: tuple[str, ...] = (),
+        commit_sha: str = "",
+        remote_branch: str = "",
+        pr_url: str = "",
+    ) -> WorkOutcome:
+        return cls(
+            status="completed",
+            message=message,
+            completed_stages=completed_stages,
+            commit_sha=commit_sha,
+            remote_branch=remote_branch,
+            pr_url=pr_url,
+        )
+
+    @classmethod
+    def failure(
+        cls,
+        message: str,
+        *,
+        code: str,
+        failure_class: str = "permanent",
+        retryable: bool = False,
+        status: WorkOutcomeStatus = "failed",
+        completed_stages: tuple[str, ...] = (),
+        commit_sha: str = "",
+        remote_branch: str = "",
+    ) -> WorkOutcome:
+        return cls(
+            status=status,
+            message=message,
+            code=code,
+            failure_class=failure_class,
+            retryable=retryable,
+            completed_stages=completed_stages,
+            commit_sha=commit_sha,
+            remote_branch=remote_branch,
+        )

--- a/src/enoch/backlog.py
+++ b/src/enoch/backlog.py
@@ -1,25 +1,18 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 from dataclasses import dataclass
 import json
 from pathlib import Path
-import threading
-
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - fcntl is unavailable on Windows.
-    fcntl = None
 
 from enoch.memory.paths import atomic_write, now as current_time
 from enoch.paths import enoch_home
 from enoch.providers.contracts import ConversationId, normalize_conversation_id
+from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 PRIORITIES = ("p0", "p1", "p2")
 DEFAULT_PRIORITY = "p1"
-_BACKLOG_THREAD_LOCK = threading.RLock()
 
 
 @dataclass(frozen=True)
@@ -35,6 +28,7 @@ class BacklogItem:
     promoted_task_id: int | None = None
     context: str = ""
     context_source: str = ""
+    idempotency_key: str = ""
 
 
 @dataclass(frozen=True)
@@ -56,6 +50,7 @@ def add_backlog_item(
     priority: str = DEFAULT_PRIORITY,
     context: str = "",
     context_source: str = "",
+    idempotency_key: str = "",
 ) -> BacklogItem:
     cleaned = " ".join(text.split())
     if not cleaned:
@@ -63,6 +58,18 @@ def add_backlog_item(
     priority = normalize_priority(priority)
     with _backlog_transaction(root):
         data = _load_backlog(root)
+        normalized_key = idempotency_key.strip()
+        if normalized_key:
+            existing = next(
+                (
+                    item
+                    for item in [*_pending_items(data), *_history_items(data)]
+                    if item.idempotency_key == normalized_key
+                ),
+                None,
+            )
+            if existing is not None:
+                return existing
         item = BacklogItem(
             id=_next_id(data),
             chat_id=chat_id,
@@ -71,6 +78,7 @@ def add_backlog_item(
             created_at=current_time(),
             context=context.strip(),
             context_source=context_source.strip(),
+            idempotency_key=normalized_key,
         )
         pending = data.setdefault("pending", [])
         pending.append(_item_to_dict(item))
@@ -94,7 +102,7 @@ def remove_backlog_item(item_id: int, root: Path | None = None) -> BacklogItem |
         history = _history_items(data)
         history.append(removed)
         data["pending"] = [_item_to_dict(item) for item in kept]
-        data["history"] = [_item_to_dict(item) for item in history[-20:]]
+        data["history"] = [_item_to_dict(item) for item in history]
         _write_backlog(data, root)
         return removed
 
@@ -134,7 +142,7 @@ def promote_next_backlog_item(root: Path | None = None, *, promoted_task_id: int
         history = _history_items(data)
         history.append(promoted)
         data["pending"] = [_item_to_dict(item) for item in pending]
-        data["history"] = [_item_to_dict(item) for item in history[-20:]]
+        data["history"] = [_item_to_dict(item) for item in history]
         _write_backlog(data, root)
         return promoted
 
@@ -164,7 +172,7 @@ def promote_backlog_item(
         history = _history_items(data)
         history.append(promoted)
         data["pending"] = [_item_to_dict(item) for item in kept]
-        data["history"] = [_item_to_dict(item) for item in history[-20:]]
+        data["history"] = [_item_to_dict(item) for item in history]
         _write_backlog(data, root)
         return promoted
 
@@ -214,14 +222,12 @@ def _next_item_index(items: list[BacklogItem]) -> int | None:
 
 def _load_backlog(root: Path | None = None) -> dict:
     path = backlog_path(root)
-    if not path.exists():
-        return _empty_backlog()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return _empty_backlog()
-    if not isinstance(raw, dict):
-        return _empty_backlog()
+    raw = load_json_object(path, default_factory=_empty_backlog)
+    for key in ("pending", "history"):
+        if key in raw and not isinstance(raw[key], list):
+            raise StateCorruptionError(path, f"expected {key} to be a list")
+        if any(_parse_item(item) is None for item in raw.get(key, [])):
+            raise StateCorruptionError(path, f"found an invalid backlog item in {key}")
     pending = [_item_to_dict(item) for item in _pending_items(raw)]
     next_id = _int(raw.get("next_id"), default=1)
     max_id = max([item["id"] for item in pending], default=0)
@@ -233,7 +239,7 @@ def _load_backlog(root: Path | None = None) -> dict:
         "schema_version": SCHEMA_VERSION,
         "next_id": max(next_id, max_id + 1),
         "pending": pending,
-        "history": history[-20:],
+        "history": history,
     }
 
 
@@ -242,25 +248,13 @@ def _write_backlog(data: dict, root: Path | None = None) -> None:
         "schema_version": SCHEMA_VERSION,
         "next_id": _next_id(data),
         "pending": [_item_to_dict(item) for item in _pending_items(data)],
-        "history": [_item_to_dict(item) for item in _history_items(data)][-20:],
+        "history": [_item_to_dict(item) for item in _history_items(data)],
     }
     atomic_write(backlog_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
-@contextmanager
 def _backlog_transaction(root: Path | None = None):
-    path = backlog_path(root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    with _BACKLOG_THREAD_LOCK:
-        with lock_path.open("a", encoding="utf-8") as lock_file:
-            if fcntl is not None:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                if fcntl is not None:
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+    return file_transaction(backlog_path(root))
 
 
 def _pending_items(data: dict) -> list[BacklogItem]:
@@ -296,6 +290,7 @@ def _parse_item(raw: object) -> BacklogItem | None:
     promoted_task_id = _optional_int(raw.get("promoted_task_id"))
     context = str(raw.get("context") or "").strip()
     context_source = str(raw.get("context_source") or "").strip()
+    idempotency_key = str(raw.get("idempotency_key") or "").strip()
     if item_id <= 0 or chat_id is None or not text:
         return None
     return BacklogItem(
@@ -310,6 +305,7 @@ def _parse_item(raw: object) -> BacklogItem | None:
         promoted_task_id=promoted_task_id,
         context=context,
         context_source=context_source,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -328,6 +324,7 @@ def _item_to_dict(item: BacklogItem | None) -> dict:
         "promoted_task_id": item.promoted_task_id,
         "context": item.context,
         "context_source": item.context_source,
+        "idempotency_key": item.idempotency_key,
     }
 
 
@@ -344,6 +341,7 @@ def _replace_item(item: BacklogItem, **changes: object) -> BacklogItem:
         "promoted_task_id": item.promoted_task_id,
         "context": item.context,
         "context_source": item.context_source,
+        "idempotency_key": item.idempotency_key,
     }
     values.update(changes)
     return BacklogItem(**values)

--- a/src/enoch/channel.py
+++ b/src/enoch/channel.py
@@ -13,6 +13,7 @@ from enoch.identity import Identity
 from enoch.paths import enoch_home
 from enoch.providers.contracts import Attachment, ChatProvider, Cursor
 from enoch.operations.update_tools import current_repository_revision, repository_sync_summary
+from enoch.state import StateCorruptionError, atomic_write, load_json_object
 
 
 MAX_IMAGE_BYTES = 20 * 1024 * 1024
@@ -39,24 +40,22 @@ def provider_label(name: str) -> str:
 
 def load_channel_cursor(name: str, root: Path | None = None) -> Cursor | None:
     path = channel_cursor_path(name, root)
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        cursor = data.get("cursor", data.get("offset"))
-    except (AttributeError, OSError, json.JSONDecodeError):
+    data = load_json_object(path)
+    if not data:
         return None
+    cursor = data.get("cursor", data.get("offset"))
     if isinstance(cursor, bool):
         return None
     if isinstance(cursor, int):
         return cursor if cursor >= 0 else None
     if isinstance(cursor, str):
         return cursor.strip() or None
-    return None
+    raise StateCorruptionError(path, "expected cursor to be a non-negative integer or string")
 
 
 def save_channel_cursor(name: str, cursor: Cursor, root: Path | None = None) -> None:
     path = channel_cursor_path(name, root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"cursor": cursor}, indent=2), encoding="utf-8")
+    atomic_write(path, json.dumps({"cursor": cursor}, indent=2) + "\n")
 
 
 def channel_cursor_path(name: str, root: Path | None = None) -> Path:
@@ -101,13 +100,7 @@ def record_channel_shutdown(
 
 def load_channel_lifecycle(name: str, root: Path | None = None) -> dict[str, Any]:
     path = channel_lifecycle_path(name, root)
-    if not path.exists():
-        return {}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-    return data if isinstance(data, dict) else {}
+    return load_json_object(path)
 
 
 def save_channel_lifecycle(
@@ -116,8 +109,7 @@ def save_channel_lifecycle(
     root: Path | None = None,
 ) -> None:
     path = channel_lifecycle_path(name, root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    atomic_write(path, json.dumps(data, indent=2) + "\n")
 
 
 def channel_lifecycle_path(name: str, root: Path | None = None) -> Path:

--- a/src/enoch/cli.py
+++ b/src/enoch/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import sys
 from pathlib import Path
 
@@ -26,24 +27,88 @@ from enoch.operations.update_tools import schedule_daemon_restart as _schedule_d
 from enoch.operations.updater import update_from_authoritative
 
 
-HELP = """Commands:
-  help        Show this help.
-  init        Create or claim a local Enoch instance worktree.
-  status      Show identity, model, and lineage.
-  setup       Configure the selected chat provider and lineage.
-  config      Show settings or select installed providers.
-  thinking    Show or set Enoch's Codex thinking level.
-  mission     Show or update Enoch's mission.
-  ancestors   Inspect ancestor chain and inheritable updates.
-  inherit     Show inheritable direct-parent changes.
-  skills      Show declared skills for Enoch or another local agent.
-  learn       Inspect a published skill for adaptation.
-  doctor      Run Enoch's local health checks.
-  update      Update from the authoritative repository, run doctor, and restart Enoch if safe.
-  exit        Put Enoch back to sleep.
+@dataclass(frozen=True)
+class AdminCommand:
+    name: str
+    summary: str
+    usage: str
+    handler: str
 
-Enoch CLI is admin-only. Use the configured chat provider for conversation, repository edits, and self-evolution.
-"""
+    def summary_line(self) -> str:
+        return f"  {self.name:<12}{self.summary}"
+
+
+ADMIN_COMMANDS = (
+    AdminCommand("help", "Show this help.", "help [command]", "_admin_help"),
+    AdminCommand(
+        "init",
+        "Create or claim a local Enoch instance worktree.",
+        "init [--instance name] [--worktree path] [--branch branch]",
+        "_admin_init",
+    ),
+    AdminCommand("status", "Show identity, model, and lineage.", "status", "_admin_status"),
+    AdminCommand(
+        "setup",
+        "Configure the selected chat provider and lineage.",
+        "setup [token|chat|ancestor] [value]",
+        "_admin_setup",
+    ),
+    AdminCommand(
+        "config",
+        "Show settings or select installed providers.",
+        "config [provider <kind> <name>|provider <kind> default]",
+        "_admin_config",
+    ),
+    AdminCommand(
+        "thinking",
+        "Show or set Enoch's Codex thinking level.",
+        "thinking [low|medium|high|default]",
+        "_admin_thinking",
+    ),
+    AdminCommand(
+        "mission",
+        "Show or update Enoch's mission.",
+        "mission [new mission]",
+        "_admin_mission",
+    ),
+    AdminCommand(
+        "ancestors",
+        "Inspect ancestor chain and inheritable updates.",
+        "ancestors",
+        "_admin_ancestors",
+    ),
+    AdminCommand(
+        "inherit",
+        "Show inheritable direct-parent changes.",
+        "inherit [change_id|all|ignore <candidate>]",
+        "_admin_inherit",
+    ),
+    AdminCommand(
+        "skills",
+        "Show declared skills for Enoch or another local agent.",
+        "skills [agent]",
+        "_admin_skills",
+    ),
+    AdminCommand(
+        "learn",
+        "Inspect a published skill for adaptation.",
+        "learn <skill> from <agent>",
+        "_admin_learn",
+    ),
+    AdminCommand(
+        "doctor",
+        "Run Enoch's local health checks.",
+        "doctor",
+        "_admin_doctor",
+    ),
+    AdminCommand(
+        "update",
+        "Update from the authoritative repository, run doctor, and restart Enoch if safe.",
+        "update",
+        "_admin_update",
+    ),
+    AdminCommand("exit", "Put Enoch back to sleep.", "exit", "_admin_exit"),
+)
 
 ADMIN_ONLY_MESSAGE = "\n".join(
     [
@@ -103,42 +168,108 @@ def _repl(identity: Identity, root: Path) -> None:
 
 
 def _command_output(raw_command: str, identity: Identity, root: Path) -> str | object:
-    command = raw_command.strip().lower()
-    if command == "":
+    normalized = raw_command.strip()
+    if not normalized:
         return ""
-    if command == "exit":
-        return EXIT
-    if command == "help":
-        return HELP
-    if command == "init" or command.startswith("init "):
-        return _init_instance(identity, raw_command, root)
-    if command == "status":
-        return _status_text(identity, root)
-    if command == "setup" or command.startswith("setup "):
-        return _setup(raw_command, root)
-    if command == "setup-chat" or command.startswith("setup-chat "):
-        return _setup(raw_command, root)
-    if command == "setup-token" or command.startswith("setup-token "):
-        return _setup(raw_command, root)
-    if command == "config" or command.startswith("config "):
-        return config_command(raw_command, root, prefix="")
-    if command == "thinking" or command.startswith("thinking "):
-        return _thinking(raw_command, root)
-    if command == "mission" or command.startswith("mission "):
-        return _mission(raw_command, identity, root)
-    if command == "ancestors" or command.startswith("ancestors "):
-        return _ancestors(raw_command, root)
-    if command == "inherit" or command.startswith("inherit "):
-        return _inherit(raw_command, root)
-    if command == "skills" or command.startswith("skills "):
-        return _skills(raw_command, root)
-    if command == "learn" or command.startswith("learn "):
-        return _learn(raw_command, root)
-    if command == "doctor":
-        return _doctor_text(root)
-    if command == "update":
-        return _update(root)
-    return ADMIN_ONLY_MESSAGE
+    command_name = normalized.split(maxsplit=1)[0].lower()
+    command = next(
+        (candidate for candidate in ADMIN_COMMANDS if candidate.name == command_name),
+        None,
+    )
+    if command is None:
+        return ADMIN_ONLY_MESSAGE
+    handler = globals().get(command.handler)
+    if not callable(handler):
+        raise RuntimeError(
+            f"Admin command {command.name} has missing handler {command.handler}."
+        )
+    return handler(normalized, identity, root)
+
+
+def admin_help(topic: str = "") -> str:
+    normalized = topic.strip().lower().lstrip("/")
+    if normalized:
+        command = next(
+            (candidate for candidate in ADMIN_COMMANDS if candidate.name == normalized),
+            None,
+        )
+        if command is None:
+            return f"No help found for {normalized}."
+        return "\n".join(
+            [
+                command.name,
+                command.summary,
+                f"Usage: {command.usage}",
+            ]
+        )
+    lines = [
+        "Commands:",
+        *(command.summary_line() for command in ADMIN_COMMANDS),
+        "",
+        "Use help <command> for detailed usage.",
+        "Example: help setup",
+        "",
+        "Enoch CLI is admin-only. Use the configured chat provider for conversation, "
+        "repository edits, and self-evolution.",
+    ]
+    return "\n".join(lines)
+
+
+def _admin_help(text: str, _identity: Identity, _root: Path) -> str:
+    parts = text.split(maxsplit=1)
+    return admin_help(parts[1] if len(parts) == 2 else "")
+
+
+def _admin_exit(_text: str, _identity: Identity, _root: Path) -> object:
+    return EXIT
+
+
+def _admin_init(text: str, identity: Identity, root: Path) -> str:
+    return _init_instance(identity, text, root)
+
+
+def _admin_status(_text: str, identity: Identity, root: Path) -> str:
+    return _status_text(identity, root)
+
+
+def _admin_setup(text: str, _identity: Identity, root: Path) -> str:
+    return _setup(text, root)
+
+
+def _admin_config(text: str, _identity: Identity, root: Path) -> str:
+    return config_command(text, root, prefix="")
+
+
+def _admin_thinking(text: str, _identity: Identity, root: Path) -> str:
+    return _thinking(text, root)
+
+
+def _admin_mission(text: str, identity: Identity, root: Path) -> str:
+    return _mission(text, identity, root)
+
+
+def _admin_ancestors(text: str, _identity: Identity, root: Path) -> str:
+    return _ancestors(text, root)
+
+
+def _admin_inherit(text: str, _identity: Identity, root: Path) -> str:
+    return _inherit(text, root)
+
+
+def _admin_skills(text: str, _identity: Identity, root: Path) -> str:
+    return _skills(text, root)
+
+
+def _admin_learn(text: str, _identity: Identity, root: Path) -> str:
+    return _learn(text, root)
+
+
+def _admin_doctor(_text: str, _identity: Identity, root: Path) -> str:
+    return _doctor_text(root)
+
+
+def _admin_update(_text: str, _identity: Identity, root: Path) -> str:
+    return _update(root)
 
 
 def _status(identity: Identity, root: Path) -> None:

--- a/src/enoch/codex_sessions.py
+++ b/src/enoch/codex_sessions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from enoch.memory.paths import atomic_write, now as current_time
 from enoch.paths import enoch_home
+from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
 SCHEMA_VERSION = 1
@@ -27,7 +28,8 @@ def codex_sessions_path(root: Path | None = None) -> Path:
 
 
 def load_codex_session(key: str, root: Path | None = None) -> CodexSessionState | None:
-    data = _load_sessions(root)
+    with file_transaction(codex_sessions_path(root)):
+        data = _load_sessions(root)
     raw = data.get("sessions", {}).get(key)
     if not isinstance(raw, dict):
         return None
@@ -47,25 +49,27 @@ def load_codex_session(key: str, root: Path | None = None) -> CodexSessionState 
 
 
 def save_codex_session(state: CodexSessionState, root: Path | None = None) -> CodexSessionState:
-    data = _load_sessions(root)
-    sessions = data.setdefault("sessions", {})
-    sessions[state.key] = {
-        "session_id": state.session_id,
-        "turn_count": state.turn_count,
-        "created_at": state.created_at,
-        "updated_at": state.updated_at,
-        "prompt_version": PROMPT_VERSION,
-    }
-    _write_sessions(data, root)
+    with file_transaction(codex_sessions_path(root)):
+        data = _load_sessions(root)
+        sessions = data.setdefault("sessions", {})
+        sessions[state.key] = {
+            "session_id": state.session_id,
+            "turn_count": state.turn_count,
+            "created_at": state.created_at,
+            "updated_at": state.updated_at,
+            "prompt_version": PROMPT_VERSION,
+        }
+        _write_sessions(data, root)
     return state
 
 
 def forget_codex_session(key: str, root: Path | None = None) -> None:
-    data = _load_sessions(root)
-    sessions = data.setdefault("sessions", {})
-    if key in sessions:
-        del sessions[key]
-        _write_sessions(data, root)
+    with file_transaction(codex_sessions_path(root)):
+        data = _load_sessions(root)
+        sessions = data.setdefault("sessions", {})
+        if key in sessions:
+            del sessions[key]
+            _write_sessions(data, root)
 
 
 def record_codex_session_turn(
@@ -90,15 +94,13 @@ def record_codex_session_turn(
 
 def _load_sessions(root: Path | None = None) -> dict:
     path = codex_sessions_path(root)
-    if not path.exists():
-        return {"schema_version": SCHEMA_VERSION, "sessions": {}}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {"schema_version": SCHEMA_VERSION, "sessions": {}}
+    data = load_json_object(
+        path,
+        default_factory=lambda: {"schema_version": SCHEMA_VERSION, "sessions": {}},
+    )
     sessions = data.get("sessions")
     if not isinstance(sessions, dict):
-        sessions = {}
+        raise StateCorruptionError(path, "expected sessions to be an object")
     return {"schema_version": SCHEMA_VERSION, "sessions": sessions}
 
 

--- a/src/enoch/config.py
+++ b/src/enoch/config.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from enoch.paths import enoch_home
+from enoch.state import atomic_write, file_transaction
 
 
 def config_path(root: Path | None = None) -> Path:
@@ -27,39 +29,36 @@ def write_section_value(
     root: Path | None = None,
 ) -> None:
     path = config_path(root)
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        lines = []
+    with file_transaction(path):
+        lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
 
-    section_index = _find_section(lines, section)
-    formatted = f"  {key}: {_quote_yaml(value)}" if value is not None else ""
-    if section_index is None:
-        if value is None:
-            return
-        if lines and lines[-1].strip():
-            lines.append("")
-        lines.extend([f"{section}:", formatted])
-    else:
-        insert_at = _section_end(lines, section_index)
-        key_index = _find_key(lines, section_index, insert_at, key)
-        if key_index is None:
-            if value is not None:
-                lines.insert(insert_at, formatted)
-        elif value is None:
-            del lines[key_index]
+        section_index = _find_section(lines, section)
+        formatted = f"  {key}: {_quote_yaml(value)}" if value is not None else ""
+        if section_index is None:
+            if value is None:
+                return
+            if lines and lines[-1].strip():
+                lines.append("")
+            lines.extend([f"{section}:", formatted])
         else:
-            lines[key_index] = formatted
+            insert_at = _section_end(lines, section_index)
+            key_index = _find_key(lines, section_index, insert_at, key)
+            if key_index is None:
+                if value is not None:
+                    lines.insert(insert_at, formatted)
+            elif value is None:
+                del lines[key_index]
+            else:
+                lines[key_index] = formatted
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        atomic_write(path, "\n".join(lines).rstrip() + "\n")
 
 
 def _parse_simple_yaml(text: str) -> dict[str, dict[str, str]]:
     data: dict[str, dict[str, str]] = {}
     current: str | None = None
     for raw_line in text.splitlines():
-        line = raw_line.split("#", 1)[0].rstrip()
+        line = _strip_yaml_comment(raw_line).rstrip()
         if not line.strip():
             continue
         if not line.startswith((" ", "\t")) and line.endswith(":"):
@@ -75,7 +74,7 @@ def _parse_simple_yaml(text: str) -> dict[str, dict[str, str]]:
 
 def _find_section(lines: list[str], section: str) -> int | None:
     for index, raw_line in enumerate(lines):
-        line = raw_line.split("#", 1)[0].rstrip()
+        line = _strip_yaml_comment(raw_line).rstrip()
         if not line.startswith((" ", "\t")) and line.endswith(":") and line[:-1].strip() == section:
             return index
     return None
@@ -91,7 +90,7 @@ def _section_end(lines: list[str], section_index: int) -> int:
 
 def _find_key(lines: list[str], start: int, end: int, key: str) -> int | None:
     for index in range(start + 1, end):
-        line = lines[index].split("#", 1)[0].rstrip()
+        line = _strip_yaml_comment(lines[index]).rstrip()
         if not line.startswith((" ", "\t")) or ":" not in line:
             continue
         found, _separator, _value = line.partition(":")
@@ -109,6 +108,37 @@ def _quote_yaml(value: str | None) -> str:
 
 def _clean_value(value: str) -> str:
     value = value.strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"Invalid quoted configuration value: {error.msg}.") from error
+        if not isinstance(decoded, str):
+            raise ValueError("Quoted configuration values must be strings.")
+        return decoded
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1].replace("''", "'")
     return value
+
+
+def _strip_yaml_comment(line: str) -> str:
+    quote = ""
+    escaped = False
+    for index, character in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if quote == '"' and character == "\\":
+            escaped = True
+            continue
+        if character in {"'", '"'}:
+            if not quote:
+                quote = character
+            elif quote == character:
+                if quote == "'" and index + 1 < len(line) and line[index + 1] == "'":
+                    continue
+                quote = ""
+            continue
+        if character == "#" and not quote:
+            return line[:index]
+    return line

--- a/src/enoch/cron.py
+++ b/src/enoch/cron.py
@@ -1,26 +1,19 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 import re
-import threading
-
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - fcntl is unavailable on Windows.
-    fcntl = None
+from uuid import uuid4
 
 from enoch.memory.paths import atomic_write, now as current_time
 from enoch.paths import enoch_home
 from enoch.providers.contracts import ConversationId, normalize_conversation_id
+from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
-SCHEMA_VERSION = 1
-HISTORY_LIMIT = 20
-_CRON_THREAD_LOCK = threading.RLock()
+SCHEMA_VERSION = 3
 _INTERVAL_PATTERN = re.compile(
     r"^\s*(?P<count>\d+)\s*(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
     re.IGNORECASE,
@@ -41,6 +34,9 @@ class CronJob:
     last_task_id: int | None = None
     context: str = ""
     context_source: str = ""
+    claim_id: str = ""
+    claimed_at: str = ""
+    idempotency_key: str = ""
 
 
 @dataclass(frozen=True)
@@ -92,6 +88,7 @@ def add_cron_job(
     context: str = "",
     context_source: str = "",
     now: datetime | None = None,
+    idempotency_key: str = "",
 ) -> CronJob:
     cleaned = " ".join(text.split())
     if not cleaned:
@@ -101,6 +98,18 @@ def add_cron_job(
     current = _coerce_utc(now) if now is not None else _utc_now()
     with _cron_transaction(root):
         data = _load_cron(root)
+        normalized_key = idempotency_key.strip()
+        if normalized_key:
+            existing = next(
+                (
+                    job
+                    for job in [*_active_jobs(data), *_history_jobs(data)]
+                    if job.idempotency_key == normalized_key
+                ),
+                None,
+            )
+            if existing is not None:
+                return existing
         job = CronJob(
             id=_next_id(data),
             chat_id=chat_id,
@@ -110,6 +119,7 @@ def add_cron_job(
             next_run_at=_iso(current + timedelta(seconds=interval_seconds)),
             context=context.strip(),
             context_source=context_source.strip(),
+            idempotency_key=normalized_key,
         )
         active = data.setdefault("active", [])
         active.append(_job_to_dict(job))
@@ -133,7 +143,7 @@ def cancel_cron_job(job_id: int, root: Path | None = None) -> CronJob | None:
         history = _history_jobs(data)
         history.append(cancelled)
         data["active"] = [_job_to_dict(job) for job in kept]
-        data["history"] = [_job_to_dict(job) for job in history[-HISTORY_LIMIT:]]
+        data["history"] = [_job_to_dict(job) for job in history]
         _write_cron(data, root)
         return cancelled
 
@@ -145,32 +155,58 @@ def claim_due_cron_jobs(root: Path | None = None, *, now: datetime | None = None
         claimed: list[CronJob] = []
         active: list[CronJob] = []
         for job in _active_jobs(data):
+            if job.claim_id:
+                claimed.append(job)
+                active.append(job)
+                continue
             next_run_at = _parse_time(job.next_run_at)
             if next_run_at is None or next_run_at > current:
                 active.append(job)
                 continue
-            claimed.append(job)
-            active.append(
-                _replace_job(
-                    job,
-                    last_run_at=_iso(current),
-                    next_run_at=_iso(current + timedelta(seconds=job.interval_seconds)),
-                )
+            claimed_job = _replace_job(
+                job,
+                claim_id=f"cron-{job.id}-{uuid4().hex}",
+                claimed_at=_iso(current),
             )
+            claimed.append(claimed_job)
+            active.append(claimed_job)
         if claimed:
             data["active"] = [_job_to_dict(job) for job in active]
             _write_cron(data, root)
         return tuple(claimed)
 
 
-def record_cron_task(cron_id: int, task_id: int, root: Path | None = None) -> CronJob | None:
+def record_cron_task(
+    cron_id: int,
+    task_id: int,
+    root: Path | None = None,
+    *,
+    claim_id: str = "",
+    now: datetime | None = None,
+) -> CronJob | None:
+    current = _coerce_utc(now) if now is not None else _utc_now()
     with _cron_transaction(root):
         data = _load_cron(root)
         active: list[CronJob] = []
         changed: CronJob | None = None
         for job in _active_jobs(data):
             if job.id == cron_id and changed is None:
-                job = _replace_job(job, last_task_id=task_id)
+                if claim_id and job.claim_id != claim_id:
+                    active.append(job)
+                    continue
+                changes: dict[str, object] = {"last_task_id": task_id}
+                if job.claim_id and claim_id:
+                    changes.update(
+                        {
+                            "last_run_at": job.claimed_at or _iso(current),
+                            "next_run_at": _iso(
+                                current + timedelta(seconds=job.interval_seconds)
+                            ),
+                            "claim_id": "",
+                            "claimed_at": "",
+                        }
+                    )
+                job = _replace_job(job, **changes)
                 changed = job
             active.append(job)
         if changed is None:
@@ -193,14 +229,12 @@ def cron_status(root: Path | None = None) -> CronStatus:
 
 def _load_cron(root: Path | None = None) -> dict:
     path = cron_path(root)
-    if not path.exists():
-        return _empty_cron()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return _empty_cron()
-    if not isinstance(raw, dict):
-        return _empty_cron()
+    raw = load_json_object(path, default_factory=_empty_cron)
+    for key in ("active", "history"):
+        if key in raw and not isinstance(raw[key], list):
+            raise StateCorruptionError(path, f"expected {key} to be a list")
+        if any(_parse_job(item) is None for item in raw.get(key, [])):
+            raise StateCorruptionError(path, f"found an invalid cron job in {key}")
     active_jobs = _active_jobs(raw)
     history_jobs = _history_jobs(raw)
     next_id = _int(raw.get("next_id"), default=1)
@@ -211,7 +245,7 @@ def _load_cron(root: Path | None = None) -> dict:
         "schema_version": SCHEMA_VERSION,
         "next_id": max(next_id, max_id + 1),
         "active": [_job_to_dict(job) for job in active_jobs],
-        "history": [_job_to_dict(job) for job in history_jobs[-HISTORY_LIMIT:]],
+        "history": [_job_to_dict(job) for job in history_jobs],
     }
 
 
@@ -220,25 +254,13 @@ def _write_cron(data: dict, root: Path | None = None) -> None:
         "schema_version": SCHEMA_VERSION,
         "next_id": _next_id(data),
         "active": [_job_to_dict(job) for job in _active_jobs(data)],
-        "history": [_job_to_dict(job) for job in _history_jobs(data)][-HISTORY_LIMIT:],
+        "history": [_job_to_dict(job) for job in _history_jobs(data)],
     }
     atomic_write(cron_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
-@contextmanager
 def _cron_transaction(root: Path | None = None):
-    path = cron_path(root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    with _CRON_THREAD_LOCK:
-        with lock_path.open("a", encoding="utf-8") as lock_file:
-            if fcntl is not None:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                if fcntl is not None:
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+    return file_transaction(cron_path(root))
 
 
 def _active_jobs(data: dict) -> list[CronJob]:
@@ -272,6 +294,9 @@ def _parse_job(raw: object) -> CronJob | None:
     last_task_id = _optional_int(raw.get("last_task_id"))
     context = str(raw.get("context") or "").strip()
     context_source = str(raw.get("context_source") or "").strip()
+    claim_id = str(raw.get("claim_id") or "").strip()
+    claimed_at = str(raw.get("claimed_at") or "").strip()
+    idempotency_key = str(raw.get("idempotency_key") or "").strip()
     if job_id <= 0 or chat_id is None or interval_seconds <= 0 or not text:
         return None
     return CronJob(
@@ -287,6 +312,9 @@ def _parse_job(raw: object) -> CronJob | None:
         last_task_id=last_task_id,
         context=context,
         context_source=context_source,
+        claim_id=claim_id,
+        claimed_at=claimed_at,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -306,6 +334,9 @@ def _job_to_dict(job: CronJob | None) -> dict:
         "last_task_id": job.last_task_id,
         "context": job.context,
         "context_source": job.context_source,
+        "claim_id": job.claim_id,
+        "claimed_at": job.claimed_at,
+        "idempotency_key": job.idempotency_key,
     }
 
 
@@ -323,6 +354,9 @@ def _replace_job(job: CronJob, **changes: object) -> CronJob:
         "last_task_id": job.last_task_id,
         "context": job.context,
         "context_source": job.context_source,
+        "claim_id": job.claim_id,
+        "claimed_at": job.claimed_at,
+        "idempotency_key": job.idempotency_key,
     }
     values.update(changes)
     return CronJob(**values)

--- a/src/enoch/evolution/core.py
+++ b/src/enoch/evolution/core.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from pathlib import Path
 from typing import Callable, Iterable
+from uuid import uuid4
 
 from enoch.backlog import BacklogItem, backlog_status
 from enoch.automatic_learning import LearningArtifact, learning_index_path
@@ -37,9 +38,10 @@ from enoch.lineage.core import LineageCandidate, load_parent_inbox_candidates
 from enoch.memory.paths import atomic_write, clean_text, now as current_time
 from enoch.paths import enoch_home
 from enoch.tasks.queue import TaskJob, task_queue_status
+from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 CANDIDATE_SCHEMA_VERSION = 4
 MODE_DISABLED = "disabled"
 MODE_CO_EVOLVE = "co-evolve"
@@ -75,6 +77,8 @@ class EvolveState:
     schedule_cron_expression: str = ""
     schedule_next_run_at: str = ""
     schedule_last_run_at: str = ""
+    schedule_claim_id: str = ""
+    schedule_claimed_at: str = ""
 
 
 @dataclass(frozen=True)
@@ -132,14 +136,14 @@ def evolve_brainstorm_fallback_path(root: Path | None = None) -> Path:
 
 
 def load_evolve_state(root: Path | None = None) -> EvolveState:
+    with file_transaction(evolve_state_path(root)):
+        return _load_evolve_state_unlocked(root)
+
+
+def _load_evolve_state_unlocked(root: Path | None = None) -> EvolveState:
     path = evolve_state_path(root)
-    if not path.exists():
-        return EvolveState()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return EvolveState()
-    if not isinstance(raw, dict):
+    raw = load_json_object(path)
+    if not raw:
         return EvolveState()
     mode = normalize_evolve_mode(str(raw.get("mode") or DEFAULT_MODE))
     theme = clean_text(str(raw.get("theme") or ""))
@@ -157,10 +161,20 @@ def load_evolve_state(root: Path | None = None) -> EvolveState:
         ),
         schedule_next_run_at=str(raw.get("schedule_next_run_at") or ""),
         schedule_last_run_at=str(raw.get("schedule_last_run_at") or ""),
+        schedule_claim_id=str(raw.get("schedule_claim_id") or ""),
+        schedule_claimed_at=str(raw.get("schedule_claimed_at") or ""),
     )
 
 
 def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveState:
+    with file_transaction(evolve_state_path(root)):
+        return _save_evolve_state_unlocked(state, root)
+
+
+def _save_evolve_state_unlocked(
+    state: EvolveState,
+    root: Path | None = None,
+) -> EvolveState:
     normalized = EvolveState(
         mode=normalize_evolve_mode(state.mode),
         theme=clean_text(state.theme),
@@ -176,6 +190,8 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
         schedule_cron_expression=_normalize_cron_expression(state.schedule_cron_expression, allow_empty=True),
         schedule_next_run_at=state.schedule_next_run_at,
         schedule_last_run_at=state.schedule_last_run_at,
+        schedule_claim_id=state.schedule_claim_id,
+        schedule_claimed_at=state.schedule_claimed_at,
     )
     payload = {
         "schema_version": SCHEMA_VERSION,
@@ -188,6 +204,8 @@ def save_evolve_state(state: EvolveState, root: Path | None = None) -> EvolveSta
         "schedule_cron_expression": normalized.schedule_cron_expression,
         "schedule_next_run_at": normalized.schedule_next_run_at,
         "schedule_last_run_at": normalized.schedule_last_run_at,
+        "schedule_claim_id": normalized.schedule_claim_id,
+        "schedule_claimed_at": normalized.schedule_claimed_at,
     }
     atomic_write(evolve_state_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
     return normalized
@@ -307,30 +325,54 @@ def disable_evolve_schedule(root: Path | None = None) -> EvolveState:
 
 
 def claim_due_evolve_schedule(root: Path | None = None, *, now: datetime | None = None) -> EvolveState | None:
-    state = load_evolve_state(root)
-    if not state.schedule_enabled or state.schedule_interval_seconds <= 0:
-        return None
-    current_source = now if now is not None else _local_now()
-    current = _coerce_utc(current_source)
-    next_run_at = _parse_time(state.schedule_next_run_at)
-    if next_run_at is None or next_run_at > current:
-        return None
-    claimed = state
-    next_run_at = _next_scheduled_run(state, current_source)
-    save_evolve_state(
-        EvolveState(
-            mode=state.mode,
-            theme=state.theme,
-            schedule_enabled=True,
-            schedule_interval_seconds=state.schedule_interval_seconds,
-            schedule_daily_time=state.schedule_daily_time,
-            schedule_cron_expression=state.schedule_cron_expression,
-            schedule_next_run_at=_iso(next_run_at),
-            schedule_last_run_at=_iso(current),
-        ),
-        root,
-    )
-    return claimed
+    path = evolve_state_path(root)
+    with file_transaction(path):
+        state = _load_evolve_state_unlocked(root)
+        if not state.schedule_enabled or state.schedule_interval_seconds <= 0:
+            return None
+        if state.schedule_claim_id:
+            return state
+        current_source = now if now is not None else _local_now()
+        current = _coerce_utc(current_source)
+        next_run_at = _parse_time(state.schedule_next_run_at)
+        if next_run_at is None or next_run_at > current:
+            return None
+        claimed = EvolveState(
+            **{
+                **state.__dict__,
+                "schedule_claim_id": f"evolve-{uuid4().hex}",
+                "schedule_claimed_at": _iso(current),
+            }
+        )
+        _save_evolve_state_unlocked(claimed, root)
+        return claimed
+
+
+def acknowledge_evolve_schedule(
+    claim_id: str,
+    root: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> EvolveState | None:
+    path = evolve_state_path(root)
+    with file_transaction(path):
+        state = _load_evolve_state_unlocked(root)
+        if not claim_id.strip() or state.schedule_claim_id != claim_id.strip():
+            return None
+        current_source = now if now is not None else _local_now()
+        current = _coerce_utc(current_source)
+        acknowledged = EvolveState(
+            **{
+                **state.__dict__,
+                "schedule_next_run_at": _iso(
+                    _next_scheduled_run(state, current_source)
+                ),
+                "schedule_last_run_at": state.schedule_claimed_at or _iso(current),
+                "schedule_claim_id": "",
+                "schedule_claimed_at": "",
+            }
+        )
+        return _save_evolve_state_unlocked(acknowledged, root)
 
 
 def normalize_evolve_mode(mode: str) -> str:
@@ -520,30 +562,29 @@ def _claim_auto_brainstorm(
     if not normalized_theme:
         return False
     path = evolve_brainstorm_fallback_path(root)
-    attempts: dict[str, str] = {}
-    if path.exists():
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            raw = {}
-        raw_attempts = raw.get("attempts") if isinstance(raw, dict) else None
-        if isinstance(raw_attempts, dict):
-            attempts = {
-                clean_text(str(key)).casefold(): str(value)
-                for key, value in raw_attempts.items()
-                if clean_text(str(key))
-            }
-    current = _coerce_utc(now) if now is not None else _utc_now()
-    previous = _parse_time(attempts.get(normalized_theme, ""))
-    if previous is not None and current - previous < timedelta(seconds=AUTO_BRAINSTORM_COOLDOWN_SECONDS):
-        return False
-    attempts[normalized_theme] = _iso(current)
-    payload = {
-        "schema_version": 1,
-        "attempts": attempts,
-    }
-    atomic_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    return True
+    with file_transaction(path):
+        raw = load_json_object(path)
+        raw_attempts = raw.get("attempts") if raw else None
+        if raw_attempts is not None and not isinstance(raw_attempts, dict):
+            raise StateCorruptionError(path, "expected attempts to be an object")
+        attempts = {
+            clean_text(str(key)).casefold(): str(value)
+            for key, value in (raw_attempts or {}).items()
+            if clean_text(str(key))
+        }
+        current = _coerce_utc(now) if now is not None else _utc_now()
+        previous = _parse_time(attempts.get(normalized_theme, ""))
+        if previous is not None and current - previous < timedelta(
+            seconds=AUTO_BRAINSTORM_COOLDOWN_SECONDS
+        ):
+            return False
+        attempts[normalized_theme] = _iso(current)
+        payload = {
+            "schema_version": 1,
+            "attempts": attempts,
+        }
+        atomic_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        return True
 
 
 def collect_evolve_candidates(
@@ -977,23 +1018,18 @@ def rank_evolve_candidates(
 
 def _load_all_evolve_candidates(root: Path | None = None) -> tuple[EvolveCandidate, ...]:
     path = evolve_candidates_path(root)
-    if not path.exists():
-        return ()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return ()
-    if not isinstance(raw, dict):
+    raw = load_json_object(path)
+    if not raw:
         return ()
     raw_candidates = raw.get("candidates")
     if not isinstance(raw_candidates, list):
-        return ()
+        raise StateCorruptionError(path, "expected candidates to be a list")
     candidates = []
     for raw_candidate in raw_candidates:
-        if isinstance(raw_candidate, dict):
-            candidate = _candidate_from_json(raw_candidate)
-            if candidate is not None:
-                candidates.append(candidate)
+        candidate = _candidate_from_json(raw_candidate) if isinstance(raw_candidate, dict) else None
+        if candidate is None:
+            raise StateCorruptionError(path, "found an invalid evolve candidate")
+        candidates.append(candidate)
     return tuple(candidates)
 
 

--- a/src/enoch/evolution/lifecycle.py
+++ b/src/enoch/evolution/lifecycle.py
@@ -14,6 +14,7 @@ from enoch.evolution.events import (
 from enoch.vcs_tools import VcsError, revision_is_ancestor
 from enoch.memory.paths import atomic_write
 from enoch.paths import enoch_home
+from enoch.state import StateCorruptionError, load_json_object
 from enoch.providers.contracts import (
     ForgeProvider,
     ForgeProviderError,
@@ -357,13 +358,12 @@ def _is_ancestor(revision: str, descendant: str, root: Path) -> bool:
 
 def _load_pending_adoptions(root: Path) -> tuple[PendingAdoption, ...]:
     path = pending_adoption_path(root)
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    data = load_json_object(path)
+    if not data:
         return ()
-    raw_items = data.get("adoptions") if isinstance(data, dict) else None
+    raw_items = data.get("adoptions")
     if not isinstance(raw_items, list):
-        return ()
+        raise StateCorruptionError(path, "expected adoptions to be a list")
     items = []
     default_branch = authoritative_branch_name(root)
     for raw in raw_items:

--- a/src/enoch/immune.py
+++ b/src/enoch/immune.py
@@ -13,7 +13,7 @@ from enoch.providers.contracts import AgentRuntimeError, VersionControlProviderE
 from enoch.providers.registry import ProviderError, load_provider, provider_name
 
 
-DEFAULT_TEST_ARGS = ["-m", "unittest", "discover", "-s", "tests"]
+DEFAULT_TEST_ARGS = ["-m", "unittest", "discover", "-s", "tests", "-t", "."]
 DEFAULT_TIMEOUT_SECONDS = 120
 MAX_OUTPUT_CHARS = 12000
 MIN_PYTHON_VERSION = (3, 11)

--- a/src/enoch/last_codex_input.py
+++ b/src/enoch/last_codex_input.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from enoch.memory.paths import atomic_write, now
 from enoch.paths import enoch_home
+from enoch.state import load_json_object
 
 
 def last_codex_input_path(root: Path | None = None) -> Path:
@@ -63,11 +64,7 @@ def _load_last_codex_input(root: Path | None = None) -> dict[str, Any] | None:
     path = last_codex_input_path(root)
     if not path.exists():
         return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    return data if isinstance(data, dict) else None
+    return load_json_object(path)
 
 
 def _yes_no(value: object) -> str:

--- a/src/enoch/memory/paths.py
+++ b/src/enoch/memory/paths.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from enoch.paths import enoch_home
+from enoch.state import atomic_write
 
 
 def memory_dir(root: Path | None = None) -> Path:
@@ -13,13 +14,6 @@ def memory_dir(root: Path | None = None) -> Path:
 
 def long_term_memory_path(root: Path | None = None) -> Path:
     return memory_dir(root) / "long_term.json"
-
-
-def atomic_write(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_suffix(path.suffix + ".tmp")
-    temp_path.write_text(text, encoding="utf-8")
-    temp_path.replace(path)
 
 
 def now() -> str:

--- a/src/enoch/memory/store.py
+++ b/src/enoch/memory/store.py
@@ -17,6 +17,7 @@ from enoch.memory.paths import (
     normalize,
     now as current_time,
 )
+from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
 SCHEMA_VERSION = 1
@@ -78,49 +79,55 @@ def apply_memory_candidates(
         return []
 
     settings = memory_settings(root)
-    data = load_long_term_memory(root)
-    memories = data["memories"]
-    timestamp = current_time()
-    changed = False
-    written: list[dict[str, Any]] = []
+    path = long_term_memory_path(root)
+    with file_transaction(path):
+        data = _load_long_term_memory_unlocked(root, create=True)
+        memories = data["memories"]
+        timestamp = current_time()
+        changed = False
+        written: list[dict[str, Any]] = []
 
-    for raw_candidate in candidates:
-        candidate = _validated_memory_candidate(raw_candidate, settings, source_ref)
-        if candidate is None:
-            continue
-        existing = _matching_memory(memories, candidate)
-        if existing is not None:
-            existing.update(
+        for raw_candidate in candidates:
+            candidate = _validated_memory_candidate(raw_candidate, settings, source_ref)
+            if candidate is None:
+                continue
+            existing = _matching_memory(memories, candidate)
+            if existing is not None:
+                existing.update(
+                    {
+                        "text": candidate["text"],
+                        "updated_at": timestamp,
+                        "confidence": _stronger_confidence(
+                            existing.get("confidence"), candidate["confidence"]
+                        ),
+                        "sensitivity": _stronger_sensitivity(
+                            existing.get("sensitivity"), candidate["sensitivity"]
+                        ),
+                        "tags": _merged_list(existing.get("tags"), candidate["tags"]),
+                        "source_refs": _merged_list(
+                            existing.get("source_refs"), candidate["source_refs"]
+                        ),
+                    }
+                )
+                written.append(existing)
+                changed = True
+                continue
+
+            candidate.update(
                 {
-                    "text": candidate["text"],
+                    "id": _new_memory_id(memories, timestamp),
+                    "created_at": timestamp,
                     "updated_at": timestamp,
-                    "confidence": _stronger_confidence(existing.get("confidence"), candidate["confidence"]),
-                    "sensitivity": _stronger_sensitivity(
-                        existing.get("sensitivity"), candidate["sensitivity"]
-                    ),
-                    "tags": _merged_list(existing.get("tags"), candidate["tags"]),
-                    "source_refs": _merged_list(existing.get("source_refs"), candidate["source_refs"]),
+                    "last_used_at": None,
                 }
             )
-            written.append(existing)
+            memories.append(candidate)
+            written.append(candidate)
             changed = True
-            continue
 
-        candidate.update(
-            {
-                "id": _new_memory_id(memories, timestamp),
-                "created_at": timestamp,
-                "updated_at": timestamp,
-                "last_used_at": None,
-            }
-        )
-        memories.append(candidate)
-        written.append(candidate)
-        changed = True
-
-    if changed:
-        write_long_term_memory(data, root)
-    return written
+        if changed:
+            _write_long_term_memory_unlocked(data, root)
+        return written
 
 
 def forget_memory(query: str, root: Path | None = None) -> ForgetResult:
@@ -128,30 +135,37 @@ def forget_memory(query: str, root: Path | None = None) -> ForgetResult:
     if not normalized:
         return ForgetResult(0, 0, "Tell Enoch which memory to forget.")
 
-    data = load_long_term_memory(root)
-    matches = [
-        memory
-        for memory in data["memories"]
-        if (
-            normalized == normalize(str(memory.get("id") or ""))
-            or normalized in normalize(str(memory.get("text") or ""))
-            or normalized in normalize(" ".join(str(tag) for tag in memory.get("tags") or []))
-        )
-    ]
-    if not matches:
-        return ForgetResult(0, 0, f"No long-term memory matched `{query}`.")
-    if len(matches) > 1 and not any(normalized == normalize(str(match.get("id") or "")) for match in matches):
-        ids = ", ".join(str(match.get("id")) for match in matches[:5])
-        return ForgetResult(len(matches), 0, f"Multiple memories matched. Use one id: {ids}")
+    path = long_term_memory_path(root)
+    with file_transaction(path):
+        data = _load_long_term_memory_unlocked(root, create=True)
+        matches = [
+            memory
+            for memory in data["memories"]
+            if (
+                normalized == normalize(str(memory.get("id") or ""))
+                or normalized in normalize(str(memory.get("text") or ""))
+                or normalized
+                in normalize(" ".join(str(tag) for tag in memory.get("tags") or []))
+            )
+        ]
+        if not matches:
+            return ForgetResult(0, 0, f"No long-term memory matched `{query}`.")
+        if len(matches) > 1 and not any(
+            normalized == normalize(str(match.get("id") or "")) for match in matches
+        ):
+            ids = ", ".join(str(match.get("id")) for match in matches[:5])
+            return ForgetResult(len(matches), 0, f"Multiple memories matched. Use one id: {ids}")
 
-    target = matches[0]
-    data["memories"] = [memory for memory in data["memories"] if memory is not target]
-    write_long_term_memory(data, root)
-    return ForgetResult(
-        matched=1,
-        forgotten=1,
-        message=f"Deleted long-term memory {target.get('id')}. Raw logs were not redacted.",
-    )
+        target = matches[0]
+        data["memories"] = [
+            memory for memory in data["memories"] if memory is not target
+        ]
+        _write_long_term_memory_unlocked(data, root)
+        return ForgetResult(
+            matched=1,
+            forgotten=1,
+            message=f"Deleted long-term memory {target.get('id')}. Raw logs were not redacted.",
+        )
 
 
 def memory_status(root: Path | None = None) -> str:
@@ -191,31 +205,57 @@ def long_term_for_prompt(root: Path | None, settings: MemorySettings) -> str:
 
 def ensure_long_term_memory(root: Path | None = None) -> None:
     path = long_term_memory_path(root)
-    if path.exists():
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write(path, json.dumps({"schema_version": SCHEMA_VERSION, "memories": []}, indent=2) + "\n")
+    with file_transaction(path):
+        if path.exists():
+            return
+        atomic_write(
+            path,
+            json.dumps({"schema_version": SCHEMA_VERSION, "memories": []}, indent=2)
+            + "\n",
+        )
 
 
 def load_long_term_memory(root: Path | None = None, *, create: bool = True) -> dict[str, Any]:
-    if create:
-        ensure_long_term_memory(root)
     path = long_term_memory_path(root)
-    if not path.exists():
-        return {"schema_version": SCHEMA_VERSION, "memories": []}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {"schema_version": SCHEMA_VERSION, "memories": []}
+    with file_transaction(path):
+        return _load_long_term_memory_unlocked(root, create=create)
+
+
+def _load_long_term_memory_unlocked(
+    root: Path | None = None,
+    *,
+    create: bool,
+) -> dict[str, Any]:
+    path = long_term_memory_path(root)
+    if create and not path.exists():
+        atomic_write(
+            path,
+            json.dumps({"schema_version": SCHEMA_VERSION, "memories": []}, indent=2)
+            + "\n",
+        )
+    data = load_json_object(
+        path,
+        default_factory=lambda: {"schema_version": SCHEMA_VERSION, "memories": []},
+    )
     memories = data.get("memories")
     if not isinstance(memories, list):
-        memories = []
+        raise StateCorruptionError(path, "expected a memories list")
+    if any(not isinstance(memory, dict) for memory in memories):
+        raise StateCorruptionError(path, "found an invalid memory entry")
     return {"schema_version": SCHEMA_VERSION, "memories": memories}
 
 
 def write_long_term_memory(data: dict[str, Any], root: Path | None = None) -> None:
     path = long_term_memory_path(root)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    with file_transaction(path):
+        _write_long_term_memory_unlocked(data, root)
+
+
+def _write_long_term_memory_unlocked(
+    data: dict[str, Any],
+    root: Path | None = None,
+) -> None:
+    path = long_term_memory_path(root)
     atomic_write(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
 
 

--- a/src/enoch/paths.py
+++ b/src/enoch/paths.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 
@@ -12,4 +13,14 @@ def repo_root(start: Path | None = None) -> Path:
 
 
 def enoch_home(root: Path | None = None) -> Path:
-    return repo_root(root) / ".enoch"
+    resolved_root = repo_root(root)
+    redirected_root = os.environ.get("ENOCH_STATE_REDIRECT_ROOT", "").strip()
+    redirected_home = os.environ.get("ENOCH_STATE_HOME", "").strip()
+    if redirected_root and redirected_home:
+        try:
+            matches = resolved_root == Path(redirected_root).expanduser().resolve()
+        except OSError:
+            matches = False
+        if matches:
+            return Path(redirected_home).expanduser().resolve()
+    return resolved_root / ".enoch"

--- a/src/enoch/profiles/contracts.py
+++ b/src/enoch/profiles/contracts.py
@@ -16,7 +16,7 @@ from enoch.providers.contracts import (
 from enoch.tasks.queue import TaskJob
 
 
-PROFILE_API_VERSION = 1
+PROFILE_API_VERSION = 2
 PromptPurpose = Literal["conversation", "image", "task-context", "task"]
 TaskEnqueuer = Callable[[str, str], TaskJob]
 
@@ -63,19 +63,14 @@ class CommandSpec:
     summary: str
     handler: CommandHandler
     usage: str = ""
-    aliases: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         name = _command_name(self.name)
-        aliases = tuple(_command_name(alias) for alias in self.aliases)
-        if name in aliases or len(set(aliases)) != len(aliases):
-            raise ProfileError(f"Profile command /{name} has duplicate aliases.")
         if not self.summary.strip():
             raise ProfileError(f"Profile command /{name} requires a summary.")
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "summary", self.summary.strip())
         object.__setattr__(self, "usage", self.usage.strip())
-        object.__setattr__(self, "aliases", aliases)
 
     @property
     def command(self) -> str:
@@ -86,7 +81,7 @@ class CommandSpec:
             normalized = _command_name(command)
         except ProfileError:
             return False
-        return normalized == self.name or normalized in self.aliases
+        return normalized == self.name
 
 
 @dataclass(frozen=True)
@@ -200,10 +195,9 @@ class AgentProfile:
             )
         seen: set[str] = set()
         for spec in self.commands:
-            for command_name in (spec.name, *spec.aliases):
-                if command_name in seen:
-                    raise ProfileError(f"Duplicate profile command /{command_name}.")
-                seen.add(command_name)
+            if spec.name in seen:
+                raise ProfileError(f"Duplicate profile command /{spec.name}.")
+            seen.add(spec.name)
         object.__setattr__(self, "name", name)
 
     @property
@@ -224,7 +218,7 @@ class AgentProfile:
             (
                 spec
                 for spec in self.commands
-                if normalized == spec.name or normalized in spec.aliases
+                if normalized == spec.name
             ),
             None,
         )

--- a/src/enoch/providers/forge.py
+++ b/src/enoch/providers/forge.py
@@ -80,6 +80,7 @@ class LocalForgeProvider:
         *,
         root: Path | None = None,
         allowed_files: list[str] | tuple[str, ...] | None = None,
+        validation_result: object | None = None,
         **_kwargs: Any,
     ) -> LocalPublishResult:
         commit_message = commit_message.strip()
@@ -96,7 +97,7 @@ class LocalForgeProvider:
             files = [path for path in files if path in allowed]
         if not files:
             raise ForgeProviderError("No local changes to publish.")
-        doctor = run_immune_system(root)
+        doctor = validation_result or run_immune_system(root)
         if not doctor.passed:
             raise ForgeProviderError(f"Doctor failed: {doctor.diagnosis.summary}")
         diff = diff_summary(root)

--- a/src/enoch/providers/registry.py
+++ b/src/enoch/providers/registry.py
@@ -175,8 +175,20 @@ def _load_provider_plugins(root: Path | None) -> None:
             continue
         try:
             module = import_module(module_name)
-        except ImportError:
-            continue
+        except ModuleNotFoundError as error:
+            missing = str(error.name or "")
+            if missing and (
+                module_name == missing or module_name.startswith(f"{missing}.")
+            ):
+                continue
+            raise ProviderError(
+                f"Provider module {module_name} could not load dependency "
+                f"{missing or 'unknown'}: {error}"
+            ) from error
+        except ImportError as error:
+            raise ProviderError(
+                f"Provider module {module_name} failed during import: {error}"
+            ) from error
         _register_module_plugins(module_name, getattr(module, PLUGIN_ATTRIBUTE, ()))
         _LOADED_PLUGIN_MODULES.add(module_name)
 

--- a/src/enoch/providers/vcs.py
+++ b/src/enoch/providers/vcs.py
@@ -113,15 +113,12 @@ class GitVersionControlProvider:
         ).returncode == 0
 
     def task_base(self, root: Path | None = None) -> str:
-        try:
-            self.refresh_authoritative(root)
-        except VersionControlProviderError:
-            pass
-        for revision in (self._authoritative_ref(), self.main_branch):
-            if self.resolve_revision(revision, root):
-                return revision
+        self.refresh_authoritative(root)
+        revision = self.resolve_revision(self._authoritative_ref(), root)
+        if revision:
+            return revision
         raise VersionControlProviderError(
-            f"Could not find {self._authoritative_ref()} or local {self.main_branch}."
+            f"Could not resolve freshly fetched task base {self._authoritative_ref()}."
         )
 
     def authoritative_branch(self, root: Path | None = None) -> str:

--- a/src/enoch/state.py
+++ b/src/enoch/state.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import tempfile
+import threading
+from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - fcntl is unavailable on Windows.
+    fcntl = None
+
+
+class StateError(RuntimeError):
+    """Base error for durable Enoch state."""
+
+
+class StateCorruptionError(StateError):
+    """Raised when existing state cannot be decoded without losing data."""
+
+    def __init__(self, path: Path, detail: str) -> None:
+        super().__init__(
+            f"Enoch state at {path} is unreadable ({detail}). "
+            "The file was preserved; repair or move it before retrying."
+        )
+        self.path = path
+        self.detail = detail
+
+
+_LOCKS_GUARD = threading.Lock()
+_THREAD_LOCKS: dict[str, threading.RLock] = {}
+
+
+def load_json_object(
+    path: Path,
+    *,
+    default_factory: Callable[[], dict[str, Any]] = dict,
+) -> dict[str, Any]:
+    """Load a JSON object without converting damaged state into empty state."""
+
+    if not path.exists():
+        return default_factory()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise StateCorruptionError(path, str(error)) from error
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as error:
+        detail = f"invalid JSON at line {error.lineno}, column {error.colno}"
+        raise StateCorruptionError(path, detail) from error
+    if not isinstance(value, dict):
+        raise StateCorruptionError(path, "expected a JSON object")
+    return value
+
+
+def atomic_write(path: Path, text: str) -> None:
+    """Durably replace a file using a unique sibling temporary file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.replace(path)
+        _fsync_directory(path.parent)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+@contextmanager
+def file_transaction(path: Path) -> Iterator[None]:
+    """Serialize read-modify-write operations across threads and processes."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = str(path.resolve())
+    with _LOCKS_GUARD:
+        thread_lock = _THREAD_LOCKS.setdefault(key, threading.RLock())
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with thread_lock:
+        with lock_path.open("a", encoding="utf-8") as lock_file:
+            if fcntl is not None:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if fcntl is not None:
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def _fsync_directory(directory: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    try:
+        descriptor = os.open(directory, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)

--- a/src/enoch/tasks/queue.py
+++ b/src/enoch/tasks/queue.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import json
 import os
 from pathlib import Path
 import re
-import threading
-
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - fcntl is unavailable on Windows.
-    fcntl = None
 
 from enoch.memory.paths import atomic_write, now as current_time
 from enoch.paths import enoch_home
@@ -24,12 +17,12 @@ from enoch.providers.contracts import (
     normalize_message_id,
 )
 from enoch.tasks.events import normalize_task_initiator, normalize_task_source, record_task_event
+from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 9
 DEFAULT_MAX_ATTEMPTS = 3
 PULL_REQUEST_URL_PATTERN = re.compile(r"https://[^\s]+/(?:pull|pulls|merge_requests)/\d+")
-_QUEUE_THREAD_LOCK = threading.RLock()
 
 
 @dataclass(frozen=True)
@@ -75,6 +68,12 @@ class TaskJob:
     runtime_event_types: tuple[str, ...] = ()
     runtime_output_refs: tuple[str, ...] = ()
     runtime_side_effects: tuple[str, ...] = ()
+    idempotency_key: str = ""
+    publish_stage: str = ""
+    commit_sha: str = ""
+    remote_branch: str = ""
+    pr_url: str = ""
+    published_remotely: bool = False
 
 
 @dataclass(frozen=True)
@@ -89,6 +88,12 @@ class TaskQueueStatus:
 
 class TaskRetryError(ValueError):
     pass
+
+
+class TaskAlreadyExists(RuntimeError):
+    def __init__(self, job: TaskJob) -> None:
+        super().__init__(f"Task #{job.id} already exists for this chat update.")
+        self.job = job
 
 
 def task_queue_path(root: Path | None = None) -> Path:
@@ -116,6 +121,7 @@ def enqueue_task(
     source_task_id: int | None = None,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     timeout_seconds: int | None = None,
+    idempotency_key: str = "",
 ) -> TaskJob:
     cleaned = " ".join(text.split())
     if not cleaned:
@@ -126,6 +132,8 @@ def enqueue_task(
     timeout_seconds = _optional_positive_int(timeout_seconds, "Task timeout")
     with _queue_transaction(root):
         data = _load_queue(root)
+        if existing := _find_task_by_idempotency_key(data, idempotency_key):
+            return existing
         job = TaskJob(
             id=_next_id(data),
             chat_id=chat_id,
@@ -146,6 +154,7 @@ def enqueue_task(
             source_task_id=_positive_int(source_task_id),
             max_attempts=max_attempts,
             timeout_seconds=timeout_seconds,
+            idempotency_key=idempotency_key.strip(),
         )
         pending = data.setdefault("pending", [])
         pending.append(_job_to_dict(job))
@@ -227,6 +236,11 @@ def retry_failed_task(
             pr_urls=_pull_request_urls(artifact_result),
             worktree_path=original.worktree_path,
             branch_name=original.branch_name,
+            publish_stage=original.publish_stage,
+            commit_sha=original.commit_sha,
+            remote_branch=original.remote_branch,
+            pr_url=original.pr_url,
+            published_remotely=original.published_remotely,
             max_attempts=original.max_attempts,
             timeout_seconds=original.timeout_seconds,
         )
@@ -272,6 +286,7 @@ def enqueue_task_front(
     source_task_id: int | None = None,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     timeout_seconds: int | None = None,
+    idempotency_key: str = "",
 ) -> TaskJob:
     cleaned = " ".join(text.split())
     if not cleaned:
@@ -282,6 +297,8 @@ def enqueue_task_front(
     timeout_seconds = _optional_positive_int(timeout_seconds, "Task timeout")
     with _queue_transaction(root):
         data = _load_queue(root)
+        if existing := _find_task_by_idempotency_key(data, idempotency_key):
+            return existing
         job = TaskJob(
             id=_next_id(data),
             chat_id=chat_id,
@@ -302,6 +319,7 @@ def enqueue_task_front(
             source_task_id=_positive_int(source_task_id),
             max_attempts=max_attempts,
             timeout_seconds=timeout_seconds,
+            idempotency_key=idempotency_key.strip(),
         )
         pending = data.setdefault("pending", [])
         pending.insert(0, _job_to_dict(job))
@@ -333,6 +351,7 @@ def begin_direct_task(
     source_task_id: int | None = None,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     timeout_seconds: int | None = None,
+    idempotency_key: str = "",
 ) -> TaskJob:
     cleaned = " ".join(text.split())
     if not cleaned:
@@ -343,6 +362,8 @@ def begin_direct_task(
     timeout_seconds = _optional_positive_int(timeout_seconds, "Task timeout")
     with _queue_transaction(root):
         data = _load_queue(root)
+        if existing := _find_task_by_idempotency_key(data, idempotency_key):
+            raise TaskAlreadyExists(existing)
         if _parse_job(data.get("running")) is not None:
             raise RuntimeError("A task is already running.")
         job = TaskJob(
@@ -368,6 +389,7 @@ def begin_direct_task(
             attempt=1,
             max_attempts=max_attempts,
             timeout_seconds=timeout_seconds,
+            idempotency_key=idempotency_key.strip(),
         )
         data["running"] = _job_to_dict(job)
         data["next_id"] = job.id + 1
@@ -756,7 +778,7 @@ def regress_task(
                 updated.append(job)
         if regressed is None:
             return None
-        data["history"] = [_job_to_dict(job) for job in updated[-20:]]
+        data["history"] = [_job_to_dict(job) for job in updated]
         _write_queue(data, root)
         _record_task_event_safely(
             regressed,
@@ -811,7 +833,7 @@ def resolve_regressed_task(
                 updated.append(job)
         if resolved is None:
             return None
-        data["history"] = [_job_to_dict(job) for job in updated[-20:]]
+        data["history"] = [_job_to_dict(job) for job in updated]
         _write_queue(data, root)
         _record_task_event_safely(
             resolved,
@@ -885,6 +907,51 @@ def record_task_result(task_id: int, result: str, root: Path | None = None) -> N
         data["pending"] = pending
         data["running"] = _job_to_dict(running) if running is not None else None
         _write_queue(data, root)
+
+
+def record_task_publish_state(
+    task_id: int,
+    worker_id: str,
+    root: Path | None = None,
+    *,
+    stage: str,
+    commit_sha: str = "",
+    remote_branch: str = "",
+    pr_url: str = "",
+    published_remotely: bool | None = None,
+) -> TaskJob | None:
+    allowed_stages = {"validated", "committed", "pushed", "pr_opened"}
+    if stage not in allowed_stages:
+        raise ValueError(f"Unknown publish stage {stage!r}.")
+    with _queue_transaction(root):
+        data = _load_queue(root)
+        running = _parse_job(data.get("running"))
+        if (
+            running is None
+            or running.id != task_id
+            or not worker_id
+            or running.worker_id != worker_id
+        ):
+            return None
+        updated = _replace_job(
+            running,
+            publish_stage=stage,
+            commit_sha=commit_sha.strip() or running.commit_sha,
+            remote_branch=remote_branch.strip() or running.remote_branch,
+            pr_url=pr_url.strip() or running.pr_url,
+            published_remotely=(
+                running.published_remotely
+                if published_remotely is None
+                else published_remotely
+            ),
+            pr_urls=_merge_pr_urls(
+                running.pr_urls,
+                (pr_url.strip(),) if pr_url.strip() else (),
+            ),
+        )
+        data["running"] = _job_to_dict(updated)
+        _write_queue(data, root)
+        return updated
 
 
 def record_task_runtime_result(
@@ -976,7 +1043,7 @@ def _finish_running_task(
         )
         history.append(finished)
         data["running"] = None
-        data["history"] = [_job_to_dict(job) for job in history[-20:]]
+        data["history"] = [_job_to_dict(job) for job in history]
         _write_queue(data, root)
         _record_task_event_safely(
             finished,
@@ -1018,7 +1085,7 @@ def cancel_task(
         history.append(cancelled)
         data["pending"] = [_job_to_dict(job) for job in kept]
         data["paused"] = [_job_to_dict(job) for job in paused_kept]
-        data["history"] = [_job_to_dict(job) for job in history[-20:]]
+        data["history"] = [_job_to_dict(job) for job in history]
         _write_queue(data, root)
         _record_task_event_safely(
             cancelled,
@@ -1060,7 +1127,7 @@ def cancel_running_task(
         history = _history_jobs(data)
         history.append(cancelled)
         data["running"] = None
-        data["history"] = [_job_to_dict(job) for job in history[-20:]]
+        data["history"] = [_job_to_dict(job) for job in history]
         _write_queue(data, root)
         _record_task_event_safely(
             cancelled,
@@ -1092,7 +1159,7 @@ def recover_interrupted_task(root: Path | None = None) -> TaskJob | None:
             history = _history_jobs(data)
             history.append(completed)
             data["running"] = None
-            data["history"] = [_job_to_dict(job) for job in history[-20:]]
+            data["history"] = [_job_to_dict(job) for job in history]
             _write_queue(data, root)
             _record_task_event_safely(
                 completed,
@@ -1122,7 +1189,7 @@ def recover_interrupted_task(root: Path | None = None) -> TaskJob | None:
             history = _history_jobs(data)
             history.append(failed)
             data["running"] = None
-            data["history"] = [_job_to_dict(job) for job in history[-20:]]
+            data["history"] = [_job_to_dict(job) for job in history]
             _write_queue(data, root)
             _record_task_event_safely(
                 failed,
@@ -1191,14 +1258,16 @@ def _job_has_pull_request(job: TaskJob) -> bool:
 
 def _load_queue(root: Path | None = None) -> dict:
     path = task_queue_path(root)
-    if not path.exists():
-        return _empty_queue()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return _empty_queue()
-    if not isinstance(raw, dict):
-        return _empty_queue()
+    raw = load_json_object(path, default_factory=_empty_queue)
+    for key in ("pending", "paused", "history"):
+        if key in raw and not isinstance(raw[key], list):
+            raise StateCorruptionError(path, f"expected {key} to be a list")
+        if any(_parse_job(item) is None for item in raw.get(key, [])):
+            raise StateCorruptionError(path, f"found an invalid task in {key}")
+    if raw.get("running") is not None and not isinstance(raw.get("running"), dict):
+        raise StateCorruptionError(path, "expected running to be an object or null")
+    if isinstance(raw.get("running"), dict) and _parse_job(raw["running"]) is None:
+        raise StateCorruptionError(path, "found an invalid running task")
     pending = [_job_to_dict(job) for job in _pending_jobs(raw)]
     paused_jobs = _paused_jobs(raw)
     paused = [_job_to_dict(job) for job in paused_jobs]
@@ -1219,7 +1288,7 @@ def _load_queue(root: Path | None = None) -> dict:
         "pending": pending,
         "paused": paused,
         "running": _job_to_dict(running) if running is not None else None,
-        "history": history[-20:],
+        "history": history,
     }
 
 
@@ -1230,25 +1299,13 @@ def _write_queue(data: dict, root: Path | None = None) -> None:
         "pending": [_job_to_dict(job) for job in _pending_jobs(data)],
         "paused": [_job_to_dict(job) for job in _paused_jobs(data)],
         "running": _job_to_dict(_parse_job(data.get("running"))) if _parse_job(data.get("running")) else None,
-        "history": [_job_to_dict(job) for job in _history_jobs(data)][-20:],
+        "history": [_job_to_dict(job) for job in _history_jobs(data)],
     }
     atomic_write(task_queue_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
-@contextmanager
 def _queue_transaction(root: Path | None = None):
-    path = task_queue_path(root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    with _QUEUE_THREAD_LOCK:
-        with lock_path.open("a", encoding="utf-8") as lock_file:
-            if fcntl is not None:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                if fcntl is not None:
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+    return file_transaction(task_queue_path(root))
 
 
 def _pending_jobs(data: dict) -> list[TaskJob]:
@@ -1288,6 +1345,26 @@ def _find_task(data: dict, task_id: int | None) -> TaskJob | None:
         if job.id == task_id:
             return job
     return None
+
+
+def _find_task_by_idempotency_key(data: dict, key: str) -> TaskJob | None:
+    normalized = key.strip()
+    if not normalized:
+        return None
+    running = _parse_job(data.get("running"))
+    return next(
+        (
+            job
+            for job in [
+                *_pending_jobs(data),
+                *_paused_jobs(data),
+                *([running] if running is not None else []),
+                *_history_jobs(data),
+            ]
+            if job.idempotency_key == normalized
+        ),
+        None,
+    )
 
 
 def _find_task_in_status(task_id: int, root: Path | None = None) -> TaskJob | None:
@@ -1347,6 +1424,12 @@ def _parse_job(raw: object) -> TaskJob | None:
     runtime_event_types = _parse_string_tuple(raw.get("runtime_event_types"))
     runtime_output_refs = _parse_string_tuple(raw.get("runtime_output_refs"))
     runtime_side_effects = _parse_string_tuple(raw.get("runtime_side_effects"))
+    idempotency_key = str(raw.get("idempotency_key") or "").strip()
+    publish_stage = str(raw.get("publish_stage") or "").strip()
+    commit_sha = str(raw.get("commit_sha") or "").strip()
+    remote_branch = str(raw.get("remote_branch") or "").strip()
+    pr_url = str(raw.get("pr_url") or "").strip()
+    published_remotely = bool(raw.get("published_remotely", False))
     if candidate_id:
         evidence_source = evidence_source or source
         signal_actor = signal_actor or _legacy_signal_actor(evidence_source)
@@ -1396,6 +1479,12 @@ def _parse_job(raw: object) -> TaskJob | None:
         runtime_event_types=runtime_event_types,
         runtime_output_refs=runtime_output_refs,
         runtime_side_effects=runtime_side_effects,
+        idempotency_key=idempotency_key,
+        publish_stage=publish_stage,
+        commit_sha=commit_sha,
+        remote_branch=remote_branch,
+        pr_url=pr_url,
+        published_remotely=published_remotely,
     )
 
 
@@ -1444,6 +1533,12 @@ def _job_to_dict(job: TaskJob | None) -> dict:
         "runtime_event_types": list(job.runtime_event_types),
         "runtime_output_refs": list(job.runtime_output_refs),
         "runtime_side_effects": list(job.runtime_side_effects),
+        "idempotency_key": job.idempotency_key,
+        "publish_stage": job.publish_stage,
+        "commit_sha": job.commit_sha,
+        "remote_branch": job.remote_branch,
+        "pr_url": job.pr_url,
+        "published_remotely": job.published_remotely,
     }
 
 
@@ -1490,6 +1585,12 @@ def _replace_job(job: TaskJob, **changes: object) -> TaskJob:
         "runtime_event_types": job.runtime_event_types,
         "runtime_output_refs": job.runtime_output_refs,
         "runtime_side_effects": job.runtime_side_effects,
+        "idempotency_key": job.idempotency_key,
+        "publish_stage": job.publish_stage,
+        "commit_sha": job.commit_sha,
+        "remote_branch": job.remote_branch,
+        "pr_url": job.pr_url,
+        "published_remotely": job.published_remotely,
     }
     values.update(changes)
     return TaskJob(**values)

--- a/src/enoch/tasks/worktree.py
+++ b/src/enoch/tasks/worktree.py
@@ -201,19 +201,31 @@ def remove_task_worktree(
     delete_local_branch: bool = True,
     force_delete_branch: bool = False,
 ) -> str:
-    remove_workspace(worktree.path, control_root)
-    messages = [f"Removed task #{worktree.task_id} worktree."]
+    registered = set(workspace_paths(control_root))
+    if worktree.path.resolve() in registered:
+        remove_workspace(worktree.path, control_root)
+        messages = [f"Removed task #{worktree.task_id} worktree."]
+    elif worktree.path.exists():
+        raise VcsError(
+            f"Task #{worktree.task_id} worktree is no longer registered but "
+            f"its path still exists: {worktree.path}"
+        )
+    else:
+        messages = [f"Task #{worktree.task_id} worktree was already removed."]
     if delete_local_branch:
-        try:
-            delete_branch(
-                worktree.branch,
-                control_root,
-                force=force_delete_branch,
-            )
-        except VcsError as error:
-            messages.append(f"Kept local branch {worktree.branch}: {error}")
+        if branch_exists(worktree.branch, control_root):
+            try:
+                delete_branch(
+                    worktree.branch,
+                    control_root,
+                    force=force_delete_branch,
+                )
+            except VcsError as error:
+                messages.append(f"Kept local branch {worktree.branch}: {error}")
+            else:
+                messages.append(f"Deleted local branch {worktree.branch}.")
         else:
-            messages.append(f"Deleted local branch {worktree.branch}.")
+            messages.append(f"Local branch {worktree.branch} was already deleted.")
     return "\n".join(messages)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,39 @@
+"""Test-suite state isolation.
+
+Tests that intentionally use the source checkout as their repository root must
+never read or modify a developer's live `.enoch` daemon state.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+STATE_HOME = Path(tempfile.mkdtemp(prefix="enoch-test-state-"))
+
+os.environ["ENOCH_STATE_REDIRECT_ROOT"] = str(SOURCE_ROOT)
+os.environ["ENOCH_STATE_HOME"] = str(STATE_HOME)
+
+
+_original_test_case_run = unittest.TestCase.run
+
+
+def _run_with_clean_resident_state(
+    test_case: unittest.TestCase,
+    *args: object,
+    **kwargs: object,
+):
+    shutil.rmtree(STATE_HOME, ignore_errors=True)
+    STATE_HOME.mkdir(parents=True, exist_ok=True)
+    return _original_test_case_run(test_case, *args, **kwargs)
+
+
+unittest.TestCase.run = _run_with_clean_resident_state
+
+atexit.register(shutil.rmtree, STATE_HOME, ignore_errors=True)

--- a/tests/test_enoch_cli.py
+++ b/tests/test_enoch_cli.py
@@ -11,13 +11,25 @@ from unittest.mock import MagicMock, patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from enoch.cli import _repl, main
+from enoch.cli import ADMIN_COMMANDS, _repl, admin_help, main
 from enoch.config import read_section
 from enoch.immune import DoctorCheckResult, DoctorDiagnosis
 from enoch.identity import load_identity
 
 
 class EnochCliTests(unittest.TestCase):
+    def test_admin_registry_drives_help_and_detailed_usage(self) -> None:
+        overview = admin_help()
+
+        self.assertEqual(
+            len({command.name for command in ADMIN_COMMANDS}),
+            len(ADMIN_COMMANDS),
+        )
+        for command in ADMIN_COMMANDS:
+            self.assertIn(command.summary_line(), overview)
+            self.assertIn(f"Usage: {command.usage}", admin_help(command.name))
+        self.assertIn("Use help <command> for detailed usage.", overview)
+
     def test_help_shows_admin_command_surface(self) -> None:
         output = _run_repl_commands("help", "exit")
 
@@ -195,13 +207,13 @@ class EnochCliTests(unittest.TestCase):
             self.assertEqual(output.count("Next:"), 1)
             self.assertNotIn("123456:secret-token", output)
 
-    def test_setup_token_shortcut_shows_next_step(self) -> None:
+    def test_setup_token_command_shows_next_step(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             output = StringIO()
 
             with patch("enoch.cli.Path.cwd", return_value=root), redirect_stdout(output):
-                main(["setup-token", "123456:secret-token"])
+                main(["setup", "token", "123456:secret-token"])
 
             self.assertEqual(read_section("telegram", root)["bot_token"], "123456:secret-token")
             self.assertIn("Telegram bot token saved", output.getvalue())
@@ -209,17 +221,30 @@ class EnochCliTests(unittest.TestCase):
             self.assertIn("bin/enoch-daemon start", output.getvalue())
             self.assertNotIn("123456:secret-token", output.getvalue())
 
-    def test_setup_chat_shortcut_saves_chat_lock_from_direct_cli(self) -> None:
+    def test_setup_chat_command_saves_chat_lock_from_direct_cli(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             output = StringIO()
 
             with patch("enoch.cli.Path.cwd", return_value=root), redirect_stdout(output):
-                main(["setup-chat", "42"])
+                main(["setup", "chat", "42"])
 
             self.assertEqual(read_section("telegram", root)["allowed_chat_id"], "42")
             self.assertIn("Telegram chat lock saved", output.getvalue())
             self.assertIn("bin/enoch-daemon restart", output.getvalue())
+
+    def test_setup_aliases_are_not_registered(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = _run_repl_commands(
+                "setup-token 123456:secret-token",
+                "setup-chat 42",
+                "exit",
+                root=root,
+            )
+
+        self.assertEqual(output.count("Enoch CLI is admin-only now."), 2)
+        self.assertFalse((root / ".enoch" / "config.yaml").exists())
 
     def test_setup_ancestor_writes_repo_side_lineage_parent(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_enoch_cron.py
+++ b/tests/test_enoch_cron.py
@@ -49,7 +49,7 @@ class EnochCronTests(unittest.TestCase):
         self.assertEqual(status.active[0].context, "Use saved context.")
         self.assertEqual(status.active[0].context_source, "chat-snapshot")
 
-    def test_claim_due_jobs_advances_next_run_once(self) -> None:
+    def test_due_job_remains_claimed_until_task_is_recorded(self) -> None:
         start = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
         due = datetime(2026, 6, 30, 12, 10, tzinfo=timezone.utc)
         with TemporaryDirectory() as temp:
@@ -58,10 +58,24 @@ class EnochCronTests(unittest.TestCase):
 
             claimed = claim_due_cron_jobs(root, now=due)
             claimed_again = claim_due_cron_jobs(root, now=due)
+            metadata_only = record_cron_task(job.id, 6, root, now=due)
+            still_claimed = claim_due_cron_jobs(root, now=due)
+            recorded = record_cron_task(
+                job.id,
+                7,
+                root,
+                claim_id=claimed[0].claim_id,
+                now=due,
+            )
+            after_ack = claim_due_cron_jobs(root, now=due)
             status = cron_status(root)
 
         self.assertEqual([item.id for item in claimed], [job.id])
-        self.assertEqual(claimed_again, ())
+        self.assertEqual(claimed_again[0].claim_id, claimed[0].claim_id)
+        self.assertEqual(metadata_only.last_task_id, 6)
+        self.assertEqual(still_claimed[0].claim_id, claimed[0].claim_id)
+        self.assertIsNotNone(recorded)
+        self.assertEqual(after_ack, ())
         self.assertEqual(status.active[0].last_run_at, "2026-06-30T12:10:00+00:00")
         self.assertEqual(status.active[0].next_run_at, "2026-06-30T12:20:00+00:00")
 

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -18,6 +18,7 @@ from enoch.evolution.core import (
     MODE_DISABLED,
     cancel_evolve_candidate_for_task,
     claim_due_evolve_schedule,
+    acknowledge_evolve_schedule,
     collect_evolve_candidates,
     collect_experience_candidates,
     disable_evolve_schedule,
@@ -561,6 +562,12 @@ class EnochEvolveTests(unittest.TestCase):
             before_due = claim_due_evolve_schedule(root, now=datetime(2020, 1, 1, 23, tzinfo=timezone.utc))
             claimed = claim_due_evolve_schedule(root, now=due)
             claimed_again = claim_due_evolve_schedule(root, now=due)
+            assert claimed is not None
+            acknowledged = acknowledge_evolve_schedule(
+                claimed.schedule_claim_id,
+                root,
+                now=due,
+            )
             disabled = disable_evolve_schedule(root)
 
         self.assertTrue(scheduled.schedule_enabled)
@@ -568,9 +575,12 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertEqual(scheduled.schedule_next_run_at, "2020-01-02T00:00:00+00:00")
         self.assertIsNone(before_due)
         self.assertIsNotNone(claimed)
-        assert claimed is not None
         self.assertEqual(claimed.schedule_next_run_at, "2020-01-02T00:00:00+00:00")
-        self.assertIsNone(claimed_again)
+        self.assertEqual(claimed_again.schedule_claim_id, claimed.schedule_claim_id)
+        self.assertEqual(
+            acknowledged.schedule_next_run_at,
+            "2020-01-03T00:00:00+00:00",
+        )
         self.assertFalse(disabled.schedule_enabled)
 
     def test_daily_schedule_uses_next_local_time(self) -> None:
@@ -581,7 +591,12 @@ class EnochEvolveTests(unittest.TestCase):
 
             scheduled = set_evolve_daily_schedule("9:00", root, now=start)
             claimed = claim_due_evolve_schedule(root, now=due)
-            state_after_claim = load_evolve_state(root)
+            assert claimed is not None
+            state_after_claim = acknowledge_evolve_schedule(
+                claimed.schedule_claim_id,
+                root,
+                now=due,
+            )
 
         self.assertEqual(scheduled.schedule_daily_time, "09:00")
         self.assertEqual(scheduled.schedule_interval_seconds, 86400)
@@ -602,7 +617,12 @@ class EnochEvolveTests(unittest.TestCase):
 
             scheduled = set_evolve_cron_schedule("30 9 * * *", root, now=start)
             claimed = claim_due_evolve_schedule(root, now=due)
-            state_after_claim = load_evolve_state(root)
+            assert claimed is not None
+            state_after_claim = acknowledge_evolve_schedule(
+                claimed.schedule_claim_id,
+                root,
+                now=due,
+            )
 
         self.assertEqual(scheduled.schedule_cron_expression, "30 9 * * *")
         self.assertEqual(scheduled.schedule_next_run_at, "2020-01-01T09:30:00+00:00")

--- a/tests/test_enoch_github_workflow.py
+++ b/tests/test_enoch_github_workflow.py
@@ -63,7 +63,7 @@ class EnochGithubWorkflowTests(unittest.TestCase):
     @patch("our_ark_github.workflow.diff_summary", return_value="README.md | 1 +")
     @patch("our_ark_github.workflow.changed_files", return_value=["README.md"])
     @patch("our_ark_github.workflow.current_branch", return_value="feature/enoch")
-    def test_stages_and_commits_after_doctor_passes(
+    def test_stages_and_commits_with_existing_validation_attestation(
         self,
         _current_branch: MagicMock,
         _changed_files: MagicMock,
@@ -73,7 +73,6 @@ class EnochGithubWorkflowTests(unittest.TestCase):
         read_section: MagicMock,
     ) -> None:
         doctor = _doctor_result(passed=True, summary="All configured health checks passed.")
-        run_immune_system.return_value = doctor
         read_section.return_value = {
             "author_name": "Gary Zhao",
             "author_email": "3261777+peking2@users.noreply.github.com",
@@ -84,12 +83,17 @@ class EnochGithubWorkflowTests(unittest.TestCase):
             _git_result(returncode=0, stdout="abc123"),
         ]
 
-        result = prepare_local_publish("Test commit", root=ROOT)
+        result = prepare_local_publish(
+            "Test commit",
+            root=ROOT,
+            validation_result=doctor,
+        )
 
         self.assertEqual(result.branch, "feature/enoch")
         self.assertEqual(result.changed_files, ["README.md"])
         self.assertEqual(result.doctor, doctor)
         self.assertEqual(result.commit_sha, "abc123")
+        run_immune_system.assert_not_called()
         run_git.assert_any_call(["add", "--", "README.md"], ROOT)
         run_git.assert_any_call(
             [
@@ -328,6 +332,52 @@ class EnochGithubWorkflowTests(unittest.TestCase):
         self.assertIn("feature/enoch", args)
         self.assertNotIn("--draft", args)
         self.assertFalse(result.draft)
+
+    @patch("our_ark_github.workflow.subprocess.run")
+    @patch("our_ark_github.workflow.shutil.which", return_value="/usr/local/bin/gh")
+    @patch("our_ark_github.workflow.ensure_clean_worktree")
+    @patch("our_ark_github.workflow.run_git")
+    @patch("our_ark_github.workflow.current_branch", return_value="feature/enoch")
+    def test_pr_reuses_existing_open_pr_after_ambiguous_create_failure(
+        self,
+        _current_branch: MagicMock,
+        run_git: MagicMock,
+        _ensure_clean_worktree: MagicMock,
+        _which: MagicMock,
+        run: MagicMock,
+    ) -> None:
+        run_git.side_effect = [
+            _git_result(returncode=0, stdout="abc123"),
+            _git_result(returncode=0, stdout="Add Enoch feature"),
+            _git_result(returncode=0, stdout="Add Enoch feature"),
+            _git_result(returncode=0, stdout="https://github.com/our-ark/enoch.git"),
+        ]
+        create = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="a pull request for branch feature/enoch already exists",
+        )
+        view = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "url": "https://github.com/our-ark/enoch/pull/12",
+                    "title": "Add Enoch feature",
+                    "body": "Existing body",
+                    "isDraft": False,
+                    "state": "OPEN",
+                }
+            ),
+            stderr="",
+        )
+        run.side_effect = [create, view]
+
+        result = create_pull_request(root=ROOT)
+
+        self.assertTrue(result.created)
+        self.assertEqual(result.url, "https://github.com/our-ark/enoch/pull/12")
+        self.assertIn("Reused", result.note)
+        self.assertEqual(run.call_args_list[1].args[0][:3], ["/usr/local/bin/gh", "pr", "view"])
 
     @patch("our_ark_github.workflow.subprocess.run")
     @patch("our_ark_github.workflow.shutil.which", return_value="/usr/local/bin/gh")

--- a/tests/test_enoch_logs.py
+++ b/tests/test_enoch_logs.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from enoch.logs import conversation_log_path, log_conversation_turn, log_system_event, system_log_path
+from enoch.paths import enoch_home
 
 
 class EnochLogsTests(unittest.TestCase):
@@ -43,11 +44,11 @@ class EnochLogsTests(unittest.TestCase):
 
         self.assertEqual(
             conversation_log_path(ROOT, when=when),
-            ROOT / ".enoch" / "logs" / "conversations" / "2026-06-19.jsonl",
+            enoch_home(ROOT) / "logs" / "conversations" / "2026-06-19.jsonl",
         )
         self.assertEqual(
             system_log_path(ROOT, when=when),
-            ROOT / ".enoch" / "logs" / "system" / "2026-06-19.jsonl",
+            enoch_home(ROOT) / "logs" / "system" / "2026-06-19.jsonl",
         )
 
 

--- a/tests/test_enoch_profiles.py
+++ b/tests/test_enoch_profiles.py
@@ -368,7 +368,7 @@ class EnochProfileTests(unittest.TestCase):
         self.assertIn("Agent profile: researcher", chat.sent[-1][1])
 
     def test_profile_rejects_unsupported_api_version(self) -> None:
-        with self.assertRaisesRegex(ProfileError, "uses API version 2"):
+        with self.assertRaisesRegex(ProfileError, "supports version 2"):
             AgentProfile(name="future", api_version=PROFILE_API_VERSION + 1)
 
     def test_profile_rejects_invalid_workflow_and_presentation_values(self) -> None:

--- a/tests/test_enoch_providers.py
+++ b/tests/test_enoch_providers.py
@@ -40,6 +40,8 @@ from enoch.providers import (
     normalize_runtime_result,
 )
 from enoch.providers.forge import LocalForgeProvider
+from enoch.providers.vcs import GitVersionControlProvider
+from enoch.providers.contracts import VersionControlProviderError
 from enoch.providers.runtime import (
     FunctionAgentRuntime,
     invoke_runtime_action,
@@ -316,6 +318,47 @@ class _EntryPoints(list):
 
 
 class EnochProviderTests(unittest.TestCase):
+    def test_git_task_base_refuses_stale_fallback_when_fetch_fails(self) -> None:
+        provider = GitVersionControlProvider()
+        with patch.object(
+            provider,
+            "refresh_authoritative",
+            side_effect=VersionControlProviderError("network unavailable"),
+        ), patch.object(provider, "resolve_revision", return_value="stale-local-sha"):
+            with self.assertRaisesRegex(
+                VersionControlProviderError,
+                "network unavailable",
+            ):
+                provider.task_base(ROOT)
+
+    def test_provider_loader_surfaces_missing_internal_dependency(self) -> None:
+        error = ModuleNotFoundError(
+            "No module named 'internal_dependency'",
+            name="internal_dependency",
+        )
+        with patch.object(
+            provider_registry,
+            "CORE_PROVIDER_MODULES",
+            ("example.provider",),
+        ), patch.object(
+            provider_registry,
+            "_LOADED_PLUGIN_MODULES",
+            set(),
+        ), patch.object(
+            provider_registry,
+            "load_runtime_dependencies",
+            return_value=(),
+        ), patch.object(
+            provider_registry,
+            "import_module",
+            side_effect=error,
+        ):
+            with self.assertRaisesRegex(
+                ProviderError,
+                "could not load dependency internal_dependency",
+            ):
+                provider_registry._load_provider_plugins(None)
+
     def test_runtime_execution_distinguishes_timeout_from_cancellation(self) -> None:
         cancellation = threading.Event()
         timeout = threading.Event()
@@ -649,6 +692,7 @@ class EnochProviderTests(unittest.TestCase):
             root = Path(temp)
             app = EnochApplication(load_identity(), root, _Chat(), runtime=_Runtime())
             app.forge = MagicMock()
+            app.forge.supports_remote_review = False
             app.forge.create_pull_request.return_value = review
             workspace = TaskWorktree(1, root / "task-1", "change/portable", True)
             with patch("enoch.app.core.feature_title", return_value="Portable change"), patch(
@@ -675,7 +719,62 @@ class EnochProviderTests(unittest.TestCase):
             delete_local_branch=False,
             force_delete_branch=False,
         )
-        self.assertIn("kept this branch locally", result)
+        self.assertIn("kept this branch locally", result.message)
+
+    def test_remote_pr_creation_failure_is_retryable_and_preserves_worktree(self) -> None:
+        doctor = MagicMock(passed=True)
+        committed = LocalPublishResult(
+            branch="change/retry-pr",
+            commit_message="Retry PR",
+            changed_files=["README.md"],
+            diff="README.md | 1 +",
+            doctor=doctor,
+            commit_sha="revision-2",
+        )
+        remote = RemotePublishResult(
+            branch="change/retry-pr",
+            remote="origin",
+            pushed=True,
+            ahead_count=1,
+            compare_url="https://github.com/our-ark/enoch/compare/change/retry-pr",
+        )
+        review = PullRequestResult(
+            branch="change/retry-pr",
+            title="Retry PR",
+            body="",
+            created=False,
+            url=None,
+            fallback_url=remote.compare_url,
+            note="temporary API failure",
+        )
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            app = EnochApplication(load_identity(), root, _Chat(), runtime=_Runtime())
+            app.forge = MagicMock(supports_remote_review=True)
+            app.forge.create_pull_request.return_value = review
+            workspace = TaskWorktree(2, root / "task-2", remote.branch, True)
+            with patch(
+                "enoch.app.core.prepare_local_publish",
+                return_value=committed,
+            ), patch(
+                "enoch.app.core.push_current_branch",
+                return_value=remote,
+            ), patch("enoch.app.core.remove_task_worktree") as remove:
+                result = app._publish_feature_pr(
+                    "room-1",
+                    "Retry PR",
+                    ("README.md",),
+                    work_root=workspace.path,
+                    task_worktree=workspace,
+                    validation_result=doctor,
+                )
+
+        self.assertEqual(result.status, "publish_incomplete")
+        self.assertEqual(result.code, "pr_creation_failed")
+        self.assertTrue(result.retryable)
+        self.assertEqual(result.commit_sha, "revision-2")
+        self.assertEqual(result.remote_branch, "change/retry-pr")
+        remove.assert_not_called()
 
     def test_config_lists_and_selects_installed_providers(self) -> None:
         register_provider("runtime", "test-runtime", lambda _root=None: _Runtime(), replace=True)

--- a/tests/test_enoch_reliability.py
+++ b/tests/test_enoch_reliability.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from enoch.app.inbox import (
+    acknowledge_event,
+    begin_event,
+    complete_event,
+    inbox_path,
+    mark_reply_sent,
+)
+from enoch.app.core import EnochApplication
+from enoch.backlog import add_backlog_item, backlog_status
+from enoch.codex_sessions import (
+    CodexSessionState,
+    load_codex_session,
+    save_codex_session,
+)
+from enoch.config import read_section, write_section_value
+from enoch.cron import add_cron_job, cron_status
+from enoch.channel import load_channel_cursor
+from enoch.memory.store import apply_memory_candidates, load_long_term_memory
+from enoch.identity import load_identity
+from enoch.providers.contracts import ChatEvent
+from enoch.state import StateCorruptionError
+from enoch.tasks.queue import (
+    cancel_task,
+    enqueue_task,
+    task_queue_path,
+    task_queue_status,
+)
+
+
+class EnochReliabilityTests(unittest.TestCase):
+    def test_corrupt_queue_is_preserved_and_never_replaced_with_empty_state(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = task_queue_path(root)
+            path.parent.mkdir(parents=True)
+            damaged = "{broken"
+            path.write_text(damaged, encoding="utf-8")
+
+            with self.assertRaises(StateCorruptionError):
+                enqueue_task(42, "must not overwrite history", root)
+
+            self.assertEqual(path.read_text(encoding="utf-8"), damaged)
+
+    def test_invalid_inbox_receipt_is_preserved(self) -> None:
+        event = ChatEvent(
+            cursor=9,
+            conversation_id=42,
+            message_id=6,
+            text="/status",
+        )
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = inbox_path("telegram", root)
+            path.parent.mkdir(parents=True)
+            damaged = '{"events":{"receipt":{"status":"mystery"}}}\n'
+            path.write_text(damaged, encoding="utf-8")
+
+            with self.assertRaises(StateCorruptionError):
+                begin_event("telegram", event, root)
+
+            self.assertEqual(path.read_text(encoding="utf-8"), damaged)
+
+    def test_task_enqueue_is_idempotent_and_history_is_not_truncated(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = enqueue_task(
+                42,
+                "run once",
+                root,
+                idempotency_key="chat:update-1:task",
+            )
+            duplicate = enqueue_task(
+                42,
+                "run once",
+                root,
+                idempotency_key="chat:update-1:task",
+            )
+            for index in range(25):
+                task = enqueue_task(42, f"history task {index}", root)
+                cancel_task(task.id, root)
+            status = task_queue_status(root)
+
+        self.assertEqual(duplicate.id, first.id)
+        self.assertEqual(status.pending_count, 1)
+        self.assertEqual(len(status.history), 25)
+
+    def test_backlog_and_cron_creation_are_idempotent(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            backlog = add_backlog_item(
+                42,
+                "later",
+                root,
+                idempotency_key="chat:update-2:backlog",
+            )
+            backlog_duplicate = add_backlog_item(
+                42,
+                "later",
+                root,
+                idempotency_key="chat:update-2:backlog",
+            )
+            cron = add_cron_job(
+                42,
+                "recurring",
+                60,
+                root,
+                idempotency_key="chat:update-3:cron",
+            )
+            cron_duplicate = add_cron_job(
+                42,
+                "recurring",
+                60,
+                root,
+                idempotency_key="chat:update-3:cron",
+            )
+
+            self.assertEqual(backlog_duplicate.id, backlog.id)
+            self.assertEqual(cron_duplicate.id, cron.id)
+            self.assertEqual(backlog_status(root).pending_count, 1)
+            self.assertEqual(cron_status(root).active_count, 1)
+
+    def test_config_round_trips_comments_quotes_and_backslashes(self) -> None:
+        value = 'alpha#beta "quoted" C:\\work'
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_section_value("telegram", "bot_token", value, root)
+
+            self.assertEqual(read_section("telegram", root)["bot_token"], value)
+
+    def test_session_read_modify_write_is_serialized(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+
+            def save(key: str) -> None:
+                save_codex_session(
+                    CodexSessionState(
+                        key=key,
+                        session_id=f"session-{key}",
+                        turn_count=1,
+                        created_at="2026-01-01T00:00:00+00:00",
+                        updated_at="2026-01-01T00:00:00+00:00",
+                    ),
+                    root,
+                )
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                tuple(executor.map(save, ("one", "two")))
+
+            self.assertEqual(load_codex_session("one", root).session_id, "session-one")
+            self.assertEqual(load_codex_session("two", root).session_id, "session-two")
+
+    def test_memory_read_modify_write_is_serialized(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+
+            def remember(text: str) -> None:
+                apply_memory_candidates([{"text": text}], root)
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                tuple(executor.map(remember, ("first decision", "second decision")))
+
+            texts = {
+                str(memory["text"])
+                for memory in load_long_term_memory(root)["memories"]
+            }
+
+        self.assertEqual(texts, {"first decision", "second decision"})
+
+    def test_completed_chat_receipt_prevents_reexecution_after_restart(self) -> None:
+        event = ChatEvent(
+            cursor=10,
+            conversation_id=42,
+            message_id=7,
+            text="/task run once",
+        )
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            receipt = begin_event("telegram", event, root)
+            completed = complete_event(
+                "telegram",
+                receipt.key,
+                root,
+                reply="Queued task #1.",
+                logged_input=event.text,
+            )
+            mark_reply_sent("telegram", receipt.key, root)
+            acknowledge_event("telegram", receipt.key, root)
+
+            replayed = begin_event("telegram", event, root)
+
+        self.assertFalse(completed.reply_sent)
+        self.assertTrue(replayed.completed)
+        self.assertTrue(replayed.reply_sent)
+        self.assertEqual(replayed.attempts, 1)
+
+    def test_reply_delivery_failure_retries_without_reexecuting_handler(self) -> None:
+        event = ChatEvent(
+            cursor=12,
+            conversation_id=42,
+            message_id=9,
+            text="/status",
+        )
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            chat = _FlakyChat()
+            app = EnochApplication(load_identity(), root, chat)
+            with patch.object(
+                app,
+                "_dispatch_chat_event",
+                return_value=("healthy", event.text),
+            ) as dispatch:
+                app.handle_event(event)
+                self.assertIsNone(load_channel_cursor("telegram", root))
+                app.handle_event(event)
+                self.assertEqual(load_channel_cursor("telegram", root), 12)
+
+        self.assertEqual(dispatch.call_count, 1)
+        self.assertEqual(chat.attempts, 2)
+        self.assertEqual(chat.sent, [(42, "healthy")])
+
+    def test_poison_chat_event_is_quarantined_after_three_attempts(self) -> None:
+        event = ChatEvent(
+            cursor=11,
+            conversation_id=42,
+            message_id=8,
+            text="/broken",
+        )
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            chat = _Chat()
+            app = EnochApplication(load_identity(), root, chat)
+            with patch("builtins.print"), patch.object(
+                app,
+                "_dispatch_chat_event",
+                side_effect=ValueError("broken command payload"),
+            ) as dispatch:
+                app.handle_event(event)
+                app.handle_event(event)
+                app.handle_event(event)
+                app.handle_event(event)
+
+        self.assertEqual(dispatch.call_count, 3)
+        self.assertEqual(len(chat.sent), 1)
+        self.assertIn("skipped this update after three failed", chat.sent[0][1])
+
+
+class _Chat:
+    name = "telegram"
+    allowed_conversation_id = 42
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[int, str]] = []
+
+    def send_message(self, conversation_id: int, text: str):
+        self.sent.append((conversation_id, text))
+        return len(self.sent)
+
+    def send_read_ack(self, _conversation_id: int, _message_id: int) -> None:
+        return None
+
+
+class _FlakyChat(_Chat):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attempts = 0
+
+    def send_message(self, conversation_id: int, text: str):
+        self.attempts += 1
+        if self.attempts == 1:
+            raise OSError("temporary Telegram failure")
+        return super().send_message(conversation_id, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enoch_task_queue.py
+++ b/tests/test_enoch_task_queue.py
@@ -25,6 +25,7 @@ from enoch.tasks.queue import (
     recover_interrupted_task,
     record_task_result,
     record_task_runtime_result,
+    record_task_publish_state,
     record_task_status_message,
     record_task_worktree,
     regress_task,
@@ -159,6 +160,15 @@ class EnochTaskQueueTests(unittest.TestCase):
                 "enoch/task-1",
                 root,
             )
+            record_task_publish_state(
+                running.id,
+                "worker-one",
+                root,
+                stage="pushed",
+                commit_sha="abc123",
+                remote_branch="enoch/task-1",
+                published_remotely=True,
+            )
             fail_task(
                 running.id,
                 root,
@@ -184,6 +194,10 @@ class EnochTaskQueueTests(unittest.TestCase):
             retried.pr_urls,
             ("https://github.com/our-ark/enoch/pull/13",),
         )
+        self.assertEqual(retried.publish_stage, "pushed")
+        self.assertEqual(retried.commit_sha, "abc123")
+        self.assertEqual(retried.remote_branch, "enoch/task-1")
+        self.assertTrue(retried.published_remotely)
         self.assertIn("Existing work is available", retried.result)
 
     def test_retry_requires_latest_failed_task_in_retry_chain(self) -> None:

--- a/tests/test_enoch_task_worktree.py
+++ b/tests/test_enoch_task_worktree.py
@@ -123,6 +123,11 @@ class TaskWorktreeTests(unittest.TestCase):
             self.assertFalse(task.path.exists())
             self.assertEqual(_git(source, "branch", "--list", task.branch), "")
 
+            repeated_cleanup = remove_task_worktree(resident, reused)
+            self.assertIn("worktree was already removed", repeated_cleanup)
+            self.assertIn("branch", repeated_cleanup)
+            self.assertIn("already deleted", repeated_cleanup)
+
     def test_existing_branch_publish_worktree_does_not_switch_resident(self) -> None:
         with TemporaryDirectory() as temp:
             source, resident = _create_agent_worktree(Path(temp))

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -4518,7 +4518,6 @@ class EnochTelegramTests(unittest.TestCase):
     @patch("enoch.app.core.ensure_clean_worktree")
     @patch("enoch.app.core.current_branch", side_effect=["main", "enoch/readme", "enoch/readme"])
     @patch("enoch.app.core.changed_files", return_value=["README.md"])
-    @patch("enoch.app.core._worktree_snapshot", side_effect=["clean", "changed"])
     @patch("enoch.app.core.act_in_session", return_value="Updated README.")
     @patch("enoch.app.core.respond")
     @patch("enoch.app.core.ensure_long_term_memory")
@@ -4531,7 +4530,6 @@ class EnochTelegramTests(unittest.TestCase):
         _update_memory: MagicMock,
         respond: MagicMock,
         act_in_session: MagicMock,
-        _snapshot: MagicMock,
         _changed_files: MagicMock,
         _current_branch: MagicMock,
         _ensure_clean_worktree: MagicMock,
@@ -4619,17 +4617,12 @@ class EnochTelegramTests(unittest.TestCase):
     @patch("enoch.app.core.run_immune_system")
     @patch("enoch.app.core.changed_files", return_value=["README.md"])
     @patch(
-        "enoch.app.core._worktree_snapshot",
-        side_effect=["preserved README diff", "preserved README diff"],
-    )
-    @patch(
         "enoch.app.core.act_in_session",
         return_value="The preserved README edit already satisfies the request.",
     )
     def test_retry_validates_and_publishes_preserved_worktree_diff(
         self,
         _act_in_session: MagicMock,
-        _snapshot: MagicMock,
         _changed_files: MagicMock,
         run_immune_system: MagicMock,
     ) -> None:
@@ -4669,6 +4662,7 @@ class EnochTelegramTests(unittest.TestCase):
             ("README.md",),
             work_root=root,
             task_worktree=task_worktree,
+            validation_result=run_immune_system.return_value,
         )
         remove_task_worktree.assert_not_called()
         self.assertIn("Opened pull request.", result)
@@ -5090,7 +5084,7 @@ class EnochTelegramTests(unittest.TestCase):
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")
-    def test_final_send_failure_still_records_and_advances_offset(
+    def test_final_send_failure_preserves_event_for_redelivery(
         self,
         log_conversation_turn: MagicMock,
         _update_memory: MagicMock,
@@ -5102,9 +5096,19 @@ class EnochTelegramTests(unittest.TestCase):
 
             _handle_update(bot, _message_update(update_id=10, chat_id=42, text="/status"))
 
-        self.assertEqual(bot.offset, 11)
-        log_conversation_turn.assert_called_once()
-        self.assertIn("Telegram send failed", log_conversation_turn.call_args.kwargs["reply"])
+        self.assertIsNone(bot.offset)
+        log_conversation_turn.assert_not_called()
+        self.log_system_event.assert_any_call(
+            "chat_reply_failed",
+            root=root,
+            status="failed",
+            details={
+                "provider": "telegram",
+                "chat_id": 42,
+                "message_id": 1010,
+                "error": "send failed",
+            },
+        )
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")


### PR DESCRIPTION
## Summary

- add durable, corruption-safe state transactions and isolated test state
- make chat processing idempotent across redelivery, retry poison events safely, and retry failed reply delivery without repeating handlers
- persist typed task outcomes and publication stages so commit/push/PR/cleanup retries resume instead of rerunning the coding agent
- change cron and evolve schedules to claim-and-ack occurrences
- reject stale task bases and surface provider dependency failures
- centralize admin command metadata, remove profile/setup aliases, and generate current help/usage from registries
- make worktree cleanup idempotent and preserve publication state through manual retries
- document the workflow guarantees and expand provider-library CI coverage

## Validation

- `python -m unittest discover -s tests -t .` — 611 passed
- all provider-library suites — 31 passed
- `git diff --check` — passed