### PR TITLE
Improve Doctor readiness diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ The Codex executable is resolved independently in this order:
 Use `/config runtime codex executable <path|auto>` to configure or restore
 automatic discovery. The daemon reads this instance setting directly.
 
+## Doctor
+
+Run `bin/enoch doctor` or `/doctor` before publishing changes. Doctor reports
+three separate sections:
+
+- code health: Python, the complete test suite, and import smoke tests;
+- environment readiness: the locked Python build backend required by the
+  portable-install tests;
+- operational readiness: Codex login, forge authentication, version-control
+  workspace state, and durable `.enoch` state storage.
+
+Doctor preserves the beginning and end of long failures so the final exception
+is not lost. It validates existing JSON and JSONL state without replacing
+unreadable files. When Doctor runs for an isolated task worktree, code checks
+use that worktree while operational state checks use the resident Enoch
+instance.
+
+If the build-backend preflight fails, install the same locked prerequisite used
+by CI:
+
+```bash
+python -m pip install --disable-pip-version-check --require-hashes \
+  -r .github/requirements/test-build.txt
+```
+
 ## Providers
 
 Codex, Git, and a local-only forge are core defaults. Telegram, GitHub,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -189,6 +189,12 @@ failures and `AgentRuntimeCancelled` for human cancellation. Forge and VCS
 providers should raise their matching provider errors. This preserves Enoch's
 pause, resume, failure, and audit behavior across implementations.
 
+Remote forge providers may also expose `health(root) -> ProviderHealth`.
+Doctor uses it when available to detect missing clients or expired
+authentication before a task reaches the publish stage. Providers without the
+optional hook remain compatible and are reported as loaded with authentication
+status unavailable.
+
 ## Typed runtime results
 
 Runtime contract version 1 uses `RuntimeResult` for both `respond()` and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,10 +3,19 @@
 Run the complete suite with:
 
 ```bash
+python -m pip install --disable-pip-version-check --require-hashes \
+  -r .github/requirements/test-build.txt
 python -m unittest discover -s tests
 python -m unittest discover -s libraries/launchd/tests
 python -m unittest discover -s libraries/systemd/tests
 ```
+
+The locked build backend is required because the portable-install test builds
+all distributions offline with build isolation disabled. Doctor checks this
+prerequisite before running the suite and reports the install command when it
+is missing or below the project requirement. When that preflight fails, Doctor
+skips the suite instead of reporting downstream packaging failures as source
+regressions.
 
 The service-provider suites verify manifest generation and lifecycle command
 delegation independently. GitHub Actions runs them on Linux alongside the core

--- a/libraries/github/src/our_ark_github/__init__.py
+++ b/libraries/github/src/our_ark_github/__init__.py
@@ -9,7 +9,7 @@ import subprocess
 from typing import Any
 
 from our_ark_github import workflow
-from our_ark_provider_kit import ForgeProviderError, agent_context
+from our_ark_provider_kit import ForgeProviderError, ProviderHealth, agent_context
 
 
 class GithubForgeProvider:
@@ -46,6 +46,45 @@ class GithubForgeProvider:
 
     def merge_pull_request(self, reference: str, root=None):
         return workflow.merge_pull_request(reference, root)
+
+    def health(self, root: Path | None = None) -> ProviderHealth:
+        if self.gh is None:
+            return ProviderHealth(
+                name="github forge",
+                passed=False,
+                command="gh auth status",
+                output="GitHub CLI is not available.",
+                summary="gh not found",
+            )
+        try:
+            result = subprocess.run(
+                [self.gh, "auth", "status"],
+                cwd=root or self.root,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=15,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            return ProviderHealth(
+                name="github forge",
+                passed=False,
+                command=f"{self.gh} auth status",
+                output=str(error),
+                summary="authentication check failed",
+            )
+        output = "\n".join(
+            part.strip()
+            for part in (result.stdout, result.stderr)
+            if part and part.strip()
+        )
+        return ProviderHealth(
+            name="github forge",
+            passed=result.returncode == 0,
+            command=f"{self.gh} auth status",
+            output=output,
+            summary="authenticated" if result.returncode == 0 else "not authenticated",
+        )
 
     def read_text(self, repo: str, path: str, ref: str = "main") -> str:
         content = self._content_text(repo, path, ref)

--- a/libraries/github/tests/test_github_provider.py
+++ b/libraries/github/tests/test_github_provider.py
@@ -47,6 +47,41 @@ class GithubProviderTests(unittest.TestCase):
             ],
         )
 
+    @patch("our_ark_github.subprocess.run")
+    def test_health_reports_authenticated_cli(self, run) -> None:
+        run.return_value.returncode = 0
+        run.return_value.stdout = "Logged in to github.com"
+        run.return_value.stderr = ""
+        provider = GithubForgeProvider(gh="/usr/local/bin/gh")
+
+        health = provider.health(ROOT)
+
+        self.assertTrue(health.passed)
+        self.assertEqual(health.summary, "authenticated")
+        self.assertEqual(
+            run.call_args.args[0],
+            ["/usr/local/bin/gh", "auth", "status"],
+        )
+
+    @patch("our_ark_github.subprocess.run")
+    def test_health_reports_invalid_authentication(self, run) -> None:
+        run.return_value.returncode = 1
+        run.return_value.stdout = ""
+        run.return_value.stderr = "The token is invalid."
+        provider = GithubForgeProvider(gh="/usr/local/bin/gh")
+
+        health = provider.health(ROOT)
+
+        self.assertFalse(health.passed)
+        self.assertEqual(health.summary, "not authenticated")
+        self.assertIn("token is invalid", health.output)
+
+    @patch("our_ark_github.shutil.which", return_value=None)
+    def test_health_reports_missing_cli(self, _which) -> None:
+        health = GithubForgeProvider().health(ROOT)
+
+        self.assertEqual(health.summary, "gh not found")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -1499,7 +1499,7 @@ class EnochApplication:
 
         self._send_step_update(chat_id, "Running doctor.")
         self._raise_if_current_task_cancelled()
