### PR TITLE
Prepare Enoch v0.2.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,11 +5,11 @@ type: software
 authors:
   - family-names: Zhao
     given-names: Gary
-version: 0.2.0
-date-released: 2026-07-22
+version: 0.2.1
+date-released: 2026-07-23
 license: Apache-2.0
 repository-code: "https://github.com/our-ark/enoch"
-url: "https://github.com/our-ark/enoch/releases/tag/v0.2.0"
+url: "https://github.com/our-ark/enoch/releases/tag/v0.2.1"
 keywords:
   - agent-owned software
   - personal agents

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,47 @@
+# Enoch v0.2.1
+
+Enoch v0.2.1 strengthens the first public agent body with durable task
+execution, clearer operational controls, richer extension contracts, and a
+smaller application core. The release focuses on making long-running work safe
+to recover, inspect, and publish without changing Enoch's provider-neutral
+architecture.
+
+## Highlights
+
+- Added durable chat inbox receipts and idempotent task acceptance so updates
+  can be retried without silently duplicating completed work.
+- Hardened task execution with worker leases, structured outcomes, timeouts,
+  cancellation, automatic retry classification, pause/resume behavior, and
+  resumable commit, push, and pull-request stages.
+- Added isolated task-worktree inspection and management through `/worktree`,
+  `/worktree show`, `/worktree cleanup`, and explicit forced discard.
+- Unified Telegram command metadata and routing in one registry, removed
+  aliases, made `/help <command>` discoverable, and eliminated stale help text.
+- Expanded provider and profile contracts with typed runtime results,
+  progress/cancellation controls, provider-neutral configuration, lifecycle
+  hooks, prompt contributors, and task policy.
+- Added semantic evolve-candidate curation, richer provenance and event
+  reporting, and clearer governance for scheduled and inherited evolution.
+- Expanded Doctor to distinguish code health, environment readiness, and
+  operational readiness while reporting actionable provider diagnostics.
+- Extracted isolated task execution and the commit/push/PR handoff from
+  `EnochApplication` into an explicitly wired task workflow.
+
+## Validation
+
+- The 621-test Enoch body suite passes.
+- GitHub, launchd, provider-kit, skill-catalog, systemd, Telegram, and Telegram
+  vision provider suites pass independently.
+- GitHub Actions covers Python 3.11, 3.12, 3.13, and 3.14.
+- Import smoke covers the CLI, application core, daemon, Doctor, lineage,
+  memory, skills, providers, and update tooling.
+
+## Compatibility
+
+- Python 3.11 or newer.
+- `genesis.toml` schema version 1.
+- Genesis v0.1.0 or a later compatible build.
+
+Credentials, memories, logs, chat identifiers, task state, and instance
+configuration remain outside both the public source archive and the inheritable
+software body.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enoch"
-version = "0.2.0"
+version = "0.2.1"
 description = "Enoch is a Genesis-created local agent."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -163,7 +163,7 @@ class EnochPortableInstallTests(unittest.TestCase):
         self.assertEqual(result["vcs"], "portable-vcs")
         self.assertEqual(result["runtime"], "codex")
         self.assertEqual(result["forge"], "local")
-        self.assertEqual(result["enoch_version"], "0.2.0")
+        self.assertEqual(result["enoch_version"], "0.2.1")
         self.assertEqual(result["chat_provider_version"], "0.0.1")
         self.assertEqual(result["vcs_provider_version"], "0.0.1")
         self.assertEqual(result["profile"], "researcher")


### PR DESCRIPTION
## What changed

- bump the Enoch package version from 0.2.0 to 0.2.1
- update `CITATION.cff` with the v0.2.1 release date and URL
- add the v0.2.1 release notes
- update the portable-install assertion for the new package version

## Why

This prepares the repository metadata and documented release record for the v0.2.1 patch release.

## Release highlights

- durable and resumable task execution
- managed task worktrees and publishing stages
- unified command registry and clearer help
- expanded provider/profile execution contracts
- semantic evolve curation and provenance
- improved Doctor readiness diagnostics
- task workflow extraction from the application core

## Validation

- `python -m unittest discover -s tests -t .` — 621 passed
- GitHub provider tests — 5 passed
- launchd tests — 4 passed
- provider-kit tests — 7 passed
- skill-catalog tests — 3 passed
- systemd tests — 4 passed
- Telegram tests — 6 passed
- Telegram vision tests — 5 passed
- `git diff --check`