### PR TITLE
Support model-aware reasoning effort

### DIFF
--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -26,6 +26,7 @@ from enoch.automatic_learning import record_learning_artifact
 from enoch.brain import (
     act_in_session,
     codex_model_options,
+    codex_reasoning_efforts,
     model_summary,
     reset_token_usage,
     respond,
@@ -433,6 +434,7 @@ class EnochApplication:
             model_summary_fn=lambda root=None: model_summary(root),
             model_options_fn=lambda: codex_model_options(),
             reset_usage_fn=lambda: reset_token_usage(),
+            reasoning_efforts_fn=lambda root=None: codex_reasoning_efforts(root),
         )
         self.forge = forge or FunctionForgeProvider(
             close_fn=lambda *args, **kwargs: close_pull_request(*args, **kwargs),

--- a/src/enoch/brain.py
+++ b/src/enoch/brain.py
@@ -4,6 +4,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -46,7 +47,8 @@ DEFAULT_CODEX_PATHS = [
     "/Applications/ChatGPT.app/Contents/Resources/codex",
     "/Applications/Codex.app/Contents/Resources/codex",
 ]
-REASONING_EFFORTS = {"low", "medium", "high"}
+REASONING_EFFORTS = ("low", "medium", "high", "xhigh", "max", "ultra")
+_REASONING_EFFORT_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 ProgressCallback = Callable[[int, str], None]
 
 
@@ -67,6 +69,7 @@ class CodexModelOption:
     slug: str
     display_name: str
     description: str = ""
+    supported_reasoning_efforts: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -225,14 +228,51 @@ def codex_model_options(root: Path | None = None) -> tuple[CodexModelOption, ...
         if not slug or slug in seen:
             continue
         seen.add(slug)
+        supported_reasoning_efforts = []
+        raw_reasoning_levels = raw.get("supported_reasoning_levels")
+        if isinstance(raw_reasoning_levels, list):
+            for raw_level in raw_reasoning_levels:
+                if not isinstance(raw_level, dict):
+                    continue
+                effort = str(raw_level.get("effort") or "").strip().lower()
+                if (
+                    _REASONING_EFFORT_PATTERN.fullmatch(effort)
+                    and effort not in supported_reasoning_efforts
+                ):
+                    supported_reasoning_efforts.append(effort)
         options.append(
             CodexModelOption(
                 slug=slug,
                 display_name=str(raw.get("display_name") or slug).strip() or slug,
                 description=str(raw.get("description") or "").strip(),
+                supported_reasoning_efforts=tuple(supported_reasoning_efforts),
             )
         )
     return tuple(options)
+
+
+def codex_reasoning_efforts(root: Path | None = None) -> tuple[str, ...]:
+    options = codex_model_options(root)
+    configured_model = _configured_model(root)
+    if not configured_model:
+        configured_model = _read_codex_config(_codex_config_path()).get("model", "")
+    if configured_model:
+        current = next(
+            (option for option in options if option.slug == configured_model),
+            None,
+        )
+        if current is not None and current.supported_reasoning_efforts:
+            return current.supported_reasoning_efforts
+        return REASONING_EFFORTS
+    first_supported = next(
+        (
+            option.supported_reasoning_efforts
+            for option in options
+            if option.supported_reasoning_efforts
+        ),
+        (),
+    )
+    return first_supported or REASONING_EFFORTS
 
 
 def _codex_config_path() -> Path:
@@ -825,7 +865,7 @@ def _enoch_reasoning_effort(root: Path | None = None) -> str:
     if root is None:
         return ""
     value = read_section("codex", root).get("reasoning_effort", "").strip().lower()
-    return value if value in REASONING_EFFORTS else ""
+    return value if _REASONING_EFFORT_PATTERN.fullmatch(value) else ""
 
 
 def _run_with_progress(

--- a/src/enoch/cli.py
+++ b/src/enoch/cli.py
@@ -69,7 +69,7 @@ ADMIN_COMMANDS = (
     AdminCommand(
         "thinking",
         "Show or set Enoch's Codex thinking level.",
-        "thinking [low|medium|high|default]",
+        "thinking [low|medium|high|xhigh|max|ultra|default]",
         "_admin_thinking",
     ),
     AdminCommand(

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -171,9 +171,15 @@ def thinking_command(
     runtime = runtime or _default_runtime(root)
     if model_summary_fn is model_summary:
         model_summary_fn = runtime.model_summary
+    reasoning_efforts = _runtime_reasoning_efforts(runtime, root)
     parts = text.split()
     if len(parts) == 1:
-        return thinking_status(root, model_summary_fn=model_summary_fn, prefix=prefix)
+        return thinking_status(
+            root,
+            model_summary_fn=model_summary_fn,
+            prefix=prefix,
+            reasoning_efforts=reasoning_efforts,
+        )
     choice = parts[1].strip().lower()
     if choice in {"default", "reset", "off"}:
         if allowed_chat_id is None:
@@ -183,11 +189,16 @@ def thinking_command(
             [
                 "Enoch cleared her local thinking override.",
                 "",
-                thinking_status(root, model_summary_fn=model_summary_fn, prefix=prefix),
+                thinking_status(
+                    root,
+                    model_summary_fn=model_summary_fn,
+                    prefix=prefix,
+                    reasoning_efforts=reasoning_efforts,
+                ),
             ]
         )
-    if choice not in REASONING_EFFORTS:
-        return thinking_usage(prefix=prefix)
+    if choice not in reasoning_efforts:
+        return thinking_usage(prefix=prefix, reasoning_efforts=reasoning_efforts)
     if allowed_chat_id is None:
         return thinking_lock_message()
     write_config(runtime.config_section, "reasoning_effort", choice, root)
@@ -195,7 +206,12 @@ def thinking_command(
         [
             f"Enoch thinking level set to {choice}.",
             "",
-            thinking_status(root, model_summary_fn=model_summary_fn, prefix=prefix),
+            thinking_status(
+                root,
+                model_summary_fn=model_summary_fn,
+                prefix=prefix,
+                reasoning_efforts=reasoning_efforts,
+            ),
         ]
     )
 
@@ -205,6 +221,7 @@ def thinking_status(
     *,
     model_summary_fn: ModelSummaryFn = model_summary,
     prefix: str = "/",
+    reasoning_efforts: tuple[str, ...] = REASONING_EFFORTS,
 ) -> str:
     command = f"{prefix}thinking"
     return "\n".join(
@@ -212,16 +229,22 @@ def thinking_status(
             "Enoch thinking status:",
             model_summary_fn(root),
             "",
-            f"Set with {command} low, {command} medium, {command} high, or {command} default.",
+            f"Set with {', '.join(f'{command} {choice}' for choice in reasoning_efforts)}, "
+            f"or {command} default.",
         ]
     )
 
 
-def thinking_usage(prefix: str = "/") -> str:
+def thinking_usage(
+    prefix: str = "/",
+    *,
+    reasoning_efforts: tuple[str, ...] = REASONING_EFFORTS,
+) -> str:
     command = f"{prefix}thinking"
+    choices = "|".join((*reasoning_efforts, "default"))
     return "\n".join(
         [
-            f"Use {command} low, {command} medium, {command} high, or {command} default.",
+            f"Use {command} <{choices}>.",
             f"Use {command} by itself to show the current setting.",
         ]
     )
@@ -390,11 +413,13 @@ def config_command(
         value = parts[2].strip().lower()
         section = runtime.config_section
         runtime_label = runtime.name.title()
+        reasoning_efforts = _runtime_reasoning_efforts(runtime, root)
         if value in {"default", "reset"}:
             write_section_value(section, "reasoning_effort", None, root)
             message = f"Enoch cleared her local {runtime_label} reasoning effort override."
-        elif value not in REASONING_EFFORTS:
-            return f"{runtime_label} reasoning effort must be low, medium, high, or default."
+        elif value not in reasoning_efforts:
+            choices = _format_choices((*reasoning_efforts, "default"))
+            return f"{runtime_label} reasoning effort must be {choices}."
         else:
             write_section_value(section, "reasoning_effort", value, root)
             message = f"Enoch {runtime_label} reasoning effort set to {value}."
@@ -437,12 +462,14 @@ def config_status(
         summary = str(runtime_config_summary(root)).strip()
         if summary:
             lines.append(summary)
+    reasoning_efforts = _runtime_reasoning_efforts(runtime, root)
+    reasoning_choices = "|".join(reasoning_efforts)
     lines.extend(
         [
             "",
             f"Use {command} model to see available models or set one with {command} model <name>.",
             (
-                f"Set reasoning with {command} reasoning-effort low|medium|high "
+                f"Set reasoning with {command} reasoning-effort {reasoning_choices} "
                 f"or {command} reasoning-effort default."
             ),
             f"Set task timeout with {command} task-timeout <duration> or {command} task-timeout default.",
@@ -576,6 +603,30 @@ def _model_name_from_summary(summary: str) -> str:
     )
 
 
+def _runtime_reasoning_efforts(
+    runtime: AgentRuntime,
+    root: Path,
+) -> tuple[str, ...]:
+    provider_choices = getattr(runtime, "reasoning_efforts", None)
+    if callable(provider_choices):
+        choices = tuple(
+            dict.fromkeys(
+                str(choice).strip().lower()
+                for choice in provider_choices(root)
+                if str(choice).strip()
+            )
+        )
+        if choices:
+            return choices
+    return REASONING_EFFORTS
+
+
+def _format_choices(choices: tuple[str, ...]) -> str:
+    if len(choices) == 1:
+        return choices[0]
+    return f"{', '.join(choices[:-1])}, or {choices[-1]}"
+
+
 def config_usage(prefix: str = "/") -> str:
     command = f"{prefix}config"
     return "\n".join(
@@ -592,7 +643,11 @@ def config_usage(prefix: str = "/") -> str:
             f"{command} model <name> - set a local runtime model override",
             f"{command} model default - inherit the runtime model",
             f"{command} reasoning-effort - show the effective reasoning effort",
-            f"{command} reasoning-effort low|medium|high - set local reasoning effort",
+            (
+                f"{command} reasoning-effort {'|'.join(REASONING_EFFORTS)} "
+                "- set local reasoning effort"
+            ),
+            "Available reasoning levels depend on the active runtime model.",
             f"{command} reasoning-effort default - inherit runtime reasoning effort",
             f"{command} task-timeout - show the task timeout",
             f"{command} task-timeout <duration> - set a timeout between 1m and 2h",

--- a/src/enoch/providers/runtime.py
+++ b/src/enoch/providers/runtime.py
@@ -24,6 +24,7 @@ RespondFn = Callable[..., RuntimeResultLike]
 ActFn = Callable[..., RuntimeResultLike]
 SummaryFn = Callable[[Path | None], str]
 OptionsFn = Callable[[], tuple[Any, ...]]
+ReasoningEffortsFn = Callable[[Path | None], tuple[str, ...]]
 ResetFn = Callable[[], None]
 HealthFn = Callable[[Path | None], ProviderHealth]
 
@@ -36,6 +37,7 @@ class FunctionAgentRuntime:
     model_options_fn: OptionsFn
     reset_usage_fn: ResetFn
     health_fn: HealthFn | None = None
+    reasoning_efforts_fn: ReasoningEffortsFn | None = None
     name: str = "codex"
     provider_kind: str = "runtime"
     config_section: str = "codex"
@@ -119,6 +121,11 @@ class FunctionAgentRuntime:
     def model_options(self) -> tuple[Any, ...]:
         return self.model_options_fn()
 
+    def reasoning_efforts(self, root: Path | None = None) -> tuple[str, ...]:
+        if self.reasoning_efforts_fn is None:
+            return ()
+        return self.reasoning_efforts_fn(root)
+
     def reset_usage(self) -> None:
         self.reset_usage_fn()
 
@@ -141,6 +148,7 @@ class CodexRuntime(FunctionAgentRuntime):
         from enoch.brain import (
             act_in_session_result,
             codex_model_options,
+            codex_reasoning_efforts,
             model_summary,
             reset_token_usage,
             respond_result,
@@ -155,6 +163,9 @@ class CodexRuntime(FunctionAgentRuntime):
                 if option.slug == "gpt-5.6" or option.slug.startswith("gpt-5.6-")
             ),
             reset_usage_fn=reset_token_usage,
+            reasoning_efforts_fn=lambda reasoning_root=None: codex_reasoning_efforts(
+                reasoning_root or root
+            ),
             health_fn=lambda health_root=None: _codex_health(health_root or root),
         )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,11 +10,13 @@ import atexit
 import os
 from pathlib import Path
 import shutil
+import sys
 import tempfile
 import unittest
 
 
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SOURCE_ROOT / "src"))
 STATE_HOME = Path(tempfile.mkdtemp(prefix="enoch-test-state-"))
 
 os.environ["ENOCH_STATE_REDIRECT_ROOT"] = str(SOURCE_ROOT)

--- a/tests/test_enoch_brain.py
+++ b/tests/test_enoch_brain.py
@@ -154,6 +154,13 @@ class EnochBrainTests(unittest.TestCase):
                         "slug": "gpt-5.6-sol",
                         "display_name": "GPT-5.6-Sol",
                         "description": "Latest frontier model.",
+                        "supported_reasoning_levels": [
+                            {"effort": "low"},
+                            {"effort": "high"},
+                            {"effort": "xhigh"},
+                            {"effort": "max"},
+                            {"effort": "ultra"},
+                        ],
                         "visibility": "list",
                     },
                     {
@@ -174,6 +181,13 @@ class EnochBrainTests(unittest.TestCase):
                     slug="gpt-5.6-sol",
                     display_name="GPT-5.6-Sol",
                     description="Latest frontier model.",
+                    supported_reasoning_efforts=(
+                        "low",
+                        "high",
+                        "xhigh",
+                        "max",
+                        "ultra",
+                    ),
                 ),
             ),
         )
@@ -181,6 +195,43 @@ class EnochBrainTests(unittest.TestCase):
             run.call_args.args[0],
             ["/usr/local/bin/codex", "debug", "models", "--bundled"],
         )
+
+    @patch("enoch.brain.codex_model_options")
+    def test_codex_reasoning_efforts_follow_configured_model(
+        self,
+        model_options: MagicMock,
+    ) -> None:
+        model_options.return_value = (
+            brain.CodexModelOption(
+                slug="gpt-5.6-sol",
+                display_name="GPT-5.6-Sol",
+                supported_reasoning_efforts=(
+                    "low",
+                    "medium",
+                    "high",
+                    "xhigh",
+                    "max",
+                    "ultra",
+                ),
+            ),
+            brain.CodexModelOption(
+                slug="gpt-5.5",
+                display_name="GPT-5.5",
+                supported_reasoning_efforts=("low", "medium", "high", "xhigh"),
+            ),
+        )
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            config = root / ".enoch" / "config.yaml"
+            config.parent.mkdir()
+            config.write_text(
+                "\n".join(["codex:", "  model: gpt-5.5"]),
+                encoding="utf-8",
+            )
+
+            efforts = brain.codex_reasoning_efforts(root)
+
+        self.assertEqual(efforts, ("low", "medium", "high", "xhigh"))
 
     def test_model_summary_reports_enoch_model_override(self) -> None:
         with TemporaryDirectory() as temp, TemporaryDirectory() as codex_home:
@@ -322,13 +373,13 @@ class EnochBrainTests(unittest.TestCase):
             root = Path(temp)
             config = root / ".enoch" / "config.yaml"
             config.parent.mkdir()
-            config.write_text("\n".join(["codex:", "  reasoning_effort: medium"]), encoding="utf-8")
+            config.write_text("\n".join(["codex:", "  reasoning_effort: xhigh"]), encoding="utf-8")
 
             respond(load_identity(), "Hello", cwd=root)
 
         args = run.call_args.args[0]
         self.assertIn("-c", args)
-        self.assertIn('model_reasoning_effort="medium"', args)
+        self.assertIn('model_reasoning_effort="xhigh"', args)
 
     @patch("enoch.brain.shutil.which", return_value="/usr/local/bin/codex")
     @patch("enoch.brain.subprocess.run")

--- a/tests/test_enoch_cli.py
+++ b/tests/test_enoch_cli.py
@@ -304,7 +304,10 @@ class EnochCliTests(unittest.TestCase):
 
         model_summary.assert_called_once_with(ROOT)
         self.assertIn("Enoch thinking status:", output)
-        self.assertIn("Set with thinking low, thinking medium, thinking high, or thinking default.", output)
+        self.assertIn("thinking xhigh", output)
+        self.assertIn("thinking max", output)
+        self.assertIn("thinking ultra", output)
+        self.assertIn("or thinking default.", output)
         self.assertNotIn("/thinking low", output)
 
     @patch("enoch.cli.run_immune_system")

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -807,7 +807,10 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/config profile <name|default>", reply)
         self.assertIn("/config model <name>", reply)
         self.assertIn("/config model default", reply)
-        self.assertIn("/config reasoning-effort low|medium|high", reply)
+        self.assertIn(
+            "/config reasoning-effort low|medium|high|xhigh|max|ultra",
+            reply,
+        )
         self.assertIn("/config reasoning-effort default", reply)
         self.assertIn("/config task-timeout <duration>", reply)
         self.assertIn("/config task-timeout default", reply)
@@ -1170,7 +1173,7 @@ class EnochTelegramTests(unittest.TestCase):
                     _message_update(
                         update_id=3,
                         chat_id=42,
-                        text="/config reasoning-effort high",
+                        text="/config reasoning-effort xhigh",
                     )
                 )
                 configured = read_section("codex", root)
@@ -1194,9 +1197,9 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("Reasoning effort: medium", client.sent[0][1])
         self.assertIn("AI model: gpt-enoch-local", client.sent[1][1])
         self.assertIn("Model source: Enoch config codex.model", client.sent[1][1])
-        self.assertIn("Reasoning effort: high", client.sent[2][1])
+        self.assertIn("Reasoning effort: xhigh", client.sent[2][1])
         self.assertEqual(configured["model"], "gpt-enoch-local")
-        self.assertEqual(configured["reasoning_effort"], "high")
+        self.assertEqual(configured["reasoning_effort"], "xhigh")
         self.assertIn("AI model: gpt-global", client.sent[3][1])
         self.assertIn("Reasoning effort: medium", client.sent[4][1])
         self.assertNotIn("model", reset)
@@ -1243,6 +1246,38 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertNotIn("gpt-5.5", reply)
         self.assertIn("Example: /config model gpt-5.6-sol", reply)
         self.assertIn("private or future Codex rollouts", reply)
+
+    def test_config_reasoning_rejects_level_unsupported_by_current_model(self) -> None:
+        runtime = FunctionAgentRuntime(
+            respond_fn=lambda *_args, **_kwargs: "",
+            act_in_session_fn=lambda *_args, **_kwargs: "",
+            model_summary_fn=lambda _root=None: "AI model: gpt-5.5",
+            model_options_fn=lambda: (),
+            reset_usage_fn=lambda: None,
+            reasoning_efforts_fn=lambda _root=None: (
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+            ),
+        )
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochApplication(load_identity(), root, client, runtime=runtime)
+
+            _handle_update(
+                bot,
+                _message_update(
+                    chat_id=42,
+                    text="/config reasoning-effort max",
+                ),
+            )
+
+        self.assertIn(
+            "Codex reasoning effort must be low, medium, high, xhigh, or default.",
+            client.sent[0][1],
+        )
 
     def test_help_inherit_shows_inherit_usage(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)


### PR DESCRIPTION
## What changed

- Read supported reasoning levels from the installed Codex model catalog.
- Support `xhigh`, `max`, and `ultra` where the active model advertises them.
- Keep command validation and status output model-aware, with a safe fallback when the catalog is unavailable.
- Update the admin CLI and `/help config` so the expanded options are discoverable.
- Accept safely formed configured effort identifiers instead of silently dropping newer catalog values.
- Centralize the test suite's source-path bootstrap so CI no longer depends on test import order.

## Root cause

Enoch used a hard-coded `low`, `medium`, `high` allowlist in runtime config loading, command validation, and help text. Codex added higher effort levels, but Enoch never consumed the per-model `supported_reasoning_levels` already present in the bundled model catalog.

The first CI run also exposed a pre-existing test bootstrap defect on `main`: `tests/test_enoch_authorization.py` imported `enoch` before any earlier test happened to add `src` to `sys.path`. `tests/__init__.py` now establishes that path deterministically for the whole suite.

## User impact

`/config reasoning-effort xhigh` now works for supported models. Models with narrower capabilities reject unsupported levels with an accurate model-specific list instead of accepting a setting that will fail later.

## Validation

- `python -m unittest discover -s tests -t .` — 684 passed without `PYTHONPATH=src`
- GitHub provider — 5 passed
- launchd provider — 4 passed
- provider-kit — 9 passed
- skill-catalog — 3 passed
- systemd provider — 4 passed
- Telegram provider — 6 passed
- Telegram vision provider — 5 passed
- `git diff --check`