-        doctor = run_immune_system(work_root)
+        doctor = run_immune_system(work_root, state_root=self.root)
         self._raise_if_current_task_cancelled()
         parts.append(_format_doctor_result(doctor))
         self._send_step_update(chat_id, "Doctor passed." if doctor.passed else "Doctor failed.")

--- a/src/enoch/formatting.py
+++ b/src/enoch/formatting.py
@@ -52,6 +52,7 @@ def format_doctor_result(result: ImmuneResult) -> str:
 def _doctor_check_sections(checks: list[object]) -> list[str]:
     categories = [
         ("code health", "Code health:"),
+        ("environment readiness", "Environment readiness:"),
         ("operational readiness", "Operational readiness:"),
     ]
     lines = []
@@ -62,7 +63,11 @@ def _doctor_check_sections(checks: list[object]) -> list[str]:
         lines.append("")
         lines.append(heading)
         for check in category_checks:
-            status = "passed" if check.passed else "failed"
+            status = (
+                "skipped"
+                if getattr(check, "skipped", False)
+                else ("passed" if check.passed else "failed")
+            )
             summary = getattr(check, "summary", "")
             suffix = f" ({summary})" if summary else ""
             lines.append(f"- {check.name}: {status}{suffix}")
@@ -73,7 +78,11 @@ def doctor_output_excerpt(output: str, limit: int = SUMMARY_CLIP_CHARS) -> str:
     cleaned = output.strip()
     if len(cleaned) <= limit:
         return cleaned
-    return f"{cleaned[:limit].rstrip()}\n\n[truncated]"
+    marker = "\n\n[truncated; final output preserved]\n\n"
+    remaining = limit - len(marker)
+    head = remaining // 2
+    tail = remaining - head
+    return f"{cleaned[:head].rstrip()}{marker}{cleaned[-tail:].lstrip()}"
 
 
 def format_publish_result(result: LocalPublishResult) -> str:

--- a/src/enoch/immune.py
+++ b/src/enoch/immune.py
@@ -1,22 +1,43 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import os
 import re
 import shlex
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
-from enoch.paths import repo_root
-from enoch.providers.contracts import AgentRuntimeError, VersionControlProviderError
+from enoch.paths import enoch_home, repo_root
+from enoch.providers.contracts import (
+    AgentRuntimeError,
+    ForgeProviderError,
+    VersionControlProviderError,
+)
 from enoch.providers.registry import ProviderError, load_provider, provider_name
+from enoch.state import StateCorruptionError, load_json_object
 
 
 DEFAULT_TEST_ARGS = ["-m", "unittest", "discover", "-s", "tests", "-t", "."]
 DEFAULT_TIMEOUT_SECONDS = 120
 MAX_OUTPUT_CHARS = 12000
 MIN_PYTHON_VERSION = (3, 11)
