### PR TITLE
Add completion evidence to semantic curation

### DIFF
--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -82,6 +82,11 @@ from enoch.evolution.core import (
     set_evolve_mode,
     set_evolve_theme,
 )
+from enoch.evolution.curation import (
+    REMOVE_CLASSIFICATIONS,
+    curation_evidence_refs,
+    latest_remove_suggestion,
+)
 from enoch.evolution.events import (
     EvolveEvent,
     close_open_proposals,
@@ -2187,6 +2192,27 @@ class EnochApplication:
                 return "Use /evolve remove <id> [reason] to remove a self-evolution candidate."
             remove_parts = rest.strip().split(maxsplit=1)
             remove_reason = remove_parts[1] if len(remove_parts) > 1 else "human-requested-removal"
+            removal_classification = ""
+            removal_curation_id = ""
+            removal_evidence_refs: tuple[str, ...] = ()
+            reason_parts = remove_reason.split(maxsplit=1)
+            requested_classification = reason_parts[0].lower()
+            if requested_classification in REMOVE_CLASSIFICATIONS:
+                removal_classification = requested_classification
+                recorded = latest_remove_suggestion(
+                    remove_parts[0],
+                    self.root,
+                    classification=requested_classification,
+                )
+                if recorded is not None:
+                    curation, suggestion = recorded
+                    removal_curation_id = curation.id
+                    removal_evidence_refs = suggestion.evidence_refs
+                    remove_reason = (
+                        reason_parts[1]
+                        if len(reason_parts) > 1
+                        else suggestion.reason
+                    )
             state = evolve_report(self.root).state
             try:
                 candidate = remove_evolve_candidate(
@@ -2194,6 +2220,9 @@ class EnochApplication:
                     self.root,
                     theme=state.theme,
                     reason=remove_reason,
+                    classification=removal_classification,
+                    curation_id=removal_curation_id,
+                    evidence_refs=removal_evidence_refs,
                 )
             except ValueError as error:
                 return str(error)
@@ -2323,6 +2352,11 @@ class EnochApplication:
                 curation_id=(proposal.curation.id if proposal is not None and proposal.curation else ""),
                 recommendation_kind=(
                     proposal.curation.status if proposal is not None and proposal.curation else ""
+                ),
+                evidence_refs=(
+                    curation_evidence_refs(proposal.curation)
+                    if proposal is not None
+                    else ()
                 ),
             )
         except (OSError, ValueError):

--- a/src/enoch/app/reporting.py
+++ b/src/enoch/app/reporting.py
@@ -454,6 +454,10 @@ def _format_evolve_event(event: EvolveEvent) -> list[str]:
         details.append(f"health {event.health_check}")
     if event.recording_mode:
         details.append(f"recording {event.recording_mode}")
+    if event.removal_classification:
+        details.append(f"classification {event.removal_classification}")
+    if event.evidence_refs:
+        details.append(f"refs {', '.join(event.evidence_refs)}")
     lines.append(f"  {'; '.join(details)}")
     if event.reason:
         lines.append(f"  Reason: {_clip_activity_text(event.reason, limit=180)}")
@@ -558,6 +562,11 @@ def _format_evolve_proposal(proposal: EvolveProposal) -> str:
                 f"- {suggestion.candidate_id} [{suggestion.classification}] "
                 f"{_clip_activity_text(suggestion.reason, limit=180)}"
             )
+            if suggestion.evidence_refs:
+                lines.append(
+                    "  Evidence: "
+                    + ", ".join(suggestion.evidence_refs)
+                )
             lines.append(
                 f"  Human action: /evolve remove {suggestion.candidate_id} {suggestion.classification}"
             )

--- a/src/enoch/evolution/core.py
+++ b/src/enoch/evolution/core.py
@@ -20,10 +20,14 @@ from enoch.cron import CronJob, cron_status, format_cron_interval
 from enoch.evolution.curation import (
     DEFAULT_CURATION_LIMIT,
     CurationGenerator,
+    REMOVE_CLASSIFICATIONS,
     SemanticCuration,
     curate_candidates,
     deterministic_fallback,
+    load_curations,
+    recent_completion_evidence,
     record_curation,
+    sanitize_curation_text,
     with_new_candidate_ids,
 )
 from enoch.evolution.sources.experience import ExperienceRecord, load_experience_records
