### PR TITLE
Preserve skipped Doctor checks during updates

### DIFF
--- a/src/enoch/operations/updater.py
+++ b/src/enoch/operations/updater.py
@@ -210,6 +210,7 @@ def _doctor_result_from_payload(payload: object) -> ImmuneResult:
             output=str(raw.get("output") or ""),
             category=str(raw.get("category") or "code health"),
             summary=str(raw.get("summary") or ""),
+            skipped=raw.get("skipped") is True,
         )
         for raw in raw_checks
         if isinstance(raw, dict)

--- a/tests/test_enoch_updater.py
+++ b/tests/test_enoch_updater.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from enoch.git_tools import GitError
+from enoch.formatting import format_doctor_result
 from enoch.immune import DoctorDiagnosis
 from enoch.operations.updater import run_update_doctor, update_from_authoritative
 
@@ -44,6 +45,7 @@ class EnochUpdaterTests(unittest.TestCase):
                     "output": "",
                     "category": "operational readiness",
                     "summary": "loaded from disk",
+                    "skipped": True,
                 }
             ],
         }
@@ -76,6 +78,11 @@ class EnochUpdaterTests(unittest.TestCase):
         self.assertEqual(result.command, "updated doctor")
         self.assertEqual(result.diagnosis.summary, "Updated doctor passed.")
         self.assertEqual(result.checks[0].summary, "loaded from disk")
+        self.assertTrue(result.checks[0].skipped)
+        self.assertIn(
+            "- updated runtime: skipped (loaded from disk)",
+            format_doctor_result(result),
+        )
 
     @patch("enoch.operations.updater.run_update_doctor")
     @patch(


### PR DESCRIPTION
## What changed

- Preserve `DoctorCheckResult.skipped` when `/update` reconstructs results from the fresh Doctor subprocess.
- Extend the post-update Doctor regression test to verify both the reconstructed flag and the user-visible `skipped` status.

## Why

The fresh Doctor process correctly serialized prerequisite-blocked tests as `passed=true, skipped=true`, but the updater dropped `skipped` while rebuilding the check. The formatter consequently reported those tests as passed even though they never ran.

## Impact

Update failure reports now distinguish skipped checks from passing checks without changing Doctor's prerequisite or rollback behavior.

## Validation

- `python -m unittest -v tests.test_enoch_updater tests.test_enoch_immune tests.test_enoch_cli` — 57 passed
- `python -m unittest discover -s tests -t .` in a clean isolated worktree — 706 passed
- `git diff --check`