### PR TITLE
Fix work validation and complete task 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,3 +344,5 @@ guidelines.
 ## License
 
 Enoch is licensed under the [Apache License 2.0](LICENSE).
+
+test

--- a/src/enoch/skills/work/skill.yaml
+++ b/src/enoch/skills/work/skill.yaml
@@ -23,4 +23,4 @@ permissions:
   chat:
     send_status_updates: true
 validation:
-  command: python3 -m unittest discover -s tests
+  command: bin/enoch doctor

--- a/tests/test_enoch_immune.py
+++ b/tests/test_enoch_immune.py
@@ -155,7 +155,7 @@ class EnochImmuneTests(unittest.TestCase):
         result = run_immune_system(ROOT)
 
         self.assertTrue(result.passed)
-        self.assertIn("-m unittest discover -s tests", result.command)
+        self.assertIn("-m unittest discover -s tests -t .", result.command)
         self.assertIn("import enoch.cli", result.command)
         self.assertIn("import enoch.providers", result.command)
         self.assertIn("import enoch.lineage", result.command)

--- a/tests/test_enoch_skills.py
+++ b/tests/test_enoch_skills.py
@@ -99,6 +99,14 @@ class EnochSkillsTests(unittest.TestCase):
         self.assertIn("contract: skill-library/v1", metadata)
         self.assertIn("implementation: procedural", metadata)
 
+    def test_work_skill_validation_uses_canonical_doctor(self) -> None:
+        metadata = (
+            ROOT / "src" / "enoch" / "skills" / "work" / "skill.yaml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("validation:\n  command: bin/enoch doctor\n", metadata)
+        self.assertNotIn("unittest discover", metadata)
+
     def test_skills_command_can_inspect_explicit_local_agent_path(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)

--- a/tests/test_enoch_test_isolation.py
+++ b/tests/test_enoch_test_isolation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+
+class EnochTestIsolationTests(unittest.TestCase):
+    def test_canonical_discovery_loads_test_state_isolation(self) -> None:
+        self.assertEqual(
+            __package__,
+            "tests",
+            "run unittest discovery with '-t .' so tests/__init__.py is loaded",
+        )
+        isolation = sys.modules.get("tests")
+        self.assertIsNotNone(isolation)
+        state_home = isolation.STATE_HOME
+        self.assertEqual(os.environ.get("ENOCH_STATE_HOME"), str(state_home))
+        self.assertIs(unittest.TestCase.run, isolation._run_with_clean_resident_state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Route the work skill's validation through `bin/enoch doctor`, inheriting Doctor's build-backend preflight and canonical `python -m unittest discover -s tests -t .` command.
- Add focused regressions that prove `tests/__init__.py` state isolation is loaded and prevent the work validation command from drifting back to direct unittest discovery.
- Complete task #4 by appending exactly one `test` line to `README.md`; the earlier PR #23 was closed without merging and was not reused.

## Validation
- Confirmed the stale `python -m unittest discover -s tests` path fails the new isolation regression.
- `python -m unittest -v tests.test_enoch_test_isolation tests.test_enoch_skills tests.test_enoch_immune tests.test_enoch_portable_install` (39 passed)
- `ENOCH_PYTHON=<isolated-venv-python> bin/enoch doctor` (passed, including locked setuptools preflight and full suite)
- Provider-library unittest suites for GitHub, launchd, provider-kit, skill-catalog, systemd, Telegram, and telegram-vision (44 passed)

## Review notes
- No global dependencies were installed or mutated.
- PR #23 remains closed and unmerged.