### PR TITLE
Add display-only Telegram formatting

### DIFF
--- a/libraries/telegram/src/our_ark_telegram/__init__.py
+++ b/libraries/telegram/src/our_ark_telegram/__init__.py
@@ -9,6 +9,11 @@ from our_ark_telegram.core import (
     telegram_event,
 )
 from our_ark_telegram.integration import load_config, setup_provider
+from our_ark_telegram.presentation import (
+    TelegramMessageChunk,
+    render_telegram_html,
+    telegram_message_chunks,
+)
 
 
 def create_provider(root=None):
@@ -35,9 +40,12 @@ __all__ = [
     "TelegramClient",
     "TelegramConfig",
     "TelegramError",
+    "TelegramMessageChunk",
     "create_provider",
     "load_config",
     "setup_provider",
     "chunks",
+    "render_telegram_html",
+    "telegram_message_chunks",
     "telegram_event",
 ]

--- a/libraries/telegram/src/our_ark_telegram/core.py
+++ b/libraries/telegram/src/our_ark_telegram/core.py
@@ -13,6 +13,11 @@ from our_ark_provider_kit import (
     ConversationId,
     MessageId,
 )
+from our_ark_telegram.presentation import (
+    is_formatting_error,
+    render_telegram_html,
+    telegram_message_chunks,
+)
 
 
 TELEGRAM_API = "https://api.telegram.org"
@@ -64,10 +69,15 @@ class TelegramClient:
         text: str,
     ) -> MessageId | None:
         first_message_id: int | None = None
-        for chunk in chunks(text):
-            data = self._call(
+        for chunk in telegram_message_chunks(text, MAX_TELEGRAM_MESSAGE):
+            data = self._call_with_plain_fallback(
                 "sendMessage",
-                {"chat_id": conversation_id, "text": chunk},
+                {
+                    "chat_id": conversation_id,
+                    "text": chunk.html,
+                    "parse_mode": "HTML",
+                },
+                plain_text=chunk.plain,
             )
             message_id = _message_id(data)
             if first_message_id is None and message_id is not None:
@@ -113,13 +123,15 @@ class TelegramClient:
         message_id: MessageId,
         text: str,
     ) -> None:
-        self._call(
+        self._call_with_plain_fallback(
             "editMessageText",
             {
                 "chat_id": conversation_id,
                 "message_id": message_id,
-                "text": text,
+                "text": render_telegram_html(text),
+                "parse_mode": "HTML",
             },
+            plain_text=text,
         )
 
     def send_read_ack(
@@ -152,6 +164,23 @@ class TelegramClient:
         if not data.get("ok"):
             raise TelegramError(str(data))
         return data
+
+    def _call_with_plain_fallback(
+        self,
+        method: str,
+        payload: dict[str, Any],
+        *,
+        plain_text: str,
+    ) -> dict[str, Any]:
+        try:
+            return self._call(method, payload)
+        except TelegramError as error:
+            if not is_formatting_error(error):
+                raise
+        fallback = dict(payload)
+        fallback["text"] = plain_text
+        fallback.pop("parse_mode", None)
+        return self._call(method, fallback)
 
 
 def telegram_event(update: dict[str, Any]) -> ChatEvent | None:

--- a/libraries/telegram/src/our_ark_telegram/presentation.py
+++ b/libraries/telegram/src/our_ark_telegram/presentation.py
@@ -1,0 +1,554 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+import re
+from urllib.parse import urlsplit
+
+
+_FENCE_RE = re.compile(
+    r"^[ \t]*```(?P<language>[A-Za-z0-9_+.-]*)[ \t]*(?:\r?\n)?$"
+)
+_HEADING_RE = re.compile(r"^[ \t]{0,3}#{1,6}[ \t]+(?P<text>.*?)[ \t]*#*[ \t]*$")
+_QUOTE_RE = re.compile(r"^(?P<indent>[ \t]*)>[ \t]?(?P<text>.*)$")
+_LIST_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?P<marker>[-+*]|\d+[.)])(?P<space>[ \t]+)(?P<text>.*)$"
+)
+_HELP_COMMAND_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?P<command>/[A-Za-z][\w-]*(?:[ \t]+.*?)*?)"
+    r"(?P<separator>[ \t]+-[ \t]+)(?P<description>.+)$"
+)
+_LABEL_RE = re.compile(
+    r"^(?P<label>[A-Za-z][A-Za-z0-9 _()/.-]{0,47}:)"
+    r"(?P<space>[ \t]*)(?P<value>.*)$"
+)
+_PATH_RE = re.compile(
+    r"""
+    (?<![\w:/])
+    (
+        (?!\d+/\d+\b)
+        (?:~?/|\./|\.\./)
+        [^\s<>()\[\]{}"']*
+        [A-Za-z0-9_./~-]
+        (?::\d+)?
+      |
+        (?!\d+/\d+\b)
+        (?:[A-Za-z0-9_.-]+/)+
+        [A-Za-z0-9_.-]+
+        (?::\d+)?
+      |
+        \b[A-Za-z0-9_.-]+\.
+        (?:py|md|toml|ya?ml|jsonl?|txt|sh|bash|zsh|js|jsx|ts|tsx|rs|go|java|rb|lock)
+        (?::\d+)?
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+_TITLE_RE = re.compile(
+    r"^(?:"
+    r"Task #\d+\b|"
+    r"Doctor\b|"
+    r"Enoch\b|"
+    r"Open pull requests\b|"
+    r"Pull request #\d+\b|"
+    r"Work status\b|"
+    r"Task worktrees\b|"
+    r"Tasks:|Cron:|Backlog:"
+    r")",
+    re.IGNORECASE,
+)
+_CODE_VALUE_LABELS = {
+    "authoritative",
+    "branch",
+    "changed",
+    "check command",
+    "command",
+    "commit",
+    "executable",
+    "file",
+    "files",
+    "local",
+    "merge commit",
+    "path",
+    "running",
+    "worktree",
+}
+_FORMATTING_ERROR_MARKERS = (
+    "can't parse entities",
+    "cant parse entities",
+    "can't find end tag",
+    "unsupported start tag",
+    "unsupported end tag",
+    "wrong entity",
+)
+
+
+@dataclass(frozen=True)
+class TelegramMessageChunk:
+    """One safe Telegram HTML payload and its plain-text fallback."""
+
+    html: str
+    plain: str
+
+
+@dataclass(frozen=True)
+class _Block:
+    kind: str
+    text: str
+
+
+def render_telegram_html(text: str) -> str:
+    """Render a conservative Markdown-like subset as Telegram-safe HTML."""
+
+    return "".join(_render_block(block) for block in _parse_blocks(text))
+
+
+def telegram_message_chunks(
+    text: str,
+    size: int,
+) -> list[TelegramMessageChunk]:
+    """Split on logical boundaries and render independently valid HTML chunks."""
+
+    if size < 1:
+        raise ValueError("Chunk size must be at least 1.")
+    blocks = [
+        piece
+        for block in _parse_blocks(text)
+        for piece in _split_block(block, size)
+    ]
+    if not blocks:
+        return [TelegramMessageChunk(html="", plain="")]
+
+    groups: list[list[_Block]] = []
+    current: list[_Block] = []
+    current_size = 0
+    for block in blocks:
+        block_size = len(block.text)
+        if current and current_size + block_size > size:
+            groups.append(current)
+            current = []
+            current_size = 0
+        current.append(block)
+        current_size += block_size
+    if current:
+        groups.append(current)
+
+    return [
+        TelegramMessageChunk(
+            html="".join(_render_block(block) for block in group),
+            plain="".join(block.text for block in group),
+        )
+        for group in groups
+    ]
+
+
+def is_formatting_error(error: BaseException) -> bool:
+    """Return whether Telegram rejected entity markup rather than delivery."""
+
+    message = str(error).lower()
+    return any(marker in message for marker in _FORMATTING_ERROR_MARKERS)
+
+
+def _parse_blocks(text: str) -> list[_Block]:
+    lines = text.splitlines(keepends=True)
+    if not lines and text:
+        lines = [text]
+    blocks: list[_Block] = []
+    regular: list[str] = []
+    index = 0
+
+    def flush_regular() -> None:
+        if regular:
+            blocks.append(_Block("text", "".join(regular)))
+            regular.clear()
+
+    while index < len(lines):
+        opening = _FENCE_RE.fullmatch(lines[index])
+        if opening is None:
+            regular.append(lines[index])
+            index += 1
+            continue
+
+        flush_regular()
+        index += 1
+        code_lines: list[str] = []
+        closing_line = ""
+        while index < len(lines):
+            if _FENCE_RE.fullmatch(lines[index]):
+                closing_line = lines[index]
+                index += 1
+                break
+            code_lines.append(lines[index])
+            index += 1
+
+        code = "".join(code_lines)
+        if closing_line:
+            code = _remove_one_trailing_newline(code)
+        blocks.append(_Block("code", code))
+        if closing_line.endswith(("\n", "\r")) and index < len(lines):
+            blocks.append(_Block("text", "\n"))
+
+    flush_regular()
+    return blocks
+
+
+def _split_block(block: _Block, size: int) -> list[_Block]:
+    if len(block.text) <= size:
+        return [block]
+    parts = _split_text(block.text, size, prefer_paragraphs=block.kind == "text")
+    return [_Block(block.kind, part) for part in parts]
+
+
+def _split_text(text: str, size: int, *, prefer_paragraphs: bool) -> list[str]:
+    remaining = text
+    parts: list[str] = []
+    while len(remaining) > size:
+        window = remaining[: size + 1]
+        cuts: list[int] = []
+        if prefer_paragraphs:
+            paragraph = window.rfind("\n\n", 0, size + 1)
+            if paragraph >= 0:
+                cuts.append(paragraph + 2)
+        newline = window.rfind("\n", 0, size + 1)
+        if newline >= 0:
+            cuts.append(newline + 1)
+        if prefer_paragraphs:
+            whitespace = max(
+                window.rfind(" ", 0, size + 1),
+                window.rfind("\t", 0, size + 1),
+            )
+            if whitespace >= 0:
+                cuts.append(whitespace + 1)
+        viable = [cut for cut in cuts if cut >= max(1, size // 3)]
+        cut = max(viable, default=size)
+        parts.append(remaining[:cut])
+        remaining = remaining[cut:]
+    if remaining or not parts:
+        parts.append(remaining)
+    return parts
+
+
+def _render_block(block: _Block) -> str:
+    if block.kind == "code":
+        return f"<pre><code>{escape(block.text, quote=False)}</code></pre>"
+    return _render_text(block.text)
+
+
+def _render_text(text: str) -> str:
+    rendered: list[str] = []
+    for raw_line in text.splitlines(keepends=True):
+        line, ending = _line_and_ending(raw_line)
+        rendered.append(_render_line(line))
+        rendered.append(ending)
+    if text and not text.endswith(("\n", "\r")) and not rendered:
+        rendered.append(_render_line(text))
+    return "".join(rendered)
+
+
+def _render_line(line: str) -> str:
+    stripped = line.strip()
+    if not stripped:
+        return escape(line, quote=False)
+
+    heading = _HEADING_RE.fullmatch(line)
+    if heading is not None:
+        return f"<b>{escape(heading.group('text'), quote=False)}</b>"
+
+    quote = _QUOTE_RE.fullmatch(line)
+    if quote is not None:
+        return (
+            f"{escape(quote.group('indent'), quote=False)}"
+            f"<blockquote>{escape(quote.group('text'), quote=False)}</blockquote>"
+        )
+
+    help_command = _HELP_COMMAND_RE.fullmatch(line)
+    if help_command is not None:
+        return "".join(
+            [
+                escape(help_command.group("indent"), quote=False),
+                f"<code>{escape(help_command.group('command'), quote=False)}</code>",
+                escape(help_command.group("separator"), quote=False),
+                _render_inline(help_command.group("description")),
+            ]
+        )
+
+    listed = _LIST_RE.fullmatch(line)
+    if listed is not None:
+        content = _render_labeled_text(
+            listed.group("text"),
+            allow_lowercase=True,
+        ) or _render_inline(listed.group("text"))
+        return "".join(
+            [
+                escape(listed.group("indent"), quote=False),
+                escape(listed.group("marker"), quote=False),
+                escape(listed.group("space"), quote=False),
+                content,
+            ]
+        )
+
+    if len(stripped) <= 80 and _TITLE_RE.match(stripped):
+        prefix = line[: len(line) - len(line.lstrip())]
+        return (
+            f"{escape(prefix, quote=False)}"
+            f"<b>{escape(line.lstrip(), quote=False)}</b>"
+        )
+
+    labeled = _render_labeled_text(line, allow_lowercase=False)
+    if labeled is not None:
+        return labeled
+
+    if _looks_like_shell_command(line):
+        return f"<code>{escape(line, quote=False)}</code>"
+    return _render_inline(line)
+
+
+def _render_labeled_text(text: str, *, allow_lowercase: bool) -> str | None:
+    match = _LABEL_RE.fullmatch(text)
+    if match is None:
+        return None
+    label = match.group("label")
+    name = label[:-1].strip()
+    if name.lower() in {"http", "https"}:
+        return None
+    if not allow_lowercase and not name[:1].isupper():
+        return None
+
+    value = match.group("value")
+    rendered_value = _render_label_value(name, value)
+    return "".join(
+        [
+            f"<b>{escape(label, quote=False)}</b>",
+            escape(match.group("space"), quote=False),
+            rendered_value,
+        ]
+    )
+
+
+def _render_label_value(label: str, value: str) -> str:
+    normalized = label.strip().lower()
+    if value and normalized in _CODE_VALUE_LABELS:
+        return f"<code>{escape(value, quote=False)}</code>"
+    return _render_inline(value)
+
+
+def _render_inline(text: str) -> str:
+    rendered: list[str] = []
+    plain_start = 0
+    index = 0
+
+    def flush_plain(end: int) -> None:
+        nonlocal plain_start
+        if end > plain_start:
+            rendered.append(_render_plain(text[plain_start:end]))
+        plain_start = end
+
+    while index < len(text):
+        if text[index] == "\\" and index + 1 < len(text):
+            flush_plain(index)
+            rendered.append(escape(text[index + 1], quote=False))
+            index += 2
+            plain_start = index
+            continue
+
+        if text[index] == "`":
+            end = _find_unescaped(text, "`", index + 1)
+            if end > index + 1:
+                flush_plain(index)
+                rendered.append(
+                    f"<code>{escape(text[index + 1:end], quote=False)}</code>"
+                )
+                index = end + 1
+                plain_start = index
+                continue
+
+        if text[index] == "[":
+            link = _parse_link(text, index)
+            if link is not None:
+                end, label, target = link
+                flush_plain(index)
+                rendered.append(_render_link(label, target))
+                index = end
+                plain_start = index
+                continue
+
+        marker = next(
+            (
+                candidate
+                for candidate in ("**", "~~")
+                if text.startswith(candidate, index)
+            ),
+            "",
+        )
+        if marker:
+            end = _find_unescaped(text, marker, index + len(marker))
+            if end > index + len(marker):
+                flush_plain(index)
+                tag = "b" if marker == "**" else "s"
+                content = escape(
+                    text[index + len(marker):end],
+                    quote=False,
+                )
+                rendered.append(f"<{tag}>{content}</{tag}>")
+                index = end + len(marker)
+                plain_start = index
+                continue
+
+        if text[index] == "*" and _valid_emphasis_open(text, index):
+            marker = text[index]
+            end = _find_emphasis_end(text, marker, index + 1)
+            if end > index + 1:
+                flush_plain(index)
+                rendered.append(
+                    f"<i>{escape(text[index + 1:end], quote=False)}</i>"
+                )
+                index = end + 1
+                plain_start = index
+                continue
+
+        index += 1
+
+    flush_plain(len(text))
+    return "".join(rendered)
+
+
+def _render_plain(text: str) -> str:
+    rendered: list[str] = []
+    position = 0
+    for match in _PATH_RE.finditer(text):
+        rendered.append(escape(text[position:match.start()], quote=False))
+        rendered.append(f"<code>{escape(match.group(0), quote=False)}</code>")
+        position = match.end()
+    rendered.append(escape(text[position:], quote=False))
+    return "".join(rendered)
+
+
+def _render_link(label: str, target: str) -> str:
+    cleaned_target = target.strip()
+    if cleaned_target.startswith("<") and cleaned_target.endswith(">"):
+        cleaned_target = cleaned_target[1:-1].strip()
+    scheme = urlsplit(cleaned_target).scheme.lower()
+    if scheme in {"http", "https"}:
+        return (
+            f'<a href="{escape(cleaned_target, quote=True)}">'
+            f"{escape(label, quote=False)}</a>"
+        )
+    if _looks_like_local_reference(cleaned_target):
+        rendered_label = f"<code>{escape(label, quote=False)}</code>"
+        if cleaned_target == label:
+            return rendered_label
+        return (
+            f"{rendered_label} "
+            f"(<code>{escape(cleaned_target, quote=False)}</code>)"
+        )
+    return (
+        f"{escape(label, quote=False)} "
+        f"(<code>{escape(cleaned_target, quote=False)}</code>)"
+    )
+
+
+def _parse_link(text: str, start: int) -> tuple[int, str, str] | None:
+    label_end = _find_unescaped(text, "]", start + 1)
+    if label_end < 0 or label_end + 1 >= len(text) or text[label_end + 1] != "(":
+        return None
+    depth = 1
+    index = label_end + 2
+    while index < len(text):
+        if text[index] == "\\":
+            index += 2
+            continue
+        if text[index] == "(":
+            depth += 1
+        elif text[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return (
+                    index + 1,
+                    text[start + 1:label_end],
+                    text[label_end + 2:index],
+                )
+        index += 1
+    return None
+
+
+def _find_unescaped(text: str, marker: str, start: int) -> int:
+    index = start
+    while True:
+        index = text.find(marker, index)
+        if index < 0:
+            return -1
+        preceding = 0
+        cursor = index - 1
+        while cursor >= 0 and text[cursor] == "\\":
+            preceding += 1
+            cursor -= 1
+        if preceding % 2 == 0:
+            return index
+        index += len(marker)
+
+
+def _valid_emphasis_open(text: str, index: int) -> bool:
+    previous = text[index - 1] if index else ""
+    following = text[index + 1] if index + 1 < len(text) else ""
+    return (
+        bool(following)
+        and not following.isspace()
+        and (not previous or previous.isspace() or previous in "([{>:;,-")
+    )
+
+
+def _find_emphasis_end(text: str, marker: str, start: int) -> int:
+    index = start
+    while True:
+        index = _find_unescaped(text, marker, index)
+        if index < 0:
+            return -1
+        previous = text[index - 1] if index else ""
+        following = text[index + 1] if index + 1 < len(text) else ""
+        if previous and not previous.isspace() and (
+            not following or following.isspace() or following in ".,!?;:)]}>-"
+        ):
+            return index
+        index += 1
+
+
+def _looks_like_local_reference(target: str) -> bool:
+    if target.startswith(("/", "./", "../", "~/")):
+        return True
+    return not urlsplit(target).scheme and "/" in target
+
+
+def _looks_like_shell_command(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    first = stripped.split(maxsplit=1)[0]
+    if first in {
+        "$",
+        "python",
+        "python3",
+        "pip",
+        "pip3",
+        "git",
+        "gh",
+        "pytest",
+        "uv",
+    }:
+        return True
+    return first.startswith(("bin/", "./bin/", "/opt/", "/usr/"))
+
+
+def _line_and_ending(line: str) -> tuple[str, str]:
+    if line.endswith("\r\n"):
+        return line[:-2], "\r\n"
+    if line.endswith(("\n", "\r")):
+        return line[:-1], line[-1]
+    return line, ""
+
+
+def _remove_one_trailing_newline(text: str) -> str:
+    if text.endswith("\r\n"):
+        return text[:-2]
+    if text.endswith(("\n", "\r")):
+        return text[:-1]
+    return text

--- a/libraries/telegram/tests/test_presentation.py
+++ b/libraries/telegram/tests/test_presentation.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROVIDER_KIT = ROOT.parent / "provider-kit"
+sys.path.insert(0, str(PROVIDER_KIT / "src"))
+sys.path.insert(0, str(ROOT / "src"))
+
+from our_ark_telegram import render_telegram_html, telegram_message_chunks
+
+
+class TelegramPresentationTests(unittest.TestCase):
+    def test_renders_markdown_without_trusting_source_html(self) -> None:
+        rendered = render_telegram_html(
+            "\n".join(
+                [
+                    "## What happened",
+                    "",
+                    "Run `bin/enoch doctor` and keep **the result**.",
+                    "Do not trust <unsafe> & text.",
+                    "[PR #34](https://github.com/our-ark/enoch/pull/34)",
+                ]
+            )
+        )
+
+        self.assertIn("<b>What happened</b>", rendered)
+        self.assertIn("<code>bin/enoch doctor</code>", rendered)
+        self.assertIn("<b>the result</b>", rendered)
+        self.assertIn("&lt;unsafe&gt; &amp; text.", rendered)
+        self.assertIn(
+            '<a href="https://github.com/our-ark/enoch/pull/34">PR #34</a>',
+            rendered,
+        )
+
+    def test_distinguishes_labels_commands_and_paths(self) -> None:
+        rendered = render_telegram_html(
+            "\n".join(
+                [
+                    "Task #4 final update",
+                    "Final status: failed",
+                    "Check command: python -m unittest discover -s tests -t .",
+                    "Path: /Users/iceberg/enoch/README.md:285",
+                    "- tests: failed",
+                    "Failure: validation_failed in __init__.py",
+                    "/help worktree - inspect worktree help",
+                ]
+            )
+        )
+
+        self.assertIn("<b>Task #4 final update</b>", rendered)
+        self.assertIn("<b>Final status:</b> failed", rendered)
+        self.assertIn(
+            "<b>Check command:</b> "
+            "<code>python -m unittest discover -s tests -t .</code>",
+            rendered,
+        )
+        self.assertIn(
+            "<b>Path:</b> <code>/Users/iceberg/enoch/README.md:285</code>",
+            rendered,
+        )
+        self.assertIn("- <b>tests:</b> failed", rendered)
+        self.assertIn(
+            "<b>Failure:</b> validation_failed in <code>__init__.py</code>",
+            rendered,
+        )
+        self.assertIn(
+            "<code>/help worktree</code> - inspect worktree help",
+            rendered,
+        )
+
+    def test_local_markdown_links_show_copyable_paths(self) -> None:
+        rendered = render_telegram_html(
+            "Changed [README.md](/Users/iceberg/My Project/README.md:285)."
+        )
+
+        self.assertEqual(
+            rendered,
+            "Changed <code>README.md</code> "
+            "(<code>/Users/iceberg/My Project/README.md:285</code>).",
+        )
+
+    def test_fenced_code_is_escaped_and_balanced(self) -> None:
+        rendered = render_telegram_html(
+            "Run this:\n\n```bash\npython -c '<unsafe> & data'\n```\nDone."
+        )
+
+        self.assertIn(
+            "<pre><code>python -c '&lt;unsafe&gt; &amp; data'</code></pre>",
+            rendered,
+        )
+        self.assertEqual(rendered.count("<pre><code>"), 1)
+        self.assertEqual(rendered.count("</code></pre>"), 1)
+
+    def test_long_code_blocks_split_into_valid_html_chunks(self) -> None:
+        chunks = telegram_message_chunks(
+            "```text\n" + ("x" * 5000) + "\n```",
+            4096,
+        )
+
+        self.assertEqual(len(chunks), 2)
+        self.assertTrue(all(len(chunk.plain) <= 4096 for chunk in chunks))
+        self.assertTrue(all(chunk.html.startswith("<pre><code>") for chunk in chunks))
+        self.assertTrue(all(chunk.html.endswith("</code></pre>") for chunk in chunks))
+        self.assertEqual(sum(chunk.plain.count("x") for chunk in chunks), 5000)
+
+    def test_chunking_prefers_logical_text_boundaries(self) -> None:
+        chunks = telegram_message_chunks("first paragraph\n\nsecond paragraph", 18)
+
+        self.assertEqual(
+            [chunk.plain for chunk in chunks],
+            ["first paragraph\n\n", "second paragraph"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libraries/telegram/tests/test_telegram.py
+++ b/libraries/telegram/tests/test_telegram.py
@@ -90,6 +90,89 @@ class TelegramLibraryTests(ProviderContractConformanceMixin, unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "at least 1"):
             chunks("hello", 0)
 
+    def test_send_renders_html_only_in_transport_payload(self) -> None:
+        client = TelegramClient(TelegramConfig(token="test"))
+        calls = []
+
+        def fake_call(method, payload):
+            calls.append((method, payload))
+            return {"ok": True, "result": {"message_id": 9}}
+
+        client._call = fake_call
+        original = "Run `bin/enoch doctor` and keep <output>."
+
+        message_id = client.send_message(42, original)
+
+        self.assertEqual(message_id, 9)
+        self.assertEqual(original, "Run `bin/enoch doctor` and keep <output>.")
+        self.assertEqual(calls[0][0], "sendMessage")
+        self.assertEqual(calls[0][1]["chat_id"], 42)
+        self.assertEqual(calls[0][1]["parse_mode"], "HTML")
+        self.assertEqual(
+            calls[0][1]["text"],
+            "Run <code>bin/enoch doctor</code> and keep &lt;output&gt;.",
+        )
+
+    def test_edit_uses_the_same_display_only_renderer(self) -> None:
+        client = TelegramClient(TelegramConfig(token="test"))
+        calls = []
+
+        def fake_call(method, payload):
+            calls.append((method, payload))
+            return {"ok": True}
+
+        client._call = fake_call
+        client.edit_message(42, 9, "Status: **completed**")
+
+        self.assertEqual(
+            calls,
+            [
+                (
+                    "editMessageText",
+                    {
+                        "chat_id": 42,
+                        "message_id": 9,
+                        "text": "<b>Status:</b> <b>completed</b>",
+                        "parse_mode": "HTML",
+                    },
+                )
+            ],
+        )
+
+    def test_format_rejection_falls_back_to_original_plain_text(self) -> None:
+        client = TelegramClient(TelegramConfig(token="test"))
+        calls = []
+
+        def fake_call(method, payload):
+            calls.append((method, payload))
+            if payload.get("parse_mode"):
+                raise TelegramError("Bad Request: can't parse entities")
+            return {"ok": True, "result": {"message_id": 11}}
+
+        client._call = fake_call
+
+        message_id = client.send_message(42, "Run `doctor`.")
+
+        self.assertEqual(message_id, 11)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1][1]["text"], "Run `doctor`.")
+        self.assertNotIn("parse_mode", calls[1][1])
+
+    def test_delivery_failure_is_not_retried_as_plain_text(self) -> None:
+        client = TelegramClient(TelegramConfig(token="test"))
+        calls = []
+
+        def fake_call(method, payload):
+            calls.append((method, payload))
+            raise TelegramError("Telegram API call sendMessage failed.")
+
+        client._call = fake_call
+
+        with self.assertRaisesRegex(TelegramError, "sendMessage failed"):
+            client.send_message(42, "**hello**")
+
+        self.assertEqual(len(calls), 1)
+
     @patch("our_ark_telegram.core.request.urlopen")
     def test_download_enforces_size_limit(self, urlopen: MagicMock) -> None:
         api_response = MagicMock()

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -5145,6 +5145,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0][0], "sendMessage")
         self.assertEqual(calls[0][1]["chat_id"], 42)
+        self.assertEqual(calls[0][1]["parse_mode"], "HTML")
 
     def test_client_sets_read_ack_as_message_reaction(self) -> None:
         config = TelegramConfig(token="token", poll_timeout=1)


### PR DESCRIPTION
## What changed

- Add a deterministic Telegram presentation layer that renders headings, labels, lists, emphasis, code, commands, paths, code fences, blockquotes, and safe web links as supported Telegram HTML.
- Apply formatting only inside the Telegram provider immediately before `sendMessage` and `editMessageText`; Enoch's original Codex responses, notification records, task results, memory, and logs remain unchanged.
- Replace fixed-width outbound slicing with logical paragraph/newline-aware chunks and independently balanced code blocks.
- Fall back to the original plain text only when Telegram specifically rejects entity formatting; transport/network failures are not retried, avoiding duplicate delivery.
- Escape all untrusted source HTML and allow clickable links only for HTTP(S). Local file references remain copyable monospace text.

## Why

Commands, paths, headings, and Markdown links were previously sent as undifferentiated plain text. This made task summaries and Doctor failures difficult to scan, while literal Markdown syntax appeared in Telegram.

## Impact

Telegram messages become easier to read without changing what Codex says or what Enoch stores. Other chat providers and inbound Telegram messages are unaffected.

## Validation

- 711 application tests passed in a clean isolated worktree
- All provider-library suites passed
- 223 Telegram integration tests passed
- 18 Telegram presentation/transport tests passed
- Python compile check passed with an isolated bytecode cache
- `git diff --check` passed