@@ -451,16 +455,36 @@ def propose_evolve(
         if curator is None:
             curation = deterministic_fallback(snapshots, reason="curator-unavailable")
         else:
+            completion_evidence: tuple[dict[str, object], ...] = ()
             try:
-                curation = curate_candidates(
-                    mission=mission,
-                    theme=report.state.theme,
-                    candidates=snapshots,
-                    generator=curator,
+                completion_evidence = recent_completion_evidence(snapshots, root)
+            except (OSError, RuntimeError, TimeoutError, ValueError) as evidence_error:
+                detail = clean_text(str(evidence_error)) or evidence_error.__class__.__name__
+                curation = deterministic_fallback(
+                    snapshots,
+                    reason=f"completion-evidence-unavailable: {detail}",
                 )
-            except (OSError, RuntimeError, TimeoutError, ValueError) as curation_error:
-                reason = clean_text(str(curation_error)) or curation_error.__class__.__name__
-                curation = deterministic_fallback(snapshots, reason=reason)
+            if curation is None:
+                try:
+                    curation = curate_candidates(
+                        mission=mission,
+                        theme=report.state.theme,
+                        candidates=snapshots,
+                        completion_evidence=completion_evidence,
+                        generator=curator,
+                    )
+                except (OSError, RuntimeError, TimeoutError, ValueError) as curation_error:
+                    reason = clean_text(str(curation_error)) or curation_error.__class__.__name__
+                    refs = (
+                        ref
+                        for item in completion_evidence
+                        for ref in item.get("evidence_refs", ())
+                    )
+                    curation = deterministic_fallback(
+                        snapshots,
+                        reason=reason,
+                        evidence_refs=refs,
+                    )
         if curation.status == "llm" and curation.new_candidates:
             ideas = tuple(
                 brainstorm_idea(
@@ -548,8 +572,7 @@ def _select_curation_candidates(
 
 
 def _bounded_curation_text(value: str, *, limit: int = 1200) -> str:
-    cleaned = clean_text(value)
-    return cleaned if len(cleaned) <= limit else cleaned[: limit - 3].rstrip() + "..."
+    return sanitize_curation_text(value, limit=limit)
 
 
 def _claim_auto_brainstorm(
@@ -669,7 +692,33 @@ def remove_evolve_candidate(
     event_actor: str = "human",
     trigger: str = "/evolve remove",
     reason: str = "human-requested-removal",
+    classification: str = "",
+    curation_id: str = "",
+    evidence_refs: tuple[str, ...] = (),
 ) -> EvolveCandidate:
+    normalized_actor = clean_text(event_actor).lower()
+    if normalized_actor != "human":
+        raise ValueError("Only a human can remove an evolve candidate.")
+    normalized_classification = clean_text(classification).lower()
+    if normalized_classification and normalized_classification not in REMOVE_CLASSIFICATIONS:
+        raise ValueError("Unknown evolve candidate removal classification.")
+    normalized_curation_id = clean_text(curation_id)
+    normalized_refs = tuple(clean_text(ref) for ref in evidence_refs if clean_text(ref))
+    if normalized_curation_id or normalized_refs:
+        matching = next(
+            (
+                suggestion
+                for curation in load_curations(root)
+                if curation.id == normalized_curation_id
+                for suggestion in curation.remove_suggestions
+                if suggestion.candidate_id.lower() == candidate_id.strip().lower().lstrip("#")
+                and suggestion.classification == normalized_classification
+                and suggestion.evidence_refs == normalized_refs
+            ),
+            None,
+        )
+        if matching is None:
+            raise ValueError("Removal evidence does not match the recorded curation suggestion.")
     candidate = get_evolve_candidate(candidate_id, root, theme=theme)
     if candidate.status not in ACTIONABLE_CANDIDATE_STATUSES:
         raise ValueError(f"Evolve candidate {candidate.id} cannot be removed from status {candidate.status}.")
@@ -683,6 +732,9 @@ def remove_evolve_candidate(
         theme=theme,
         proposal_id=latest_open_proposal_id(removed.id, root),
         reason=reason,
+        curation_id=normalized_curation_id,
+        removal_classification=normalized_classification,
+        evidence_refs=normalized_refs,
     )
     return removed
 
@@ -980,6 +1032,9 @@ def _record_candidate_event_safely(
     retry_of_task_id: int | None = None,
     reason: str = "",
     proposal_id: str = "",
+    curation_id: str = "",
+    removal_classification: str = "",
+    evidence_refs: tuple[str, ...] = (),
     runtime_task: TaskJob | None = None,
 ) -> None:
     state = load_evolve_state(root)
@@ -1001,6 +1056,9 @@ def _record_candidate_event_safely(
             retry_of_task_id=retry_of_task_id,
             reason=reason,
             proposal_id=linked_id,
+            curation_id=curation_id,
+            removal_classification=removal_classification,
+            evidence_refs=evidence_refs,
             runtime_task=runtime_task,
         )
     except (OSError, ValueError):

--- a/src/enoch/evolution/curation.py
+++ b/src/enoch/evolution/curation.py
@@ -7,12 +7,15 @@ import re
 from typing import Callable, Iterable, Mapping
 from uuid import uuid4
 
+from enoch.evolution.events import load_evolve_events
 from enoch.memory.paths import clean_text, now as current_time
 from enoch.paths import enoch_home
+from enoch.tasks.events import TaskEvent, load_recent_task_outcomes
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DEFAULT_CURATION_LIMIT = 24
+DEFAULT_COMPLETION_EVIDENCE_LIMIT = 12
 REMOVE_CLASSIFICATIONS = {
     "duplicate",
     "superseded",
@@ -22,6 +25,40 @@ REMOVE_CLASSIFICATIONS = {
     "not-actionable",
 }
 CurationGenerator = Callable[[str], str]
+
+_PR_URL_PATTERN = re.compile(
+    r"https://[A-Za-z0-9.-]+/[^\s]+/(?:pull|pulls|merge_requests)/\d+/?$"
+)
+_EVIDENCE_REF_PATTERNS = (
+    re.compile(r"task:[1-9]\d*$"),
+    re.compile(r"pr:https://[A-Za-z0-9.-]+/[^\s]+/(?:pull|pulls|merge_requests)/\d+/?$"),
+    re.compile(r"merge:[0-9a-fA-F]{7,64}$"),
+    re.compile(r"version:[A-Za-z0-9._-]{1,80}$"),
+)
+_SECRET_PATTERN = re.compile(
+    r"(?i)\b(api[_ -]?key|access[_ -]?token|token|password|secret|authorization)"
+    r"\b\s*[:=]\s*(?:bearer\s+)?[^\s,;]+"
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}")
+_CHAT_ID_PATTERN = re.compile(
+    r"(?i)\b(chat|conversation|session|message)[_-]?id\b\s*[:=]\s*[^\s,;]+"
+)
+_MEMORY_ID_PATTERN = re.compile(r"\bmem_\d{8}_[A-Za-z0-9_-]+\b")
+_MEMORY_BLOCK_PATTERN = re.compile(
+    r"(?is)\[ENOCH_MEMORY_REQUEST\].*?\[/ENOCH_MEMORY_REQUEST\]"
+)
+_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9:])(?:/(?:Users|home|private|tmp|var|etc|opt)/[^\s,;)\]}]+"
+    r"|(?<![:/\w])/(?:[^/\s]+/)+[^\s,;)\]}]+"
+    r"|[A-Za-z]:\\[^\s,;)\]}]+)"
+)
+_PRIVATE_STATE_PATTERN = re.compile(r"(?<![\w/])\.enoch/[^\s,;)\]}]+")
+_BODY_CHANGE_PATTERN = re.compile(
+    r"\b(?:add|change|create|delete|edit|fix|implement|modify|remove|replace|rewrite|"
+    r"update|code|file|repository|module|function|class|schema|test|docs?|config|"
+    r"prompt|journal|command|cli)\b",
+    re.IGNORECASE,
+)
 
 _ACTION = r"(?:change|modify|edit|update|alter|rewrite|replace|delete|grant|revoke|expand|remove|bypass|automate|enable|disable|configure|deploy|merge|publish|rotate|expose)"
 _PROTECTED = r"(?:identity|mission|secret|credential|permission|access control|merge authority|auto[- ]?merge|deployment|forge settings?|daemon configuration)"
@@ -55,6 +92,7 @@ class RemoveSuggestion:
     candidate_id: str
     classification: str
     reason: str
+    evidence_refs: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -73,6 +111,7 @@ class SemanticCuration:
     created_at: str
     status: str
     input_candidate_ids: tuple[str, ...]
+    input_evidence_refs: tuple[str, ...] = ()
     recommendation: CandidateRecommendation | None = None
     remove_suggestions: tuple[RemoveSuggestion, ...] = ()
     new_candidates: tuple[NewCandidateSuggestion, ...] = ()
@@ -88,11 +127,15 @@ def semantic_curation_prompt(
     mission: str,
     theme: str,
     candidates: Iterable[Mapping[str, object]],
+    completion_evidence: Iterable[Mapping[str, object]] = (),
 ) -> str:
     payload = {
-        "mission": _clip(clean_text(mission), 2000),
-        "evolution_theme": _clip(clean_text(theme), 500),
-        "candidates": list(candidates),
+        "mission": sanitize_curation_text(mission, limit=2000),
+        "evolution_theme": sanitize_curation_text(theme, limit=500),
+        "candidates": [_prompt_candidate(item) for item in candidates],
+        "recent_completed_work": [
+            _prompt_completion_evidence(item) for item in completion_evidence
+        ],
     }
     schema = {
         "recommended_candidate_id": "existing candidate ID or null",
@@ -105,6 +148,7 @@ def semantic_curation_prompt(
                 "candidate_id": "existing candidate ID",
                 "classification": "duplicate|superseded|obsolete|already-resolved|context-only|not-actionable",
                 "reason": "auditable reason",
+                "evidence_refs": ["task:17", "pr:https://...", "merge:e536d32", "version:..."],
             }
         ],
         "new_candidates": [
@@ -125,6 +169,10 @@ def semantic_curation_prompt(
             "Recommend at most one existing candidate. Do not invent an ID.",
             "Treat provenance as immutable evidence; never rewrite or reclassify its source or actors.",
             "Suggest removals only; do not approve, queue, run, remove, merge, deploy, or change permissions.",
+            "For already-resolved or superseded, cite only evidence_refs present in recent_completed_work.",
+            "A completed worker task or open/unmerged PR is not authoritative evidence that a body change is resolved.",
+            "Body-change resolution requires evidence labelled authoritative-body; task-completion evidence only supports genuinely non-body work.",
+            "Failed, cancelled, regressed, partial, or unpromoted body work must not support already-resolved or superseded.",
             "New candidates must be concrete, small, reversible, and testable.",
             "Do not propose changes to identity, mission, secrets, credentials, permissions, access control, merge authority, deployment, forge settings, daemon configuration, or destructive behavior.",
             f"Required response schema: {json.dumps(schema, sort_keys=True)}",
@@ -138,12 +186,15 @@ def curate_candidates(
     mission: str,
     theme: str,
     candidates: Iterable[Mapping[str, object]],
+    completion_evidence: Iterable[Mapping[str, object]] = (),
     generator: CurationGenerator,
 ) -> SemanticCuration:
     snapshots = tuple(candidates)
+    evidence = tuple(completion_evidence)
     candidate_ids = tuple(clean_text(str(item.get("id") or "")) for item in snapshots)
     known = {candidate_id: item for candidate_id, item in zip(candidate_ids, snapshots) if candidate_id}
-    response = generator(semantic_curation_prompt(mission, theme, snapshots))
+    known_evidence = _known_evidence(evidence)
+    response = generator(semantic_curation_prompt(mission, theme, snapshots, evidence))
     payload = _json_object(response)
     if not isinstance(payload, dict):
         raise CurationError("semantic curator returned malformed JSON")
@@ -160,7 +211,11 @@ def curate_candidates(
         raise CurationError("semantic curator returned an invalid schema")
 
     recommendation = _recommendation(payload, known)
-    remove_suggestions = _remove_suggestions(payload.get("remove_suggestions"), known)
+    remove_suggestions = _remove_suggestions(
+        payload.get("remove_suggestions"),
+        known,
+        known_evidence,
+    )
     new_candidates = _new_candidates(payload.get("new_candidates"))
     if recommendation is not None and any(
         item.candidate_id == recommendation.candidate_id for item in remove_suggestions
@@ -173,6 +228,7 @@ def curate_candidates(
         created_at=current_time(),
         status="llm",
         input_candidate_ids=candidate_ids,
+        input_evidence_refs=tuple(known_evidence),
         recommendation=recommendation,
         remove_suggestions=remove_suggestions,
         new_candidates=new_candidates,
@@ -183,6 +239,7 @@ def deterministic_fallback(
     candidates: Iterable[Mapping[str, object]],
     *,
     reason: str,
+    evidence_refs: Iterable[str] = (),
 ) -> SemanticCuration:
     snapshots = tuple(candidates)
     ids = tuple(clean_text(str(item.get("id") or "")) for item in snapshots)
@@ -205,8 +262,9 @@ def deterministic_fallback(
         created_at=created_at,
         status="deterministic-fallback",
         input_candidate_ids=ids,
+        input_evidence_refs=_valid_evidence_refs(evidence_refs),
         recommendation=recommendation,
-        fallback_reason=_clip(clean_text(reason), 300),
+        fallback_reason=sanitize_curation_text(reason, limit=300),
     )
 
 
@@ -233,6 +291,330 @@ def record_curation(curation: SemanticCuration, root: Path | None = None) -> Non
         handle.write(json.dumps(payload, sort_keys=True) + "\n")
 
 
+def recent_completion_evidence(
+    candidates: Iterable[Mapping[str, object]],
+    root: Path | None = None,
+    *,
+    limit: int = DEFAULT_COMPLETION_EVIDENCE_LIMIT,
+) -> tuple[dict[str, object], ...]:
+    """Build bounded, redacted completion evidence from structured journals."""
+    if limit <= 0:
+        return ()
+    snapshots = tuple(candidates)
+    outcomes = load_recent_task_outcomes(root, limit=max(limit * 4, limit))
+    lifecycle = load_evolve_events(root)
+    promoted_by_task = {
+        event.task_id: event
+        for event in lifecycle
+        if event.event == "promoted" and event.task_id is not None
+    }
+    adopted_by_task = {
+        event.task_id: event
+        for event in lifecycle
+        if event.event == "adopted" and event.task_id is not None
+    }
+    evidence: list[dict[str, object]] = []
+    for outcome in outcomes:
+        if outcome.event != "completed":
+            continue
+        promoted = promoted_by_task.get(outcome.task_id)
+        adopted = adopted_by_task.get(outcome.task_id)
+        evidence.append(
+            _completion_evidence_payload(
+                outcome,
+                snapshots,
+                promoted=promoted,
+                adopted=adopted,
+            )
+        )
+    return tuple(evidence[-limit:])
+
+
+def _prompt_candidate(candidate: Mapping[str, object]) -> dict[str, object]:
+    provenance = candidate.get("provenance")
+    provenance = provenance if isinstance(provenance, Mapping) else {}
+    return {
+        "id": _clip(clean_text(str(candidate.get("id") or "")), 200),
+        "source": _clip(clean_text(str(candidate.get("source") or "")), 80),
+        "title": sanitize_curation_text(candidate.get("title"), limit=1200),
+        "rationale": sanitize_curation_text(candidate.get("rationale"), limit=1200),
+        "proposed_change": sanitize_curation_text(
+            candidate.get("proposed_change"),
+            limit=1200,
+        ),
+        "expected_benefit": sanitize_curation_text(
+            candidate.get("expected_benefit"),
+            limit=1200,
+        ),
+        "risk": sanitize_curation_text(candidate.get("risk"), limit=1200),
+        "test_plan": sanitize_curation_text(candidate.get("test_plan"), limit=1200),
+        "status": _clip(clean_text(str(candidate.get("status") or "")), 40),
+        "deterministic_score": _bounded_int(candidate.get("deterministic_score")),
+        "provenance": {
+            "evidence_source": _clip(
+                clean_text(str(provenance.get("evidence_source") or "")),
+                80,
+            ),
+            "signal_actor": _clip(
+                clean_text(str(provenance.get("signal_actor") or "")),
+                40,
+            ),
+            "candidate_actor": _clip(
+                clean_text(str(provenance.get("candidate_actor") or "")),
+                40,
+            ),
+            "parent_candidate_id": _clip(
+                clean_text(str(provenance.get("parent_candidate_id") or "")),
+                200,
+            ),
+            "source_task_id": _positive_int(provenance.get("source_task_id")),
+        },
+    }
+
+
+def _prompt_completion_evidence(evidence: Mapping[str, object]) -> dict[str, object]:
+    direct_ids = evidence.get("direct_candidate_ids")
+    direct_ids = direct_ids if isinstance(direct_ids, (list, tuple)) else ()
+    changed_files = evidence.get("changed_files")
+    changed_files = changed_files if isinstance(changed_files, (list, tuple)) else ()
+    pr_urls = evidence.get("pr_urls")
+    pr_urls = pr_urls if isinstance(pr_urls, (list, tuple)) else ()
+    return {
+        "task_id": _positive_int(evidence.get("task_id")),
+        "completed_at": sanitize_curation_text(
+            evidence.get("completed_at"),
+            limit=80,
+        ),
+        "completion_kind": _clip(
+            clean_text(str(evidence.get("completion_kind") or "")),
+            80,
+        ),
+        "resolution_authority": _clip(
+            clean_text(str(evidence.get("resolution_authority") or "")),
+            40,
+        ),
+        "request_summary": sanitize_curation_text(
+            evidence.get("request_summary"),
+            limit=600,
+        ),
+        "result_summary": sanitize_curation_text(
+            evidence.get("result_summary"),
+            limit=800,
+        ),
+        "direct_candidate_ids": [
+            _clip(clean_text(str(value or "")), 200)
+            for value in direct_ids[:12]
+            if clean_text(str(value or ""))
+        ],
+        "parent_task_id": _positive_int(evidence.get("parent_task_id")),
+        "source_task_id": _positive_int(evidence.get("source_task_id")),
+        "pr_urls": list(_safe_pr_urls(str(value) for value in pr_urls)),
+        "changed_files": list(_safe_changed_files(str(value) for value in changed_files)),
+        "merge_commit": _safe_revision(str(evidence.get("merge_commit") or "")),
+        "authoritative_branch": _safe_branch(
+            str(evidence.get("authoritative_branch") or "")
+        ),
+        "promoted_at": sanitize_curation_text(
+            evidence.get("promoted_at"),
+            limit=80,
+        ),
+        "authoritative_version": _safe_version(
+            str(evidence.get("authoritative_version") or "")
+        ),
+        "verified_at": sanitize_curation_text(
+            evidence.get("verified_at"),
+            limit=80,
+        ),
+        "evidence_refs": list(_valid_evidence_refs(evidence.get("evidence_refs", ()))),
+    }
+
+
+def _completion_evidence_payload(
+    outcome: TaskEvent,
+    candidates: tuple[Mapping[str, object], ...],
+    *,
+    promoted: object | None,
+    adopted: object | None,
+) -> dict[str, object]:
+    pr_urls = _safe_pr_urls(
+        (
+            *outcome.pr_urls,
+            str(getattr(promoted, "pr_url", "") or ""),
+        )
+    )
+    changed_files = _safe_changed_files(outcome.changed_files)
+    runtime_reason = clean_text(outcome.runtime_completion_reason).lower()
+    partial = bool(runtime_reason and runtime_reason != "completed")
+    merge_commit = _safe_revision(str(getattr(promoted, "merge_commit", "") or ""))
+    version = _safe_version(str(getattr(adopted, "version", "") or ""))
+    body_change = bool(
+        changed_files
+        or pr_urls
+        or outcome.commit_sha
+        or outcome.publish_stage in {"committed", "pushed", "pr_opened"}
+    )
+    if partial:
+        completion_kind = "partial"
+        authority = "none"
+    elif promoted is not None and merge_commit:
+        completion_kind = "authoritative-body-change"
+        authority = "authoritative-body"
+    elif body_change:
+        completion_kind = "open-or-unpromoted-body-change"
+        authority = "none"
+    else:
+        completion_kind = "completed-no-body-change"
+        authority = "task-completion"
+
+    linked = {
+        clean_text(outcome.candidate_id),
+        clean_text(outcome.parent_candidate_id),
+        clean_text(str(getattr(promoted, "candidate_id", "") or "")),
+    }
+    for candidate in candidates:
+        candidate_id = clean_text(str(candidate.get("id") or ""))
+        provenance = candidate.get("provenance")
+        source_task_id = (
+            provenance.get("source_task_id")
+            if isinstance(provenance, Mapping)
+            else None
+        )
+        if candidate_id and _positive_int(source_task_id) == outcome.task_id:
+            linked.add(candidate_id)
+    linked.discard("")
+
+    refs = [f"task:{outcome.task_id}"]
+    refs.extend(f"pr:{url}" for url in pr_urls)
+    if merge_commit:
+        refs.append(f"merge:{merge_commit}")
+    if version:
+        refs.append(f"version:{version}")
+    return {
+        "task_id": outcome.task_id,
+        "completed_at": _clip(clean_text(outcome.occurred_at), 80),
+        "completion_kind": completion_kind,
+        "resolution_authority": authority,
+        "request_summary": sanitize_curation_text(outcome.request, limit=600),
+        "result_summary": sanitize_curation_text(outcome.result_summary, limit=800),
+        "direct_candidate_ids": sorted(linked)[:12],
+        "parent_task_id": outcome.parent_task_id,
+        "source_task_id": outcome.source_task_id,
+        "pr_urls": list(pr_urls),
+        "changed_files": list(changed_files),
+        "merge_commit": merge_commit,
+        "authoritative_branch": _safe_branch(
+            str(getattr(promoted, "authoritative_branch", "") or "")
+        ),
+        "promoted_at": _clip(
+            clean_text(str(getattr(promoted, "promoted_at", "") or "")),
+            80,
+        ),
+        "authoritative_version": version,
+        "verified_at": _clip(
+            clean_text(
+                str(
+                    getattr(adopted, "verified_at", "")
+                    or getattr(promoted, "verified_at", "")
+                    or ""
+                )
+            ),
+            80,
+        ),
+        "evidence_refs": list(_valid_evidence_refs(refs)),
+    }
+
+
+def sanitize_curation_text(value: object, *, limit: int) -> str:
+    text = str(value or "")
+    text = _MEMORY_BLOCK_PATTERN.sub("[memory-block-redacted]", text)
+    text = _SECRET_PATTERN.sub(r"\1=[redacted]", text)
+    text = _BEARER_PATTERN.sub("Bearer [redacted]", text)
+    text = _CHAT_ID_PATTERN.sub(r"\1_id=[redacted]", text)
+    text = _MEMORY_ID_PATTERN.sub("[memory-ref-redacted]", text)
+    text = _ABSOLUTE_PATH_PATTERN.sub("[local-path-redacted]", text)
+    text = _PRIVATE_STATE_PATTERN.sub("[private-state-redacted]", text)
+    return _clip(clean_text(text), limit)
+
+
+def _safe_pr_urls(values: Iterable[str]) -> tuple[str, ...]:
+    output: list[str] = []
+    for value in values:
+        cleaned = clean_text(str(value or "")).rstrip("/")
+        if cleaned and _PR_URL_PATTERN.fullmatch(cleaned) and cleaned not in output:
+            output.append(cleaned)
+        if len(output) >= 4:
+            break
+    return tuple(output)
+
+
+def _safe_changed_files(values: Iterable[str]) -> tuple[str, ...]:
+    output: list[str] = []
+    for value in values:
+        cleaned = clean_text(str(value or "")).replace("\\", "/")
+        if (
+            not cleaned
+            or cleaned.startswith(("/", "../", ".enoch/"))
+            or "/../" in cleaned
+            or re.match(r"^[A-Za-z]:/", cleaned)
+        ):
+            continue
+        cleaned = _clip(cleaned, 240)
+        if cleaned not in output:
+            output.append(cleaned)
+        if len(output) >= 40:
+            break
+    return tuple(output)
+
+
+def _safe_revision(value: str) -> str:
+    cleaned = clean_text(value)
+    return cleaned if re.fullmatch(r"[0-9a-fA-F]{7,64}", cleaned) else ""
+
+
+def _safe_version(value: str) -> str:
+    cleaned = clean_text(value)
+    return cleaned if re.fullmatch(r"[A-Za-z0-9._-]{1,80}", cleaned) else ""
+
+
+def _safe_branch(value: str) -> str:
+    cleaned = clean_text(value)
+    return cleaned if re.fullmatch(r"[A-Za-z0-9._/-]{1,160}", cleaned) else ""
+
+
+def _positive_int(value: object) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _bounded_int(value: object) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(-1_000_000, min(parsed, 1_000_000))
+
+
+def _valid_evidence_refs(values: Iterable[object]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    output: list[str] = []
+    for value in values:
+        ref = clean_text(str(value or ""))
+        if (
+            not ref
+            or ref in seen
+            or not any(pattern.fullmatch(ref) for pattern in _EVIDENCE_REF_PATTERNS)
+        ):
+            continue
+        seen.add(ref)
+        output.append(ref)
+        if len(output) >= 64:
+            break
+    return tuple(output)
+
+
 def load_curations(root: Path | None = None, *, limit: int = 100) -> tuple[SemanticCuration, ...]:
     path = curation_index_path(root)
     if not path.exists() or limit <= 0:
@@ -254,6 +636,37 @@ def load_curations(root: Path | None = None, *, limit: int = 100) -> tuple[Seman
             break
     items.reverse()
     return tuple(items)
+
+
+def curation_evidence_refs(curation: SemanticCuration | None) -> tuple[str, ...]:
+    if curation is None:
+        return ()
+    return _valid_evidence_refs(
+        ref
+        for suggestion in curation.remove_suggestions
+        for ref in suggestion.evidence_refs
+    )
+
+
+def latest_remove_suggestion(
+    candidate_id: str,
+    root: Path | None = None,
+    *,
+    classification: str = "",
+) -> tuple[SemanticCuration, RemoveSuggestion] | None:
+    wanted_id = clean_text(candidate_id).lower().lstrip("#")
+    wanted_classification = clean_text(classification).lower()
+    for curation in reversed(load_curations(root)):
+        for suggestion in curation.remove_suggestions:
+            if suggestion.candidate_id.lower() != wanted_id:
+                continue
+            if (
+                wanted_classification
+                and suggestion.classification != wanted_classification
+            ):
+                continue
+            return curation, suggestion
+    return None
 
 
 def candidate_scope_is_safe(candidate: Mapping[str, object]) -> bool:
@@ -291,25 +704,97 @@ def _recommendation(
 def _remove_suggestions(
     raw_items: object,
     known: Mapping[str, Mapping[str, object]],
+    known_evidence: Mapping[str, Mapping[str, object]],
 ) -> tuple[RemoveSuggestion, ...]:
     if not isinstance(raw_items, list):
         raise CurationError("remove_suggestions must be a JSON array")
     suggestions: list[RemoveSuggestion] = []
     seen: set[str] = set()
     for raw in raw_items[:20]:
-        if not isinstance(raw, dict) or set(raw) != {"candidate_id", "classification", "reason"}:
+        expected = {"candidate_id", "classification", "reason", "evidence_refs"}
+        legacy = expected - {"evidence_refs"}
+        if (
+            not isinstance(raw, dict)
+            or frozenset(raw) not in {frozenset(expected), frozenset(legacy)}
+        ):
             raise CurationError("remove suggestion has an invalid schema")
         candidate_id = clean_text(str(raw.get("candidate_id") or ""))
         classification = clean_text(str(raw.get("classification") or "")).lower()
         reason = _required_text(raw, "reason")
+        evidence_refs = _response_evidence_refs(raw.get("evidence_refs", ()), known_evidence)
         if candidate_id not in known:
             raise CurationError("semantic curator suggested removing an unknown candidate ID")
         if classification not in REMOVE_CLASSIFICATIONS:
             raise CurationError("semantic curator returned an invalid removal classification")
+        if classification in {"already-resolved", "superseded"}:
+            if not evidence_refs:
+                raise CurationError(
+                    f"{classification} removal suggestion requires completion evidence"
+                )
+            if not _supports_resolution(
+                known[candidate_id],
+                evidence_refs,
+                known_evidence,
+            ):
+                raise CurationError(
+                    f"{classification} removal suggestion lacks authoritative evidence"
+                )
         if candidate_id not in seen:
-            suggestions.append(RemoveSuggestion(candidate_id, classification, reason))
+            suggestions.append(
+                RemoveSuggestion(candidate_id, classification, reason, evidence_refs)
+            )
             seen.add(candidate_id)
     return tuple(suggestions)
+
+
+def _known_evidence(
+    evidence: Iterable[Mapping[str, object]],
+) -> dict[str, Mapping[str, object]]:
+    known: dict[str, Mapping[str, object]] = {}
+    for item in evidence:
+        refs = _valid_evidence_refs(item.get("evidence_refs", ()))
+        for ref in refs:
+            known.setdefault(ref, item)
+    return known
+
+
+def _response_evidence_refs(
+    raw: object,
+    known: Mapping[str, Mapping[str, object]],
+) -> tuple[str, ...]:
+    if not isinstance(raw, (list, tuple)):
+        raise CurationError("remove suggestion evidence_refs must be a JSON array")
+    refs = _valid_evidence_refs(raw)
+    if len(refs) != len(raw):
+        raise CurationError("remove suggestion contains a malformed evidence ref")
+    if any(ref not in known for ref in refs):
+        raise CurationError("remove suggestion cites unknown completion evidence")
+    return refs
+
+
+def _supports_resolution(
+    candidate: Mapping[str, object],
+    refs: Iterable[str],
+    known: Mapping[str, Mapping[str, object]],
+) -> bool:
+    authorities = {
+        clean_text(str(known[ref].get("resolution_authority") or ""))
+        for ref in refs
+        if ref in known
+    }
+    if "authoritative-body" in authorities:
+        return True
+    if _candidate_requires_body_change(candidate):
+        return False
+    return "task-completion" in authorities
+
+
+def _candidate_requires_body_change(candidate: Mapping[str, object]) -> bool:
+    text = " ".join(
+        clean_text(str(candidate.get(field) or ""))
+        for field in ("title", "proposed_change", "test_plan")
+    )
+    return bool(_BODY_CHANGE_PATTERN.search(text))
 
 
 def _new_candidates(raw_items: object) -> tuple[NewCandidateSuggestion, ...]:
@@ -330,12 +815,12 @@ def _new_candidates(raw_items: object) -> tuple[NewCandidateSuggestion, ...]:
 
 
 def _required_text(payload: Mapping[str, object], key: str) -> str:
-    value = clean_text(str(payload.get(key) or ""))
-    if not value:
+    raw_value = clean_text(str(payload.get(key) or ""))
+    if not raw_value:
         raise CurationError(f"semantic curator omitted {key}")
-    if len(value) > 1000:
+    if len(raw_value) > 1000:
         raise CurationError(f"semantic curator exceeded the {key} limit")
-    return value
+    return sanitize_curation_text(raw_value, limit=1000)
 
 
 def _unsafe_scope(text: str) -> bool:
@@ -374,7 +859,14 @@ def _curation_from_json(raw: object) -> SemanticCuration | None:
             else None
         )
         remove = tuple(
-            RemoveSuggestion(**item)
+            RemoveSuggestion(
+                candidate_id=clean_text(str(item.get("candidate_id") or "")),
+                classification=clean_text(
+                    str(item.get("classification") or "")
+                ).lower(),
+                reason=clean_text(str(item.get("reason") or "")),
+                evidence_refs=_valid_evidence_refs(item.get("evidence_refs", ())),
+            )
             for item in raw.get("remove_suggestions", [])
             if isinstance(item, dict)
         )
@@ -388,6 +880,7 @@ def _curation_from_json(raw: object) -> SemanticCuration | None:
             created_at=str(raw.get("created_at") or ""),
             status=clean_text(str(raw.get("status") or "")),
             input_candidate_ids=tuple(str(item) for item in raw.get("input_candidate_ids", [])),
+            input_evidence_refs=_valid_evidence_refs(raw.get("input_evidence_refs", ())),
             recommendation=recommendation,
             remove_suggestions=remove,
             new_candidates=new,

--- a/src/enoch/evolution/events.py
+++ b/src/enoch/evolution/events.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 import json
 from pathlib import Path
+import re
 import threading
 from typing import Protocol
 from uuid import uuid4
@@ -17,7 +18,7 @@ from enoch.memory.paths import clean_text, now as current_time
 from enoch.paths import enoch_home
 
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 EVOLVE_EVENT_TYPES = {
     "checked",
     "proposed",
@@ -65,6 +66,20 @@ _CANDIDATE_EVENTS = {
 }
 PROPOSAL_DISPOSITION_EVENTS = {"selected", "removed", "no-action"}
 RECORDING_MODES = {"realtime", "backfill"}
+REMOVAL_CLASSIFICATIONS = {
+    "duplicate",
+    "superseded",
+    "obsolete",
+    "already-resolved",
+    "context-only",
+    "not-actionable",
+}
+_EVIDENCE_REF_PATTERNS = (
+    re.compile(r"task:[1-9]\d*$"),
+    re.compile(r"pr:https://[A-Za-z0-9.-]+/[^\s]+/(?:pull|pulls|merge_requests)/\d+/?$"),
+    re.compile(r"merge:[0-9a-fA-F]{7,64}$"),
+    re.compile(r"version:[A-Za-z0-9._-]{1,80}$"),
+)
 _EVOLVE_EVENT_THREAD_LOCK = threading.RLock()
 
 
@@ -115,6 +130,8 @@ class EvolveEvent:
     retry_of_task_id: int | None = None
     score: int = 0
     reason: str = ""
+    removal_classification: str = ""
+    evidence_refs: tuple[str, ...] = ()
     pr_url: str = ""
     merge_commit: str = ""
     authoritative_branch: str = ""
@@ -149,6 +166,8 @@ def record_evolve_event(
     approval_actor: str = "",
     retry_of_task_id: int | None = None,
     reason: str = "",
+    removal_classification: str = "",
+    evidence_refs: tuple[str, ...] = (),
     proposal_id: str = "",
     curation_id: str = "",
     recommendation_kind: str = "",
@@ -219,6 +238,15 @@ def record_evolve_event(
     if approval_actor and not normalized_approval_actor:
         raise ValueError("Approval actor must be human, agent, or system.")
     normalized_task_id = _positive_int(task_id)
+    normalized_removal_classification = clean_text(removal_classification).lower()
+    if (
+        normalized_removal_classification
+        and normalized_removal_classification not in REMOVAL_CLASSIFICATIONS
+    ):
+        raise ValueError("Unknown evolve candidate removal classification.")
+    if normalized_removal_classification and normalized_event != "removed":
+        raise ValueError("Removal classification is only valid for removed events.")
+    normalized_evidence_refs = _validated_evidence_refs(evidence_refs)
     normalized_proposal_id = clean_text(proposal_id)
     if normalized_event == "proposed" and not normalized_proposal_id:
         normalized_proposal_id = f"proposal-{uuid4().hex}"
@@ -287,6 +315,8 @@ def record_evolve_event(
         retry_of_task_id=_positive_int(retry_of_task_id),
         score=_int(getattr(candidate, "score", 0)),
         reason=_clip(clean_text(reason)),
+        removal_classification=normalized_removal_classification,
+        evidence_refs=normalized_evidence_refs,
         pr_url=normalized_pr_url,
         merge_commit=normalized_merge_commit,
         authoritative_branch=normalized_authoritative_branch,
@@ -545,6 +575,10 @@ def _event_from_line(line: str) -> EvolveEvent | None:
         retry_of_task_id=_positive_int(raw.get("retry_of_task_id")),
         score=_int(raw.get("score")),
         reason=_clip(clean_text(str(raw.get("reason") or ""))),
+        removal_classification=_loaded_removal_classification(
+            raw.get("removal_classification")
+        ),
+        evidence_refs=_loaded_evidence_refs(raw.get("evidence_refs")),
         pr_url=clean_text(str(raw.get("pr_url") or "")),
         merge_commit=clean_text(str(raw.get("merge_commit") or "")),
         authoritative_branch=clean_text(
@@ -623,6 +657,37 @@ def _string_tuple(value: object) -> tuple[str, ...]:
         seen.add(cleaned)
         output.append(cleaned)
     return tuple(output)
+
+
+def _validated_evidence_refs(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise ValueError("Evolution evidence refs must be a list or tuple.")
+    refs = _loaded_evidence_refs(value)
+    if len(refs) != len(value):
+        raise ValueError("Evolution evidence refs contain a malformed or duplicate ref.")
+    return refs
+
+
+def _loaded_evidence_refs(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    output: list[str] = []
+    for item in value:
+        ref = clean_text(str(item or ""))
+        if (
+            ref
+            and ref not in output
+            and any(pattern.fullmatch(ref) for pattern in _EVIDENCE_REF_PATTERNS)
+        ):
+            output.append(ref)
+        if len(output) >= 64:
+            break
+    return tuple(output)
+
+
+def _loaded_removal_classification(value: object) -> str:
+    classification = clean_text(str(value or "")).lower()
+    return classification if classification in REMOVAL_CLASSIFICATIONS else ""
 
 
 def _actor(value: object) -> str:

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -29,17 +29,33 @@ The theme is semantic curation context and deterministic pre-ranking pressure, n
 
 `/propose` refreshes all six sources, applies deterministic pre-ranking, and
 passes a bounded set of structured candidate fields and provenance to semantic
-curation. The curator may recommend one existing ID with narrower scope, risk,
+curation. It also includes bounded, privacy-cleaned recent completion evidence
+from the structured task and evolution journals: task/candidate linkage,
+request and result summaries, PRs and changed files, and recorded
+promotion/merge/version verification. Absolute local paths, credentials,
+private-state paths, chat identifiers, memory identifiers, full logs, and
+runtime session identifiers are not included. The curator may recommend one existing ID with narrower scope, risk,
 and test guidance; suggest duplicate, superseded, obsolete, already-resolved,
 context-only, or not-actionable candidates for removal; and suggest up to three
 new bounded candidates. New suggestions are persisted with
 `brainstorming`/`agent` provenance and never masquerade as human feedback.
 
+Completion evidence distinguishes a worker-completed open PR from a promoted
+body change on the authoritative branch, a completed non-body task, and a
+partial runtime result. Failed, cancelled, regressed, and stale earlier
+completion events are excluded. An open PR or task status of `completed` alone
+does not establish authoritative body resolution. `already-resolved` and
+`superseded` suggestions must cite prompt-provided refs such as `task:<id>`,
+`pr:<url>`, `merge:<revision>`, or `version:<version>`; body-change candidates
+require evidence labelled `authoritative-body`.
+
 Semantic curation is stored separately in `.enoch/evolve_curations.jsonl`. It
 references raw candidate IDs and immutable provenance instead of rewriting raw
-evidence. Deterministic ranking remains only for bounded context ordering and an
+evidence. It records bounded input and suggestion evidence refs, never the full
+private task result or conversation. Deterministic ranking remains only for bounded context ordering and an
 explicitly labelled fallback when the reasoning engine is unavailable, times
-out, returns malformed JSON, or produces no valid result. The legacy empty-pool
+out, completion evidence cannot be loaded, returns malformed JSON, cites
+unknown or non-authoritative resolution evidence, or produces no valid result. The legacy empty-pool
 brainstorm fallback remains available to direct callers, while the application
 proposal flow uses semantic curation for both existing and newly suggested work.
 
@@ -48,7 +64,10 @@ Candidates are persisted in `.enoch/evolve_candidates.json` so Enoch can remembe
 Evolution decisions are appended to `.enoch/evolve_events.jsonl`. The funnel
 records checks, proposals, selections, queueing, terminal outcomes, skips, and
 human removals. Proposal events link `curation_id` and `recommendation_kind` to
-the separate curation journal. Candidate provenance separates `evidence_source`, `signal_actor`, and
+the separate curation journal and retain bounded evidence refs. Human removals
+made from a curator suggestion preserve the removal classification, reason,
+curation ID, and evidence refs. The LLM and scheduler never apply a suggestion
+or change candidate status. Candidate provenance separates `evidence_source`, `signal_actor`, and
 `candidate_actor`; execution records `approval_actor`, while `event_actor` and
 `trigger` identify who caused each lifecycle decision. `parent_candidate_id`
 and `source_task_id` preserve causal links for candidates learned from prior

--- a/src/enoch/tasks/events.py
+++ b/src/enoch/tasks/events.py
@@ -17,7 +17,7 @@ from enoch.memory.paths import clean_text, now as current_time
 from enoch.paths import enoch_home
 
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 SUMMARY_LIMIT = 4000
 TASK_SOURCES = {
     "backlog",
@@ -56,6 +56,8 @@ class TaskLike(Protocol):
     completed_at: str
     result: str
     pr_urls: tuple[str, ...]
+    publish_stage: str
+    commit_sha: str
     context_source: str
     source: str
     initiated_by: str
@@ -107,6 +109,8 @@ class TaskEvent:
     related_task_id: int | None = None
     pr_urls: tuple[str, ...] = ()
     changed_files: tuple[str, ...] = ()
+    publish_stage: str = ""
+    commit_sha: str = ""
     attempt: int = 0
     max_attempts: int = 3
     next_attempt_at: str = ""
@@ -173,6 +177,8 @@ def record_task_event(
         related_task_id=_positive_int(related_task_id),
         pr_urls=_dedupe(tuple(getattr(job, "pr_urls", ()) or ())),
         changed_files=_changed_files(summary),
+        publish_stage=clean_text(str(getattr(job, "publish_stage", "") or "")).lower(),
+        commit_sha=clean_text(str(getattr(job, "commit_sha", "") or "")),
         attempt=max(0, _int(getattr(job, "attempt", 0))),
         max_attempts=max(1, _int(getattr(job, "max_attempts", 3), default=3)),
         next_attempt_at=str(getattr(job, "next_attempt_at", "") or "").strip(),
@@ -220,6 +226,40 @@ def load_task_events(
             break
     events.reverse()
     return tuple(events)
+
+
+def load_recent_task_outcomes(
+    root: Path | None = None,
+    *,
+    limit: int = 100,
+) -> tuple[TaskEvent, ...]:
+    """Return the latest terminal event for each recent task.
+
+    A later failure, cancellation, or regression replaces an earlier completion,
+    so callers cannot accidentally treat a stale completed event as current
+    completion evidence.
+    """
+    if limit <= 0:
+        return ()
+    terminal = {
+        "completed",
+        "failed",
+        "cancelled",
+        "regressed",
+        "reverted",
+        "forward-fixed",
+    }
+    outcomes: list[TaskEvent] = []
+    seen: set[int] = set()
+    for event in reversed(load_task_events(root)):
+        if event.task_id in seen or event.event not in terminal:
+            continue
+        seen.add(event.task_id)
+        outcomes.append(event)
+        if len(outcomes) >= limit:
+            break
+    outcomes.reverse()
+    return tuple(outcomes)
 
 
 def normalize_task_source(value: str) -> str:
@@ -301,6 +341,8 @@ def _event_from_line(line: str) -> TaskEvent | None:
         related_task_id=_positive_int(raw.get("related_task_id")),
         pr_urls=_string_tuple(raw.get("pr_urls")),
         changed_files=_string_tuple(raw.get("changed_files")),
+        publish_stage=clean_text(str(raw.get("publish_stage") or "")).lower(),
+        commit_sha=clean_text(str(raw.get("commit_sha") or "")),
         attempt=max(0, _int(raw.get("attempt"))),
         max_attempts=max(1, _int(raw.get("max_attempts"), default=3)),
         next_attempt_at=str(raw.get("next_attempt_at") or "").strip(),

--- a/tests/test_enoch_evolve_curation.py
+++ b/tests/test_enoch_evolve_curation.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json
 import sys
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 import unittest
 
 
@@ -17,8 +18,9 @@ from enoch.evolution.core import (
     propose_evolve,
     remove_evolve_candidate,
 )
-from enoch.evolution.curation import load_curations
-from enoch.evolution.events import load_evolve_events
+from enoch.evolution.curation import curation_index_path, load_curations
+from enoch.evolution.events import load_evolve_events, record_evolve_event
+from enoch.tasks.events import record_task_event
 from enoch.tasks.queue import task_queue_status
 from enoch.logs import log_conversation_turn
 
@@ -123,12 +125,26 @@ class EnochEvolveCurationTests(unittest.TestCase):
         with TemporaryDirectory() as temp:
             root = Path(temp)
             _write_candidates(root, (first, second))
+            _record_completed_work(
+                root,
+                task_id=17,
+                candidate=second,
+                request="Implement focused experience validation.",
+                result="Implemented focused experience validation.\nFiles:\n- src/enoch/evolution/core.py",
+                pr_url="https://github.com/our-ark/enoch/pull/19",
+                promoted=True,
+            )
             proposal = propose_evolve(
                 root,
                 curator=lambda _prompt: _response(
                     remove=[
                         {"candidate_id": first.id, "classification": "duplicate", "reason": "Same bounded change."},
-                        {"candidate_id": second.id, "classification": "already-resolved", "reason": "Tests show it is fixed."},
+                        {
+                            "candidate_id": second.id,
+                            "classification": "already-resolved",
+                            "reason": "Task 17 was promoted through PR 19.",
+                            "evidence_refs": ["task:17", "merge:e536d32"],
+                        },
                     ]
                 ),
             )
@@ -140,6 +156,246 @@ class EnochEvolveCurationTests(unittest.TestCase):
             ["duplicate", "already-resolved"],
         )
         self.assertEqual(statuses, {first.id: "candidate", second.id: "candidate"})
+
+    def test_prompt_receives_bounded_redacted_recent_completed_work(self) -> None:
+        candidate = _candidate(
+            "feedback",
+            1,
+            title="Review /workspace/private/candidate.py token=candidate-secret",
+        )
+        prompts: list[str] = []
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (candidate,))
+            for task_id in range(1, 16):
+                _record_completed_work(
+                    root,
+                    task_id=task_id,
+                    request=(
+                        f"Review task {task_id} at /Users/gary/private/repo "
+                        "chat_id=987 mem_20260723_private api_key=top-secret"
+                    ),
+                    result=(
+                        "Completed review in /tmp/private.log with password=hunter2. "
+                        + "bounded " * 300
+                    ),
+                )
+            propose_evolve(
+                root,
+                mission="Evolve /workspace/private/body.py with secret=mission-secret",
+                curator=lambda prompt: prompts.append(prompt)
+                or _response(recommended_candidate_id=candidate.id),
+            )
+
+        prompt_payload = _prompt_input(prompts[0])
+        evidence = prompt_payload["recent_completed_work"]
+        serialized = json.dumps(prompt_payload)
+        self.assertEqual(len(evidence), 12)
+        self.assertNotIn("/Users/", serialized)
+        self.assertNotIn("/tmp/", serialized)
+        self.assertNotIn("chat_id=987", serialized)
+        self.assertNotIn("mem_20260723_private", serialized)
+        self.assertNotIn("top-secret", serialized)
+        self.assertNotIn("hunter2", serialized)
+        self.assertNotIn("candidate-secret", serialized)
+        self.assertNotIn("mission-secret", serialized)
+        self.assertLessEqual(
+            max(len(item["result_summary"]) for item in evidence),
+            800,
+        )
+        self.assertEqual(
+            {item["completion_kind"] for item in evidence},
+            {"completed-no-body-change"},
+        )
+        self.assertEqual(
+            {item["resolution_authority"] for item in evidence},
+            {"task-completion"},
+        )
+
+    def test_direct_merged_candidate_link_supports_already_resolved_evidence(self) -> None:
+        candidate = EvolveCandidate(
+            **{**_candidate("feedback", 1).__dict__, "source_task_id": 17}
+        )
+        prompts: list[str] = []
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (candidate,))
+            _record_completed_work(
+                root,
+                task_id=17,
+                candidate=candidate,
+                request="Add semantic candidate curation.",
+                result="Added semantic candidate curation.\nFiles:\n- src/enoch/evolution/curation.py",
+                pr_url="https://github.com/our-ark/enoch/pull/19",
+                promoted=True,
+                version="v0.2.1",
+            )
+            proposal = propose_evolve(
+                root,
+                curator=lambda prompt: prompts.append(prompt)
+                or _response(
+                    remove=[
+                        {
+                            "candidate_id": candidate.id,
+                            "classification": "already-resolved",
+                            "reason": (
+                                "The linked task is merged into the authoritative body; "
+                                "/Users/gary/private/result token=private-token."
+                            ),
+                            "evidence_refs": ["task:17", "pr:https://github.com/our-ark/enoch/pull/19", "merge:e536d32"],
+                        }
+                    ]
+                ),
+            )
+            stored = load_evolve_candidates(root, include_inactive=True)[0]
+            journal = load_curations(root)[0]
+            raw_journal = curation_index_path(root).read_text(encoding="utf-8")
+
+        completion = _prompt_input(prompts[0])["recent_completed_work"][0]
+        self.assertIn(candidate.id, completion["direct_candidate_ids"])
+        self.assertEqual(completion["resolution_authority"], "authoritative-body")
+        self.assertEqual(completion["authoritative_version"], "v0.2.1")
+        self.assertIn("version:v0.2.1", completion["evidence_refs"])
+        self.assertEqual(proposal.curation.status, "llm")
+        self.assertEqual(stored.status, "candidate")
+        self.assertEqual(
+            journal.remove_suggestions[0].evidence_refs,
+            (
+                "task:17",
+                "pr:https://github.com/our-ark/enoch/pull/19",
+                "merge:e536d32",
+            ),
+        )
+        self.assertNotIn("Added semantic candidate curation", raw_journal)
+        self.assertNotIn("/Users/gary", raw_journal)
+        self.assertNotIn("private-token", raw_journal)
+
+    def test_semantic_resolution_without_direct_link_and_supersession_are_allowed(self) -> None:
+        resolved = _candidate("feedback", 1, title="Use LLM semantic candidate curation")
+        superseded = _candidate("backlog", 2, title="Add fixed-score candidate pruning")
+        completed_candidate = _candidate("brainstorming", 99)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (resolved, superseded))
+            _record_completed_work(
+                root,
+                task_id=22,
+                candidate=completed_candidate,
+                request="Replace fixed pruning with LLM semantic candidate curation.",
+                result=(
+                    "Implemented LLM semantic curation and replaced fixed pruning."
+                    "\nFiles:\n- src/enoch/evolution/curation.py"
+                ),
+                pr_url="https://github.com/our-ark/enoch/pull/22",
+                promoted=True,
+                merge_commit="abcdef123456",
+            )
+            proposal = propose_evolve(
+                root,
+                curator=lambda _prompt: _response(
+                    remove=[
+                        {
+                            "candidate_id": resolved.id,
+                            "classification": "already-resolved",
+                            "reason": "Task 22 semantically implements this request.",
+                            "evidence_refs": ["task:22", "merge:abcdef123456"],
+                        },
+                        {
+                            "candidate_id": superseded.id,
+                            "classification": "superseded",
+                            "reason": "The later semantic implementation replaces fixed pruning.",
+                            "evidence_refs": ["task:22", "merge:abcdef123456"],
+                        },
+                    ]
+                ),
+            )
+
+        self.assertEqual(
+            [item.classification for item in proposal.curation.remove_suggestions],
+            ["already-resolved", "superseded"],
+        )
+
+    def test_open_pr_partial_failed_and_cancelled_work_cannot_resolve_body_candidate(self) -> None:
+        candidate = _candidate("feedback", 1)
+        for label, event, runtime_reason, promoted in (
+            ("open-pr", "completed", "completed", False),
+            ("partial", "completed", "output-limit", True),
+            ("failed", "failed", "failed", False),
+            ("cancelled", "cancelled", "cancelled", False),
+        ):
+            with self.subTest(label=label), TemporaryDirectory() as temp:
+                root = Path(temp)
+                _write_candidates(root, (candidate,))
+                _record_completed_work(
+                    root,
+                    task_id=31,
+                    candidate=candidate,
+                    result="Changed curation.\nFiles:\n- src/enoch/evolution/curation.py",
+                    pr_url="https://github.com/our-ark/enoch/pull/31",
+                    event=event,
+                    runtime_reason=runtime_reason,
+                    promoted=promoted,
+                )
+                proposal = propose_evolve(
+                    root,
+                    curator=lambda _prompt: _response(
+                        remove=[
+                            {
+                                "candidate_id": candidate.id,
+                                "classification": "already-resolved",
+                                "reason": "Claimed complete.",
+                                "evidence_refs": ["task:31"],
+                            }
+                        ]
+                    ),
+                )
+                stored = load_evolve_candidates(root, include_inactive=True)[0]
+
+            self.assertEqual(proposal.curation.status, "deterministic-fallback")
+            self.assertEqual(stored.status, "candidate")
+
+    def test_unknown_and_malformed_evidence_refs_are_rejected_without_mutation(self) -> None:
+        candidate = _candidate("feedback", 1)
+        for ref in ("task:999", "local:/Users/gary/private"):
+            with self.subTest(ref=ref), TemporaryDirectory() as temp:
+                root = Path(temp)
+                _write_candidates(root, (candidate,))
+                _record_completed_work(root, task_id=17)
+                proposal = propose_evolve(
+                    root,
+                    curator=lambda _prompt, value=ref: _response(
+                        remove=[
+                            {
+                                "candidate_id": candidate.id,
+                                "classification": "already-resolved",
+                                "reason": "Invalid evidence must not be trusted.",
+                                "evidence_refs": [value],
+                            }
+                        ]
+                    ),
+                )
+                status = load_evolve_candidates(root, include_inactive=True)[0].status
+            self.assertEqual(proposal.curation.status, "deterministic-fallback")
+            self.assertEqual(status, "candidate")
+
+    def test_completion_evidence_loading_failure_uses_explicit_fallback(self) -> None:
+        candidate = _candidate("feedback", 1)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_candidates(root, (candidate,))
+            from unittest.mock import patch
+
+            with patch(
+                "enoch.evolution.core.recent_completion_evidence",
+                side_effect=OSError("journal unavailable"),
+            ):
+                proposal = propose_evolve(
+                    root,
+                    curator=lambda _prompt: self.fail("curator must not run"),
+                )
+
+        self.assertEqual(proposal.curation.status, "deterministic-fallback")
+        self.assertIn("completion-evidence-unavailable", proposal.curation.fallback_reason)
 
     def test_llm_recommends_existing_candidate_without_state_change(self) -> None:
         first = _candidate("backlog", 1, score=100)
@@ -287,22 +543,86 @@ class EnochEvolveCurationTests(unittest.TestCase):
         with TemporaryDirectory() as temp:
             root = Path(temp)
             _write_candidates(root, (candidate,))
-            propose_evolve(
+            _record_completed_work(
+                root,
+                task_id=17,
+                candidate=candidate,
+                result="Resolved candidate.\nFiles:\n- src/enoch/evolution/curation.py",
+                pr_url="https://github.com/our-ark/enoch/pull/19",
+                promoted=True,
+            )
+            proposal = propose_evolve(
                 root,
                 curator=lambda _prompt: _response(
                     remove=[
-                        {"candidate_id": candidate.id, "classification": "not-actionable", "reason": "No concrete change."}
+                        {
+                            "candidate_id": candidate.id,
+                            "classification": "already-resolved",
+                            "reason": "Merged by task 17.",
+                            "evidence_refs": ["task:17", "merge:e536d32"],
+                        }
                     ]
                 ),
             )
             before = load_evolve_candidates(root, include_inactive=True)[0]
-            removed = remove_evolve_candidate(candidate.id, root, reason="not-actionable: No concrete change")
+            suggestion = proposal.curation.remove_suggestions[0]
+            with self.assertRaisesRegex(ValueError, "Only a human"):
+                remove_evolve_candidate(
+                    candidate.id,
+                    root,
+                    event_actor="agent",
+                    reason=suggestion.reason,
+                    classification=suggestion.classification,
+                    curation_id=proposal.curation.id,
+                    evidence_refs=suggestion.evidence_refs,
+                )
+            removed = remove_evolve_candidate(
+                candidate.id,
+                root,
+                reason=suggestion.reason,
+                classification=suggestion.classification,
+                curation_id=proposal.curation.id,
+                evidence_refs=suggestion.evidence_refs,
+            )
             event = load_evolve_events(root, candidate_id=candidate.id)[-1]
 
         self.assertEqual(before.status, "candidate")
         self.assertEqual(removed.status, "removed")
         self.assertEqual(event.event_actor, "human")
-        self.assertEqual(event.reason, "not-actionable: No concrete change")
+        self.assertEqual(event.reason, "Merged by task 17.")
+        self.assertEqual(event.removal_classification, "already-resolved")
+        self.assertEqual(event.curation_id, proposal.curation.id)
+        self.assertEqual(event.evidence_refs, ("task:17", "merge:e536d32"))
+
+    def test_legacy_curation_without_evidence_fields_still_loads(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            path = curation_index_path(root)
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "id": "curation-legacy",
+                        "created_at": "2026-07-19T00:00:00Z",
+                        "status": "llm",
+                        "input_candidate_ids": ["feedback-1"],
+                        "remove_suggestions": [
+                            {
+                                "candidate_id": "feedback-1",
+                                "classification": "duplicate",
+                                "reason": "Legacy duplicate.",
+                            }
+                        ],
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            loaded = load_curations(root)[0]
+
+        self.assertEqual(loaded.input_evidence_refs, ())
+        self.assertEqual(loaded.remove_suggestions[0].evidence_refs, ())
 
 
 def _sources() -> tuple[str, ...]:
@@ -336,6 +656,10 @@ def _response(
     new: list[dict[str, str]] | None = None,
     scope: str = "Limit the change to one focused module.",
 ) -> str:
+    remove_suggestions = [
+        {**item, "evidence_refs": item.get("evidence_refs", [])}
+        for item in (remove or [])
+    ]
     return json.dumps(
         {
             "recommended_candidate_id": recommended_candidate_id,
@@ -343,7 +667,7 @@ def _response(
             "scope_guidance": scope if recommended_candidate_id else "",
             "risk_guidance": "Keep the change reversible and reviewable." if recommended_candidate_id else "",
             "test_plan_guidance": "Run focused tests and doctor." if recommended_candidate_id else "",
-            "remove_suggestions": remove or [],
+            "remove_suggestions": remove_suggestions,
             "new_candidates": new or [],
         }
     )
@@ -366,6 +690,95 @@ def _write_candidates(root: Path, candidates: tuple[EvolveCandidate, ...]) -> No
         ),
         encoding="utf-8",
     )
+
+
+def _record_completed_work(
+    root: Path,
+    *,
+    task_id: int,
+    candidate: EvolveCandidate | None = None,
+    request: str = "Complete a bounded non-code review.",
+    result: str = "Completed the bounded review.",
+    pr_url: str = "",
+    event: str = "completed",
+    runtime_reason: str = "completed",
+    promoted: bool = False,
+    merge_commit: str = "e536d32",
+    version: str = "",
+) -> None:
+    completed_at = f"2026-07-23T12:{task_id % 60:02d}:00Z"
+    job = SimpleNamespace(
+        id=task_id,
+        text=request,
+        created_at=completed_at,
+        started_at=completed_at,
+        completed_at=completed_at,
+        result=result,
+        pr_urls=(pr_url,) if pr_url else (),
+        publish_stage="pr_opened" if pr_url else "",
+        commit_sha="d58edcc" if pr_url else "",
+        context_source="",
+        source=candidate.source if candidate is not None else "task",
+        initiated_by="human",
+        trigger="/task",
+        candidate_id=candidate.id if candidate is not None else "",
+        parent_task_id=None,
+        evidence_source=candidate.evidence_source if candidate is not None else "",
+        signal_actor=candidate.signal_actor if candidate is not None else "",
+        candidate_actor=candidate.candidate_actor if candidate is not None else "",
+        approval_actor="human" if candidate is not None else "",
+        parent_candidate_id="",
+        source_task_id=None,
+        attempt=1,
+        max_attempts=3,
+        next_attempt_at="",
+        failure_code="",
+        failure_class="",
+        retryable=False,
+        runtime_provider="codex",
+        runtime_session_id="private-session-not-persisted-in-curation",
+        runtime_completion_reason=runtime_reason,
+        runtime_usage={},
+        runtime_event_types=(),
+        runtime_output_refs=(),
+        runtime_side_effects=(),
+    )
+    record_task_event(
+        job,
+        event,
+        root,
+        event_actor="agent" if event != "cancelled" else "human",
+        trigger="task-runner",
+    )
+    if promoted:
+        promoted_candidate = candidate or _candidate("brainstorming", task_id)
+        record_evolve_event(
+            "promoted",
+            root,
+            event_actor="human",
+            trigger="/evolve reconcile",
+            candidate=promoted_candidate,
+            task_id=task_id,
+            pr_url=pr_url or f"https://github.com/our-ark/enoch/pull/{task_id}",
+            merge_commit=merge_commit,
+            authoritative_branch="main",
+            promoted_at=completed_at,
+        )
+        if version:
+            record_evolve_event(
+                "adopted",
+                root,
+                event_actor="system",
+                trigger="daemon-startup",
+                candidate=promoted_candidate,
+                task_id=task_id,
+                pr_url=pr_url or f"https://github.com/our-ark/enoch/pull/{task_id}",
+                merge_commit=merge_commit,
+                authoritative_branch="main",
+                promoted_at=completed_at,
+                version=version,
+                health_check="passed",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_enoch_evolve_events.py
+++ b/tests/test_enoch_evolve_events.py
@@ -212,6 +212,63 @@ class EnochEvolveEventTests(unittest.TestCase):
         )
         self.assertEqual(proposal_events[-1].reason, "superseded-by-new-proposal")
 
+    def test_proposal_and_human_removal_preserve_bounded_evidence_refs(self) -> None:
+        candidate = _candidate()
+        refs = ("task:17", "merge:e536d32")
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            proposal = record_evolve_event(
+                "proposed",
+                root,
+                event_actor="human",
+                trigger="/propose",
+                candidate=candidate,
+                curation_id="curation-123",
+                recommendation_kind="llm",
+                evidence_refs=refs,
+            )
+            removed = record_evolve_event(
+                "removed",
+                root,
+                event_actor="human",
+                trigger="/evolve remove",
+                candidate=candidate,
+                proposal_id=proposal.proposal_id,
+                curation_id="curation-123",
+                removal_classification="already-resolved",
+                evidence_refs=refs,
+                reason="Merged by task 17.",
+            )
+            loaded = load_evolve_events(root)[-1]
+
+        self.assertEqual(removed.evidence_refs, refs)
+        self.assertEqual(loaded.removal_classification, "already-resolved")
+        self.assertEqual(loaded.curation_id, "curation-123")
+        self.assertEqual(loaded.evidence_refs, refs)
+
+    def test_malformed_evidence_refs_are_rejected_and_legacy_events_still_load(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            with self.assertRaisesRegex(ValueError, "malformed"):
+                record_evolve_event(
+                    "proposed",
+                    root,
+                    event_actor="human",
+                    trigger="/propose",
+                    candidate=_candidate(),
+                    evidence_refs=("local:/Users/private",),
+                )
+            path = evolve_event_path(root)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                """{"event":"proposed","event_actor":"human","trigger":"/propose","candidate_id":"brainstorm-1","source":"brainstorming","candidate_initiated_by":"agent"}\n""",
+                encoding="utf-8",
+            )
+            legacy = load_evolve_events(root)[0]
+
+        self.assertEqual(legacy.evidence_refs, ())
+        self.assertEqual(legacy.removal_classification, "")
+
     def test_governed_lifecycle_events_require_verified_evidence(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)

--- a/tests/test_enoch_task_queue.py
+++ b/tests/test_enoch_task_queue.py
@@ -44,11 +44,59 @@ from enoch.providers import (
     RuntimeSideEffect,
     RuntimeUsage,
 )
-from enoch.tasks.events import load_task_events
+from enoch.tasks.events import load_recent_task_outcomes, load_task_events
 from enoch.tasks import queue as task_queue
 
 
 class EnochTaskQueueTests(unittest.TestCase):
+    def test_recent_task_outcomes_keep_latest_terminal_state_and_publish_evidence(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            first = enqueue_task(42, "publish bounded task", root)
+            running = begin_next_task(root)
+            assert running is not None
+            claim_running_task(running.id, "worker-one", os.getpid(), root)
+            record_task_publish_state(
+                running.id,
+                "worker-one",
+                root,
+                stage="pr_opened",
+                commit_sha="d58edcc",
+                pr_url="https://github.com/our-ark/enoch/pull/19",
+                published_remotely=True,
+            )
+            complete_task(
+                running.id,
+                root,
+                result=(
+                    "Implemented bounded task.\n"
+                    "Files:\n"
+                    "- src/enoch/evolution/curation.py"
+                ),
+                worker_id="worker-one",
+            )
+            regress_task(first.id, root, result="A regression was confirmed.")
+
+            second = enqueue_task(42, "complete stable task", root)
+            running_second = begin_next_task(root)
+            assert running_second is not None
+            complete_task(running_second.id, root, result="Completed stable task.")
+            outcomes = load_recent_task_outcomes(root)
+            published_event = next(
+                event
+                for event in load_task_events(root, task_id=first.id)
+                if event.event == "completed"
+            )
+
+        self.assertEqual([event.task_id for event in outcomes], [first.id, second.id])
+        self.assertEqual([event.event for event in outcomes], ["regressed", "completed"])
+        self.assertEqual(published_event.publish_stage, "pr_opened")
+        self.assertEqual(published_event.commit_sha, "d58edcc")
+        self.assertEqual(
+            published_event.changed_files,
+            ("src/enoch/evolution/curation.py",),
+        )
+
     def test_runtime_result_metadata_is_persisted_in_task_and_event_history(self) -> None:
         runtime_result = RuntimeResult(
             final_text="Implemented the task.",

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -2538,6 +2538,7 @@ class EnochTelegramTests(unittest.TestCase):
                             "candidate_id": "backlog-1",
                             "classification": "context-only",
                             "reason": "The note does not request an implementation change.",
+                            "evidence_refs": ["task:17"],
                         }
                     ],
                     "new_candidates": [],
@@ -2546,7 +2547,16 @@ class EnochTelegramTests(unittest.TestCase):
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            with patch.object(bot, "_respond_read_only_turn", return_value=response):
+            with patch(
+                "enoch.evolution.core.recent_completion_evidence",
+                return_value=(
+                    {
+                        "task_id": 17,
+                        "resolution_authority": "task-completion",
+                        "evidence_refs": ["task:17"],
+                    },
+                ),
+            ), patch.object(bot, "_respond_read_only_turn", return_value=response):
                 _handle_update(bot, _message_update(chat_id=42, text="/propose"))
             candidates = load_evolve_candidates(root)
             events = load_evolve_events(root)
@@ -2557,10 +2567,12 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("backlog-2 [candidate backlog]", reply)
         self.assertIn("LLM remove suggestions (no status changed):", reply)
         self.assertIn("backlog-1 [context-only]", reply)
+        self.assertIn("Evidence: task:17", reply)
         self.assertEqual({candidate.status for candidate in candidates}, {"candidate"})
         self.assertEqual(queued.pending_count, 0)
         self.assertEqual(events[-1].recommendation_kind, "llm")
         self.assertTrue(events[-1].curation_id.startswith("curation-"))
+        self.assertEqual(events[-1].evidence_refs, ("task:17",))
 
     def test_repeated_proposal_marks_previous_one_no_action(self) -> None:
         with TemporaryDirectory() as temp:
@@ -2609,6 +2621,63 @@ class EnochTelegramTests(unittest.TestCase):
 
         self.assertEqual([event.event for event in events], ["proposed", "removed"])
         self.assertEqual(events[0].proposal_id, events[1].proposal_id)
+
+    def test_human_remove_applies_recorded_curation_classification_and_refs(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_backlog_item(42, "add bounded curation evidence", root, priority="p0")
+            response = json.dumps(
+                {
+                    "recommended_candidate_id": None,
+                    "recommendation_reason": "",
+                    "scope_guidance": "",
+                    "risk_guidance": "",
+                    "test_plan_guidance": "",
+                    "remove_suggestions": [
+                        {
+                            "candidate_id": "backlog-1",
+                            "classification": "already-resolved",
+                            "reason": "Task 17 was merged into the authoritative body.",
+                            "evidence_refs": ["task:17", "merge:e536d32"],
+                        }
+                    ],
+                    "new_candidates": [],
+                }
+            )
+            evidence = (
+                {
+                    "task_id": 17,
+                    "resolution_authority": "authoritative-body",
+                    "evidence_refs": ["task:17", "merge:e536d32"],
+                },
+            )
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochApplication(load_identity(), root, client)
+
+            with patch(
+                "enoch.evolution.core.recent_completion_evidence",
+                return_value=evidence,
+            ), patch.object(bot, "_respond_read_only_turn", return_value=response):
+                _handle_update(bot, _message_update(chat_id=42, text="/propose"))
+            _handle_update(
+                bot,
+                _message_update(
+                    update_id=2,
+                    chat_id=42,
+                    text="/evolve remove backlog-1 already-resolved",
+                ),
+            )
+            removed = load_evolve_events(root, candidate_id="backlog-1")[-1]
+
+        self.assertEqual(removed.event, "removed")
+        self.assertEqual(removed.event_actor, "human")
+        self.assertEqual(removed.removal_classification, "already-resolved")
+        self.assertTrue(removed.curation_id.startswith("curation-"))
+        self.assertEqual(removed.evidence_refs, ("task:17", "merge:e536d32"))
+        self.assertEqual(
+            removed.reason,
+            "Task 17 was merged into the authoritative body.",
+        )
 
     def test_propose_curator_suggests_bounded_candidate_when_pool_is_empty(self) -> None:
         response = json.dumps(


### PR DESCRIPTION
## Summary

- aggregate bounded, privacy-cleaned recent task, PR, promotion, merge, and version evidence for semantic candidate curation
- require auditable authoritative evidence refs for `already-resolved` and `superseded` suggestions while keeping all candidate removal human-only
- persist evidence refs and removal metadata without copying private task bodies or changing raw candidate provenance
- expose evidence refs in proposal/reporting output and document the governance contract

## Validation

- `python -m unittest tests.test_enoch_evolve_curation tests.test_enoch_evolve_events tests.test_enoch_task_queue tests.test_enoch_telegram` (281 tests)
- `enoch doctor` (full project tests, import smoke, build backend, and operational readiness passed)
- `git diff --check`