+TEST_BUILD_REQUIREMENTS = Path(".github/requirements/test-build.txt")
+STATE_OBJECT_FIELDS: dict[str, dict[str, type]] = {
+    "backlog.json": {"pending": list, "history": list},
+    "codex_sessions.json": {"sessions": dict},
+    "cron.json": {"active": list, "history": list},
+    "evolve_candidates.json": {"candidates": list},
+    "inbox.json": {"events": dict},
+    "long_term.json": {"memories": list},
+    "task_queue.json": {
+        "pending": list,
+        "paused": list,
+        "history": list,
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -44,19 +65,47 @@ class DoctorCheckResult:
     output: str
     category: str = "code health"
     summary: str = ""
+    skipped: bool = False
 
 
-def run_immune_system(root: Path | None = None) -> ImmuneResult:
+def run_immune_system(
+    root: Path | None = None,
+    *,
+    state_root: Path | None = None,
+) -> ImmuneResult:
     root_path = repo_root(root)
+    operational_root = repo_root(state_root or root_path)
     timeout = _timeout_seconds()
     checks = [
         _python_runtime_check(root_path, timeout),
-        _run_check("tests", _test_command(), root_path, timeout),
-        _run_check("import smoke", _import_smoke_command(), root_path, timeout),
-        _runtime_provider_check(root_path),
-        _vcs_workspace_check(root_path, timeout),
-        _memory_storage_check(root_path),
     ]
+    test_check: DoctorCheckResult
+    if os.environ.get("ENOCH_TEST_COMMAND") is None:
+        build_backend = _build_backend_check(root_path, timeout)
+        checks.append(build_backend)
+        if build_backend.passed:
+            test_check = _run_check("tests", _test_command(), root_path, timeout)
+        else:
+            test_check = DoctorCheckResult(
+                name="tests",
+                passed=True,
+                command=shlex.join(_test_command()),
+                output="",
+                summary="not run until the build-backend prerequisite passes",
+                skipped=True,
+            )
+    else:
+        test_check = _run_check("tests", _test_command(), root_path, timeout)
+    checks.extend(
+        [
+            test_check,
+            _run_check("import smoke", _import_smoke_command(), root_path, timeout),
+            _runtime_provider_check(operational_root, timeout),
+            _forge_provider_check(operational_root),
+            _vcs_workspace_check(root_path, timeout),
+            _memory_storage_check(operational_root),
+        ]
+    )
     output = _combined_output(checks)
     passed = all(check.passed for check in checks)
     return ImmuneResult(
@@ -126,6 +175,126 @@ def _python_runtime_check(root: Path, timeout: float) -> DoctorCheckResult:
     )
 
 
+def _build_backend_check(root: Path, timeout: float) -> DoctorCheckResult:
+    backend, distribution, minimum_version = _project_build_backend(root)
+    command = [
+        _python_executable(),
+        "-c",
+        (
+            "import importlib, importlib.metadata; "
+            f"importlib.import_module({backend!r}); "
+            f"print({distribution!r} + ' ' + importlib.metadata.version({distribution!r}))"
+        ),
+    ]
+    check = _run_check("build backend", command, root, timeout)
+    install_command = _test_prerequisite_install_command(root)
+    if not check.passed:
+        return DoctorCheckResult(
+            name=check.name,
+            passed=False,
+            command=check.command,
+            output=_join_output(
+                f"Doctor test environment is missing build backend {backend}.",
+                f"Install the locked test prerequisite with:\n{install_command}",
+                check.output,
+            ),
+            category="environment readiness",
+            summary=f"missing {backend}",
+        )
+
+    found = _distribution_version(check.output, distribution)
+    if (
+        minimum_version
+        and found
+        and _numeric_version(found) < _numeric_version(minimum_version)
+    ):
+        return DoctorCheckResult(
+            name=check.name,
+            passed=False,
+            command=check.command,
+            output=_join_output(
+                (
+                    f"Doctor test environment has {distribution} {found or 'unknown'}, "
+                    f"but the project requires at least {minimum_version}."
+                ),
+                f"Install the locked test prerequisite with:\n{install_command}",
+            ),
+            category="environment readiness",
+            summary=f"{distribution} {found}; requires >= {minimum_version}",
+        )
+    return DoctorCheckResult(
+        name=check.name,
+        passed=True,
+        command=check.command,
+        output=check.output,
+        category="environment readiness",
+        summary=f"{distribution} {found or 'available'}",
+    )
+
+
+def _project_build_backend(root: Path) -> tuple[str, str, str]:
+    path = root / "pyproject.toml"
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return "setuptools.build_meta", "setuptools", ""
+    build_system = data.get("build-system")
+    if not isinstance(build_system, dict):
+        return "setuptools.build_meta", "setuptools", ""
+    backend = str(build_system.get("build-backend") or "setuptools.build_meta").strip()
+    distribution = backend.split(".", 1)[0].replace("_", "-")
+    requirements = build_system.get("requires")
+    minimum_version = ""
+    if isinstance(requirements, list):
+        requirement = next(
+            (
+                str(item)
+                for item in requirements
+                if re.match(
+                    rf"^{re.escape(distribution)}\s*>=",
+                    str(item),
+                    re.IGNORECASE,
+                )
+            ),
+            "",
+        )
+        match = re.match(
+            rf"^{re.escape(distribution)}\s*>=\s*([A-Za-z0-9_.+-]+)",
+            requirement,
+            re.IGNORECASE,
+        )
+        if match:
+            minimum_version = match.group(1)
+    return backend, distribution, minimum_version
+
+
+def _numeric_version(value: str) -> tuple[int, ...]:
+    return tuple(
+        int(part)
+        for part in re.findall(r"\d+", value)
+    )
+
+
+def _distribution_version(output: str, distribution: str) -> str:
+    match = re.search(
+        rf"(?m)^{re.escape(distribution)}\s+([^\s]+)\s*$",
+        output,
+        re.IGNORECASE,
+    )
+    return match.group(1) if match else ""
+
+
+def _test_prerequisite_install_command(root: Path) -> str:
+    requirements = root / TEST_BUILD_REQUIREMENTS
+    if requirements.is_file():
+        return (
+            f"{shlex.quote(_python_executable())} -m pip install "
+            "--disable-pip-version-check --require-hashes "
+            f"-r {TEST_BUILD_REQUIREMENTS.as_posix()}"
+        )
+    return f"{shlex.quote(_python_executable())} -m pip install setuptools"
+
+
 def _python_version(output: str) -> tuple[int, int] | None:
     match = re.search(r"Python\s+(\d+)\.(\d+)", output)
     if not match:
@@ -181,21 +350,42 @@ def _run_check(name: str, command: list[str], root: Path, timeout: float) -> Doc
     )
 
 
-def _codex_binary_check(root: Path) -> DoctorCheckResult:
+def _codex_binary_check(
+    root: Path,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> DoctorCheckResult:
     from enoch.brain import resolve_codex_executable
 
     resolution = resolve_codex_executable(root)
     if resolution.path:
+        check = _run_check(
+            "codex runtime",
+            [resolution.path, "login", "status"],
+            root,
+            min(timeout, 15),
+        )
+        if not check.passed:
+            return DoctorCheckResult(
+                name=check.name,
+                passed=False,
+                command=check.command,
+                output=_join_output(
+                    check.output,
+                    "Authenticate Codex with `codex login`, then run doctor again.",
+                ),
+                category="operational readiness",
+                summary=f"not authenticated ({resolution.path})",
+            )
         return DoctorCheckResult(
-            name="codex binary",
+            name=check.name,
             passed=True,
-            command="which codex",
-            output="",
+            command=check.command,
+            output=check.output,
             category="operational readiness",
-            summary=f"{resolution.path} (source: {resolution.source})",
+            summary=f"authenticated; {resolution.path} (source: {resolution.source})",
         )
     return DoctorCheckResult(
-        name="codex binary",
+        name="codex runtime",
         passed=False,
         command="which codex",
         output=" ".join(
@@ -213,11 +403,15 @@ def _codex_binary_check(root: Path) -> DoctorCheckResult:
     )
 
 
-def _runtime_provider_check(root: Path) -> DoctorCheckResult:
-    if provider_name("runtime", root) == "codex":
-        return _codex_binary_check(root)
+def _runtime_provider_check(
+    root: Path,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> DoctorCheckResult:
     try:
-        runtime = load_provider("runtime", root)
+        selected = provider_name("runtime", root)
+        if selected == "codex":
+            return _codex_binary_check(root, timeout)
+        runtime = load_provider("runtime", root, name=selected)
         health = runtime.health(root)
     except (ProviderError, AgentRuntimeError, OSError) as error:
         return DoctorCheckResult(
@@ -238,16 +432,55 @@ def _runtime_provider_check(root: Path) -> DoctorCheckResult:
     )
 
 
+def _forge_provider_check(root: Path) -> DoctorCheckResult:
+    try:
+        selected = provider_name("forge", root)
+        forge = load_provider("forge", root, name=selected)
+        health_fn = getattr(forge, "health", None)
+        if callable(health_fn):
+            health = health_fn(root)
+            return DoctorCheckResult(
+                name=health.name,
+                passed=health.passed,
+                command=health.command,
+                output=health.output,
+                category="operational readiness",
+                summary=health.summary,
+            )
+    except (ProviderError, ForgeProviderError, OSError) as error:
+        return DoctorCheckResult(
+            name="forge provider",
+            passed=False,
+            command="load selected forge provider",
+            output=str(error),
+            category="operational readiness",
+            summary="provider unavailable",
+        )
+    remote_review = bool(getattr(forge, "supports_remote_review", True))
+    return DoctorCheckResult(
+        name=f"{selected} forge",
+        passed=True,
+        command=f"load {selected} forge provider",
+        output="",
+        category="operational readiness",
+        summary=(
+            "provider loaded; authentication check unavailable"
+            if remote_review
+            else "local-only publishing"
+        ),
+    )
+
+
 def _vcs_workspace_check(root: Path, timeout: float) -> DoctorCheckResult:
     del timeout
-    selected = provider_name("vcs", root)
     try:
+        selected = provider_name("vcs", root)
         clean = bool(load_provider("vcs", root, name=selected).is_clean(root))
     except (ProviderError, VersionControlProviderError, OSError) as error:
         return DoctorCheckResult(
-            name=f"{selected} worktree",
+            name="version control workspace",
             passed=False,
-            command=f"{selected} workspace status",
+            command="load selected version control provider",
             output=str(error),
             category="operational readiness",
             summary="provider unavailable",
@@ -268,28 +501,80 @@ def _git_worktree_check(root: Path, timeout: float) -> DoctorCheckResult:
 
 
 def _memory_storage_check(root: Path) -> DoctorCheckResult:
-    path = root / ".enoch" / ".doctor_write_check"
+    home = enoch_home(root)
+    path = home / ".doctor_write_check"
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("ok\n", encoding="utf-8")
         path.unlink(missing_ok=True)
-    except OSError as error:
+        state_files = _validate_state_files(home)
+    except (OSError, StateCorruptionError) as error:
         return DoctorCheckResult(
-            name="memory storage",
+            name="state storage",
             passed=False,
-            command=f"write {path}",
+            command=f"validate {home}",
             output=str(error),
             category="operational readiness",
-            summary="not writable",
+            summary="unreadable or not writable",
         )
     return DoctorCheckResult(
-        name="memory storage",
+        name="state storage",
         passed=True,
-        command=f"write {path}",
+        command=f"validate {home}",
         output="",
         category="operational readiness",
-        summary=".enoch writable",
+        summary=f"{home} writable; {state_files} state file(s) readable",
     )
+
+
+def _validate_state_files(home: Path) -> int:
+    count = 0
+    for path in sorted(home.rglob("*.json")):
+        data = load_json_object(path)
+        _validate_state_object_shape(path, data)
+        count += 1
+    for path in sorted(home.rglob("*.jsonl")):
+        _validate_json_lines(path)
+        count += 1
+    return count
+
+
+def _validate_state_object_shape(path: Path, data: dict[str, object]) -> None:
+    fields = STATE_OBJECT_FIELDS.get(path.name, {})
+    for field, expected_type in fields.items():
+        if field not in data:
+            continue
+        if not isinstance(data[field], expected_type):
+            raise StateCorruptionError(
+                path,
+                f"expected {field} to be {expected_type.__name__}",
+            )
+    if path.name == "task_queue.json":
+        running = data.get("running")
+        if running is not None and not isinstance(running, dict):
+            raise StateCorruptionError(path, "expected running to be an object or null")
+
+
+def _validate_json_lines(path: Path) -> None:
+    try:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise StateCorruptionError(
+                        path,
+                        f"invalid JSON at line {line_number}, column {error.colno}",
+                    ) from error
+                if not isinstance(value, dict):
+                    raise StateCorruptionError(
+                        path,
+                        f"expected a JSON object at line {line_number}",
+                    )
+    except OSError as error:
+        raise StateCorruptionError(path, str(error)) from error
 
 
 def _prepend_path(first: str, rest: str) -> str:
@@ -304,7 +589,7 @@ def _prepend_path(first: str, rest: str) -> str:
 def _combined_output(checks: list[DoctorCheckResult]) -> str:
     blocks = []
     for check in checks:
-        status = "passed" if check.passed else "failed"
+        status = "skipped" if check.skipped else ("passed" if check.passed else "failed")
         lines = [f"[{check.category}: {check.name}] {status}", f"Command: {check.command}"]
         if check.summary:
             lines.append(f"Summary: {check.summary}")
@@ -329,7 +614,11 @@ def _join_output(*parts: object) -> str:
 def _limit_output(output: str) -> str:
     if len(output) <= MAX_OUTPUT_CHARS:
         return output
-    return f"{output[:MAX_OUTPUT_CHARS].rstrip()}\n\n[doctor output truncated]"
+    marker = "\n\n[doctor output truncated; final output preserved]\n\n"
+    remaining = MAX_OUTPUT_CHARS - len(marker)
+    head = remaining // 2
+    tail = remaining - head
+    return f"{output[:head].rstrip()}{marker}{output[-tail:].lstrip()}"
 
 
 def _first_output_line(output: str) -> str:
@@ -383,8 +672,14 @@ def diagnose_output(output: str, passed: bool) -> DoctorDiagnosis:
 
     failing_tests = _failing_tests(output)
     likely_files = _likely_files(output)
+    environment_error = _environment_error_summary(output)
     import_error = _import_error_summary(output)
-    if failing_tests:
+    if environment_error:
+        summary = f"Test environment unavailable: {environment_error}"
+        suggested_action = (
+            "Install the reported locked test prerequisite, then run doctor again."
+        )
+    elif failing_tests:
         summary = f"{len(failing_tests)} test(s) failed."
         suggested_action = "Inspect the failing tests, make one focused repair pass, then run doctor again."
     elif import_error:
@@ -403,6 +698,28 @@ def diagnose_output(output: str, passed: bool) -> DoctorDiagnosis:
         likely_files=likely_files,
         suggested_action=suggested_action,
     )
+
+
+def _environment_error_summary(output: str) -> str:
+    explicit = re.search(
+        r"Doctor test environment is missing build backend ([^\s.]+(?:\.[^\s.]+)*)\.",
+        output,
+    )
+    if explicit:
+        return f"missing build backend {explicit.group(1)}."
+    backend = re.search(r"BackendUnavailable:\s+Cannot import ['\"]([^'\"]+)['\"]", output)
+    if backend:
+        return f"missing build backend {backend.group(1)}."
+    incompatible = re.search(
+        r"Doctor test environment has ([^\s]+) ([^,\s]+), but .* requires at least (\S+)\.",
+        output,
+    )
+    if incompatible:
+        return (
+            f"{incompatible.group(1)} {incompatible.group(2)} is below "
+            f"required version {incompatible.group(3)}."
+        )
+    return ""
 
 
 def _failing_tests(output: str) -> list[str]:
@@ -445,7 +762,15 @@ def _likely_files(output: str) -> list[str]:
     files = []
     for match in re.finditer(r'File "([^"]+)", line \d+', output):
         path = match.group(1)
-        if "/unittest/" in path or path.endswith("/unittest/case.py"):
+        if (
+            path.startswith("<")
+            or "/unittest/" in path
+            or path.endswith("/unittest/case.py")
+            or "/site-packages/" in path
+            or "/pip/_internal/" in path
+        ):
+            continue
+        if not any(segment in path for segment in ("/src/", "/tests/", "/libraries/")):
             continue
         files.append(path)
 

--- a/tests/test_enoch_e2e.py
+++ b/tests/test_enoch_e2e.py
@@ -63,7 +63,7 @@ class EnochEvolutionEndToEndTests(unittest.TestCase):
 
         bot_doctor = patch(
             "enoch.app.core.run_immune_system",
-            side_effect=lambda _root=None: _passing_doctor(),
+            side_effect=lambda _root=None, **_kwargs: _passing_doctor(),
         )
         publish_doctor = patch(
             "our_ark_github.workflow.run_immune_system",

--- a/tests/test_enoch_immune.py
+++ b/tests/test_enoch_immune.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import subprocess
 import sys
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -8,7 +10,18 @@ from unittest.mock import MagicMock, patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from enoch.immune import diagnose_output, run_immune_system
+from enoch.formatting import doctor_output_excerpt
+from enoch.immune import (
+    MAX_OUTPUT_CHARS,
+    _build_backend_check,
+    _codex_binary_check,
+    _forge_provider_check,
+    _limit_output,
+    _memory_storage_check,
+    diagnose_output,
+    run_immune_system,
+)
+from enoch.providers.registry import ProviderError
 
 
 def _check(
@@ -32,16 +45,109 @@ def _check(
 
 class EnochImmuneTests(unittest.TestCase):
     @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._forge_provider_check")
+    @patch("enoch.immune._codex_binary_check")
+    @patch("enoch.immune._build_backend_check")
+    @patch("enoch.immune.load_provider")
+    @patch("enoch.immune.subprocess.run")
+    def test_missing_build_backend_skips_tests_without_masking_failure(
+        self,
+        run: MagicMock,
+        load_provider: MagicMock,
+        build_backend_check: MagicMock,
+        codex_binary_check: MagicMock,
+        forge_provider_check: MagicMock,
+        memory_storage_check: MagicMock,
+    ) -> None:
+        run.return_value.returncode = 0
+        run.return_value.stdout = "OK"
+        run.return_value.stderr = ""
+        load_provider.return_value.is_clean.return_value = True
+        build_backend_check.return_value = _check(
+            "build backend",
+            passed=False,
+            category="environment readiness",
+        )
+        codex_binary_check.return_value = _check(
+            "codex runtime",
+            category="operational readiness",
+        )
+        forge_provider_check.return_value = _check(
+            "github forge",
+            category="operational readiness",
+        )
+        memory_storage_check.return_value = _check(
+            "state storage",
+            category="operational readiness",
+        )
+
+        result = run_immune_system(ROOT)
+
+        self.assertFalse(result.passed)
+        tests = next(check for check in result.checks if check.name == "tests")
+        self.assertTrue(tests.skipped)
+        self.assertTrue(tests.passed)
+        self.assertFalse(
+            any(
+                "-m unittest discover" in " ".join(call.args[0])
+                for call in run.call_args_list
+            )
+        )
+
+    @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._vcs_workspace_check")
+    @patch("enoch.immune._forge_provider_check")
+    @patch("enoch.immune._runtime_provider_check")
+    @patch("enoch.immune._run_check")
+    @patch("enoch.immune._python_runtime_check")
+    def test_task_doctor_uses_resident_root_for_operational_state(
+        self,
+        python_runtime_check: MagicMock,
+        run_check: MagicMock,
+        runtime_provider_check: MagicMock,
+        forge_provider_check: MagicMock,
+        vcs_workspace_check: MagicMock,
+        memory_storage_check: MagicMock,
+    ) -> None:
+        passed = _check("passed")
+        for mocked_check in (
+            python_runtime_check,
+            run_check,
+            runtime_provider_check,
+            forge_provider_check,
+            vcs_workspace_check,
+            memory_storage_check,
+        ):
+            mocked_check.return_value = passed
+        with TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            worktree = base / "task-worktree"
+            resident = base / "resident"
+            worktree.mkdir()
+            resident.mkdir()
+            with patch.dict("os.environ", {"ENOCH_TEST_COMMAND": "true"}):
+                result = run_immune_system(worktree, state_root=resident)
+
+        self.assertTrue(result.passed)
+        runtime_provider_check.assert_called_once_with(resident.resolve(), 120)
+        forge_provider_check.assert_called_once_with(resident.resolve())
+        memory_storage_check.assert_called_once_with(resident.resolve())
+        vcs_workspace_check.assert_called_once_with(worktree.resolve(), 120)
+
+    @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._forge_provider_check")
     @patch("enoch.immune._codex_binary_check")
     @patch("enoch.immune.subprocess.run")
     def test_runs_default_test_command(
         self,
         run: MagicMock,
         codex_binary_check: MagicMock,
+        forge_provider_check: MagicMock,
         memory_storage_check: MagicMock,
     ) -> None:
         codex_binary_check.return_value = _check("codex binary", category="operational readiness")
-        memory_storage_check.return_value = _check("memory storage", category="operational readiness")
+        forge_provider_check.return_value = _check("github forge", category="operational readiness")
+        memory_storage_check.return_value = _check("state storage", category="operational readiness")
         run.return_value.returncode = 0
         run.return_value.stdout = "OK"
         run.return_value.stderr = ""
@@ -59,14 +165,25 @@ class EnochImmuneTests(unittest.TestCase):
         self.assertIn("OK", result.output)
         self.assertEqual(
             [check.name for check in result.checks],
-            ["python runtime", "tests", "import smoke", "codex binary", "git worktree", "memory storage"],
+            [
+                "python runtime",
+                "build backend",
+                "tests",
+                "import smoke",
+                "codex binary",
+                "github forge",
+                "git worktree",
+                "state storage",
+            ],
         )
         self.assertEqual(
             [check.category for check in result.checks],
             [
                 "code health",
+                "environment readiness",
                 "code health",
                 "code health",
+                "operational readiness",
                 "operational readiness",
                 "operational readiness",
                 "operational readiness",
@@ -75,16 +192,19 @@ class EnochImmuneTests(unittest.TestCase):
         self.assertEqual(result.diagnosis.summary, "All configured health checks passed.")
 
     @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._forge_provider_check")
     @patch("enoch.immune._codex_binary_check")
     @patch("enoch.immune.subprocess.run")
     def test_empty_configured_test_command_fails_without_crashing(
         self,
         run: MagicMock,
         codex_binary_check: MagicMock,
+        forge_provider_check: MagicMock,
         memory_storage_check: MagicMock,
     ) -> None:
         codex_binary_check.return_value = _check("codex binary", category="operational readiness")
-        memory_storage_check.return_value = _check("memory storage", category="operational readiness")
+        forge_provider_check.return_value = _check("github forge", category="operational readiness")
+        memory_storage_check.return_value = _check("state storage", category="operational readiness")
         run.return_value.returncode = 0
         run.return_value.stdout = "OK"
         run.return_value.stderr = ""
@@ -98,19 +218,24 @@ class EnochImmuneTests(unittest.TestCase):
         self.assertIn("Doctor check command is empty", result.output)
 
     @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._forge_provider_check")
     @patch("enoch.immune._codex_binary_check")
     @patch("enoch.immune.subprocess.run")
     def test_timeout_is_reported_as_failed_check(
         self,
         run: MagicMock,
         codex_binary_check: MagicMock,
+        forge_provider_check: MagicMock,
         memory_storage_check: MagicMock,
     ) -> None:
         codex_binary_check.return_value = _check("codex binary", category="operational readiness")
-        memory_storage_check.return_value = _check("memory storage", category="operational readiness")
+        forge_provider_check.return_value = _check("github forge", category="operational readiness")
+        memory_storage_check.return_value = _check("state storage", category="operational readiness")
         passed = MagicMock(returncode=0, stdout="OK", stderr="")
+        backend = MagicMock(returncode=0, stdout="setuptools 83.0.0", stderr="")
         run.side_effect = [
             passed,
+            backend,
             subprocess.TimeoutExpired(["python3", "-m", "unittest"], timeout=1, output="partial"),
             passed,
             passed,
@@ -121,9 +246,10 @@ class EnochImmuneTests(unittest.TestCase):
 
         self.assertFalse(result.passed)
         self.assertIn("Timed out after 1 second(s).", result.output)
-        self.assertFalse(result.checks[1].passed)
+        self.assertFalse(result.checks[2].passed)
 
     @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._forge_provider_check")
     @patch("enoch.immune._codex_binary_check")
     @patch("enoch.immune.load_provider")
     @patch("enoch.immune.subprocess.run")
@@ -132,27 +258,32 @@ class EnochImmuneTests(unittest.TestCase):
         run: MagicMock,
         load_provider: MagicMock,
         codex_binary_check: MagicMock,
+        forge_provider_check: MagicMock,
         memory_storage_check: MagicMock,
     ) -> None:
         codex_binary_check.return_value = _check("codex binary", category="operational readiness")
-        memory_storage_check.return_value = _check("memory storage", category="operational readiness")
+        forge_provider_check.return_value = _check("github forge", category="operational readiness")
+        memory_storage_check.return_value = _check("state storage", category="operational readiness")
         clean = MagicMock(returncode=0, stdout="OK", stderr="")
-        run.side_effect = [clean, clean, clean]
+        backend = MagicMock(returncode=0, stdout="setuptools 83.0.0", stderr="")
+        run.side_effect = [clean, backend, clean, clean]
         load_provider.return_value.is_clean.return_value = False
 
         result = run_immune_system(ROOT)
 
         self.assertTrue(result.passed)
-        self.assertEqual(result.checks[4].name, "git worktree")
-        self.assertEqual(result.checks[4].summary, "worktree dirty")
+        self.assertEqual(result.checks[6].name, "git worktree")
+        self.assertEqual(result.checks[6].summary, "worktree dirty")
 
     @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._forge_provider_check")
     @patch("enoch.immune._codex_binary_check")
     @patch("enoch.immune.subprocess.run")
     def test_operational_failure_gets_specific_diagnosis(
         self,
         run: MagicMock,
         codex_binary_check: MagicMock,
+        forge_provider_check: MagicMock,
         memory_storage_check: MagicMock,
     ) -> None:
         codex_binary_check.return_value = _check(
@@ -161,7 +292,8 @@ class EnochImmuneTests(unittest.TestCase):
             output="Codex binary was not found.",
             category="operational readiness",
         )
-        memory_storage_check.return_value = _check("memory storage", category="operational readiness")
+        forge_provider_check.return_value = _check("github forge", category="operational readiness")
+        memory_storage_check.return_value = _check("state storage", category="operational readiness")
         run.return_value.returncode = 0
         run.return_value.stdout = "OK"
         run.return_value.stderr = ""
@@ -173,19 +305,23 @@ class EnochImmuneTests(unittest.TestCase):
         self.assertIn("failed doctor checks", result.diagnosis.suggested_action)
 
     @patch("enoch.immune._memory_storage_check")
+    @patch("enoch.immune._forge_provider_check")
     @patch("enoch.immune._codex_binary_check")
     @patch("enoch.immune.subprocess.run")
     def test_python_runtime_must_satisfy_project_minimum(
         self,
         run: MagicMock,
         codex_binary_check: MagicMock,
+        forge_provider_check: MagicMock,
         memory_storage_check: MagicMock,
     ) -> None:
         codex_binary_check.return_value = _check("codex binary", category="operational readiness")
-        memory_storage_check.return_value = _check("memory storage", category="operational readiness")
+        forge_provider_check.return_value = _check("github forge", category="operational readiness")
+        memory_storage_check.return_value = _check("state storage", category="operational readiness")
         old_python = MagicMock(returncode=0, stdout="Python 3.9.6\n", stderr="")
         passed = MagicMock(returncode=0, stdout="OK", stderr="")
-        run.side_effect = [old_python, passed, passed, passed]
+        backend = MagicMock(returncode=0, stdout="setuptools 83.0.0", stderr="")
+        run.side_effect = [old_python, backend, passed, passed, passed]
 
         result = run_immune_system(ROOT)
 
@@ -241,6 +377,141 @@ FAILED (failures=1)
             "Import smoke failed: cannot import missing_symbol from enoch.example.",
         )
         self.assertIn("broken import", diagnosis.suggested_action)
+
+    @patch("enoch.immune.subprocess.run")
+    def test_build_backend_failure_reports_locked_install_command(
+        self,
+        run: MagicMock,
+    ) -> None:
+        run.return_value.returncode = 1
+        run.return_value.stdout = ""
+        run.return_value.stderr = (
+            "pip._vendor.pyproject_hooks._impl.BackendUnavailable: "
+            "Cannot import 'setuptools.build_meta'"
+        )
+
+        check = _build_backend_check(ROOT, 1)
+
+        self.assertFalse(check.passed)
+        self.assertEqual(check.category, "environment readiness")
+        self.assertIn("missing setuptools.build_meta", check.summary)
+        self.assertIn("--require-hashes -r .github/requirements/test-build.txt", check.output)
+
+    @patch("enoch.immune.subprocess.run")
+    def test_build_backend_rejects_version_below_project_requirement(
+        self,
+        run: MagicMock,
+    ) -> None:
+        run.return_value.returncode = 0
+        run.return_value.stdout = "setuptools 76.0.0"
+        run.return_value.stderr = ""
+
+        check = _build_backend_check(ROOT, 1)
+
+        self.assertFalse(check.passed)
+        self.assertIn("requires >= 77", check.summary)
+        self.assertIn("requires at least 77", check.output)
+
+    def test_environment_failure_outranks_resulting_test_failure(self) -> None:
+        output = """
+Doctor test environment is missing build backend setuptools.build_meta.
+FAIL: test_wheel (tests.test_portable.PortableTests.test_wheel)
+"""
+
+        diagnosis = diagnose_output(output, passed=False)
+
+        self.assertEqual(
+            diagnosis.summary,
+            "Test environment unavailable: missing build backend setuptools.build_meta.",
+        )
+        self.assertEqual(
+            diagnosis.failing_tests,
+            ["tests.test_portable.PortableTests.test_wheel"],
+        )
+
+    def test_long_doctor_output_preserves_beginning_and_root_cause(self) -> None:
+        output = "beginning\n" + ("x" * MAX_OUTPUT_CHARS) + "\nROOT CAUSE"
+
+        limited = _limit_output(output)
+        excerpt = doctor_output_excerpt(limited)
+
+        self.assertLessEqual(len(limited), MAX_OUTPUT_CHARS)
+        self.assertIn("beginning", limited)
+        self.assertIn("ROOT CAUSE", limited)
+        self.assertIn("ROOT CAUSE", excerpt)
+
+    def test_state_storage_detects_and_preserves_corrupt_json(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state_file = root / ".enoch" / "task_queue.json"
+            state_file.parent.mkdir(parents=True)
+            state_file.write_text('{"pending": [', encoding="utf-8")
+
+            check = _memory_storage_check(root)
+
+            self.assertFalse(check.passed)
+            self.assertEqual(check.name, "state storage")
+            self.assertIn("invalid JSON", check.output)
+            self.assertEqual(state_file.read_text(encoding="utf-8"), '{"pending": [')
+
+    @patch("enoch.brain.resolve_codex_executable")
+    @patch("enoch.immune.subprocess.run")
+    def test_codex_runtime_check_verifies_login(
+        self,
+        run: MagicMock,
+        resolve_codex: MagicMock,
+    ) -> None:
+        resolve_codex.return_value = SimpleNamespace(
+            path="/Applications/Codex.app/codex",
+            source="configured",
+            detail="",
+        )
+        run.return_value.returncode = 0
+        run.return_value.stdout = "Logged in using ChatGPT"
+        run.return_value.stderr = ""
+
+        check = _codex_binary_check(ROOT, timeout=30)
+
+        self.assertTrue(check.passed)
+        self.assertIn("authenticated", check.summary)
+        self.assertEqual(
+            run.call_args.args[0],
+            ["/Applications/Codex.app/codex", "login", "status"],
+        )
+        self.assertEqual(run.call_args.kwargs["timeout"], 15)
+
+    @patch("enoch.brain.resolve_codex_executable")
+    @patch("enoch.immune.subprocess.run")
+    def test_codex_runtime_check_reports_expired_login(
+        self,
+        run: MagicMock,
+        resolve_codex: MagicMock,
+    ) -> None:
+        resolve_codex.return_value = SimpleNamespace(
+            path="/Applications/Codex.app/codex",
+            source="configured",
+            detail="",
+        )
+        run.return_value.returncode = 1
+        run.return_value.stdout = ""
+        run.return_value.stderr = "Not logged in."
+
+        check = _codex_binary_check(ROOT)
+
+        self.assertFalse(check.passed)
+        self.assertIn("not authenticated", check.summary)
+        self.assertIn("codex login", check.output)
+
+    @patch("enoch.immune.provider_name", side_effect=ProviderError("bad provider config"))
+    def test_forge_provider_configuration_failure_does_not_crash_doctor(
+        self,
+        _provider_name: MagicMock,
+    ) -> None:
+        check = _forge_provider_check(ROOT)
+
+        self.assertFalse(check.passed)
+        self.assertEqual(check.name, "forge provider")
+        self.assertIn("bad provider config", check.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -426,6 +426,9 @@ def _write_fake_codex(path: Path) -> None:
             import sys
 
             args = sys.argv[1:]
+            if args[:2] == ["login", "status"]:
+                print("Logged in using portable test runtime.")
+                raise SystemExit(0)
             prompt = sys.stdin.read()
             if "Operate as a careful researcher." not in prompt:
                 raise SystemExit("Installed profile context did not reach the task prompt.")

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -4655,7 +4655,7 @@ class EnochTelegramTests(unittest.TestCase):
                             session_key="telegram:42:task:2",
                         )
 
-        run_immune_system.assert_called_once_with(root)
+        run_immune_system.assert_called_once_with(root, state_root=root)
         publish_feature_pr.assert_called_once_with(
             42,
             "add test to the README",


### PR DESCRIPTION
## Summary

- preflight the configured Python build backend and skip the suite cleanly when its prerequisite is unavailable
- verify Codex login and optional forge-provider health, including GitHub CLI authentication
- validate persisted JSON and JSONL state without replacing corrupt files, using the resident state root for isolated task worktrees
- preserve both the beginning and root-cause tail of long Doctor failures and filter irrelevant third-party traceback paths
- document Doctor’s code, environment, and operational readiness sections

## Root cause

Doctor previously treated a missing local build backend as a source-code test regression, only checked that the Codex executable existed, did not inspect forge authentication, touched `.enoch` without validating its contents, and truncated away the final exception that usually explains a failure.

## Validation

- `python -m unittest discover -s tests -t .` — 621 passed
- all provider-library suites — 34 passed
- end-to-end `bin/enoch doctor` with the locked backend — passed
- `git diff --check` — passed