### PR TITLE
Remove backlog from evolution evidence

### DIFF
--- a/docs/evolve-skill.md
+++ b/docs/evolve-skill.md
@@ -52,13 +52,10 @@ theme, auto-evolve can drift into random optimization.
 
 ## Candidate Sources
 
-Self-evolution candidates can come from six sources.
-
-### backlog
-
-Enoch can inspect backlog items and select the most important candidate that also fits the current theme.
-
-Backlog items are human-visible deferred work, so they are strong candidates when they are relevant and actionable.
+Self-evolution candidates can come from five sources. Backlog items are ordinary
+deferred work and are deliberately not evolution evidence. A failure or user
+feedback encountered while executing backlog work may still provide evidence
+through the experience or feedback pathways.
 
 ### feedback
 
@@ -88,7 +85,7 @@ every success into an evolve candidate.
 
 Evolve-linked candidates and tasks add explicit provenance fields:
 
-- `evidence_source`: which of the six evolve sources supplied the evidence;
+- `evidence_source`: which of the five evolve sources supplied the evidence;
 - `signal_actor`: who produced the original signal;
 - `candidate_actor`: who turned that signal into a candidate;
 - `approval_actor`: who approved a particular execution;
@@ -133,7 +130,7 @@ Each candidate should be stored with enough context to explain why it exists and
 
 ```yaml
 id: evo_001
-source: backlog|feedback|experience|brainstorming|inheritance|learning
+source: feedback|experience|brainstorming|inheritance|learning
 evidence_source: feedback
 signal_actor: human|agent|system
 candidate_actor: human|agent|system
@@ -151,7 +148,7 @@ status: candidate|running|done|failed|cancelled|regressed|reverted|forward-fixed
 
 ## Selection
 
-The six source adapters discover raw candidates and preserve their provenance.
+The five source adapters discover raw candidates and preserve their provenance.
 They do not make the final recommendation. `/propose` deterministically
 pre-ranks and bounds the pool, then gives the reasoning engine the candidate
 fields, mission, theme, provenance, and privacy-cleaned completion evidence.
@@ -263,7 +260,7 @@ Candidate selection and control:
 
 `/feedback` shows the human feedback signals available to evolution. `/experience`
 shows candidates derived from Enoch's task history, recurring workflows, and
-successful skill work. `/propose` refreshes all six sources, pre-ranks new and
+successful skill work. `/propose` refreshes all five sources, pre-ranks new and
 failed candidates into a bounded pool, and asks the reasoning engine for a
 semantic recommendation without selecting or running it. Failed candidates
 remain available for `/evolve retry <id>`, which

--- a/src/enoch/app/reporting.py
+++ b/src/enoch/app/reporting.py
@@ -532,7 +532,7 @@ def _format_evolve_proposal(proposal: EvolveProposal) -> str:
     lines = [
         "Enoch proposes:",
         f"Theme: {report.state.theme or 'not set'}",
-        f"Ranked {len(proposal.candidates)} actionable candidate(s) from the six evolve sources.",
+        f"Ranked {len(proposal.candidates)} actionable candidate(s) from the five evolve sources.",
         "Deterministic ranking was used only for bounded input ordering and fallback.",
     ]
     if proposal.brainstorm_attempted:

--- a/src/enoch/evolution/core.py
+++ b/src/enoch/evolution/core.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Callable, Iterable
 from uuid import uuid4
 
-from enoch.backlog import BacklogItem, backlog_status
 from enoch.automatic_learning import LearningArtifact, learning_index_paths
 from enoch.evolution.sources.brainstorming import (
     BrainstormIdea,
@@ -67,6 +66,7 @@ ACTIONABLE_CANDIDATE_STATUSES = {"candidate", "failed"}
 VISIBLE_CANDIDATE_STATUSES = {"candidate", "running", "failed"}
 AUTO_BRAINSTORM_COOLDOWN_SECONDS = 24 * 60 * 60
 FAILED_RETRY_SCORE_BONUS = 30
+RETIRED_CANDIDATE_SOURCES = {"backlog"}
 BrainstormFallback = Callable[[str], Iterable[object]]
 
 
@@ -616,7 +616,6 @@ def collect_evolve_candidates(
     theme: str = "",
 ) -> tuple[EvolveCandidate, ...]:
     candidates: list[EvolveCandidate] = []
-    candidates.extend(_backlog_candidates(backlog_status(root).pending))
     candidates.extend(_feedback_candidates(extract_feedback_signals(root)))
     candidates.extend(_inheritance_candidates(load_parent_inbox_candidates(root)))
     candidates.extend(collect_experience_candidates(root))
@@ -645,21 +644,38 @@ def sync_evolve_candidates(root: Path | None = None, *, theme: str = "") -> tupl
     stored = {candidate.id: candidate for candidate in _load_all_evolve_candidates(root)}
     collected = collect_evolve_candidates(root, theme=theme)
     collected_ids = {candidate.id for candidate in collected}
-    merged: dict[str, EvolveCandidate] = {
-        candidate_id: candidate
-        for candidate_id, candidate in stored.items()
-        if not (
+    merged: dict[str, EvolveCandidate] = {}
+    retired: list[EvolveCandidate] = []
+    for candidate_id, candidate in stored.items():
+        if (
             candidate.source == "brainstorming"
             and candidate.status in VISIBLE_CANDIDATE_STATUSES
             and candidate_id not in collected_ids
-        )
-    }
+        ):
+            continue
+        if (
+            candidate.source in RETIRED_CANDIDATE_SOURCES
+            and candidate.status in ACTIONABLE_CANDIDATE_STATUSES
+        ):
+            candidate = EvolveCandidate(**{**candidate.__dict__, "status": "removed"})
+            retired.append(candidate)
+        merged[candidate_id] = candidate
     for candidate in collected:
         previous = stored.get(candidate.id)
         status = previous.status if previous is not None else candidate.status
         merged[candidate.id] = EvolveCandidate(**{**candidate.__dict__, "status": status})
     ranked = rank_evolve_candidates(merged.values(), theme=theme)
     _write_evolve_candidates(ranked, root)
+    for candidate in retired:
+        record_evolve_event(
+            "removed",
+            root,
+            event_actor="system",
+            trigger="candidate-source-retirement",
+            candidate=candidate,
+            reason="backlog-is-not-evolution-evidence",
+            proposal_id=latest_open_proposal_id(candidate.id, root),
+        )
     return tuple(candidate for candidate in ranked if candidate.status in VISIBLE_CANDIDATE_STATUSES)
 
 
@@ -1253,30 +1269,6 @@ def _provenance_actor(value: object, *, default: str) -> str:
     return actor if actor in {"human", "agent", "system"} else default
 
 
-def _backlog_candidates(items: Iterable[BacklogItem]) -> list[EvolveCandidate]:
-    priority_score = {"p0": 35, "p1": 25, "p2": 15}
-    candidates = []
-    for item in items:
-        candidates.append(
-            EvolveCandidate(
-                id=f"backlog-{item.id}",
-                source="backlog",
-                title=item.text,
-                rationale=f"Pending {item.priority} backlog item.",
-                proposed_change=item.text,
-                expected_benefit="Completes deferred human-visible work that may improve Enoch's body or workflow.",
-                risk="Backlog item may need clarification before implementation.",
-                test_plan="Run focused tests for the changed behavior and Enoch doctor if code changes.",
-                initiated_by="agent",
-                evidence_source="backlog",
-                signal_actor="human",
-                candidate_actor="agent",
-                score=priority_score.get(item.priority, 10),
-            )
-        )
-    return candidates
-
-
 def _inheritance_candidates(items: Iterable[LineageCandidate]) -> list[EvolveCandidate]:
     relevance_score = {"high": 32, "medium": 22, "low": 8}
     candidates = []
@@ -1609,8 +1601,6 @@ def _score_candidate(candidate: EvolveCandidate, *, theme: str) -> EvolveCandida
     theme_words = {word for word in clean_text(theme).lower().split() if len(word) >= 4}
     if theme_words and any(word in text for word in theme_words):
         score += 20
-    if candidate.source == "backlog":
-        score += 10
     if candidate.source == "inheritance":
         score += 8
     if candidate.source == "experience":

--- a/src/enoch/evolution/events.py
+++ b/src/enoch/evolution/events.py
@@ -40,13 +40,14 @@ EVOLVE_EVENT_TYPES = {
 }
 EVOLVE_EVENT_ACTORS = {"human", "agent", "system"}
 EVOLVE_SOURCES = {
-    "backlog",
     "feedback",
     "experience",
     "inheritance",
     "learning",
     "brainstorming",
 }
+LEGACY_EVOLVE_SOURCES = {"backlog"}
+RECOGNIZED_EVOLVE_SOURCES = EVOLVE_SOURCES | LEGACY_EVOLVE_SOURCES
 _CANDIDATE_EVENTS = {
     "proposed",
     "selected",
@@ -221,13 +222,14 @@ def record_evolve_event(
         )
     if normalized_event in _CANDIDATE_EVENTS and not candidate_id:
         raise ValueError(f"Evolve event {normalized_event} requires a candidate.")
-    if candidate_id and source not in EVOLVE_SOURCES:
+    if candidate_id and source not in RECOGNIZED_EVOLVE_SOURCES:
         raise ValueError(
-            f"Evolve source must be one of: {', '.join(sorted(EVOLVE_SOURCES))}."
+            f"Evolve source must be one of: {', '.join(sorted(RECOGNIZED_EVOLVE_SOURCES))}."
         )
-    if candidate_id and evidence_source not in EVOLVE_SOURCES:
+    if candidate_id and evidence_source not in RECOGNIZED_EVOLVE_SOURCES:
         raise ValueError(
-            f"Evolution evidence source must be one of: {', '.join(sorted(EVOLVE_SOURCES))}."
+            "Evolution evidence source must be one of: "
+            f"{', '.join(sorted(RECOGNIZED_EVOLVE_SOURCES))}."
         )
     if candidate_id and initiated_by not in {"human", "agent"}:
         raise ValueError("Candidate initiator must be human or agent.")
@@ -494,7 +496,7 @@ def _event_from_line(line: str) -> EvolveEvent | None:
     source = clean_text(str(raw.get("source") or "")).lower()
     initiated_by = clean_text(str(raw.get("candidate_initiated_by") or "")).lower()
     evidence_source = clean_text(str(raw.get("evidence_source") or source)).lower()
-    if evidence_source not in EVOLVE_SOURCES:
+    if evidence_source not in RECOGNIZED_EVOLVE_SOURCES:
         evidence_source = source
     signal_actor = _actor(raw.get("signal_actor"))
     candidate_actor = _actor(raw.get("candidate_actor"))
@@ -505,7 +507,7 @@ def _event_from_line(line: str) -> EvolveEvent | None:
     if event in _CANDIDATE_EVENTS and not candidate_id:
         return None
     if candidate_id and (
-        source not in EVOLVE_SOURCES or initiated_by not in {"human", "agent"}
+        source not in RECOGNIZED_EVOLVE_SOURCES or initiated_by not in {"human", "agent"}
     ):
         return None
     if candidate_id:

--- a/src/enoch/skills/evolve/SKILL.md
+++ b/src/enoch/skills/evolve/SKILL.md
@@ -16,9 +16,9 @@ The default mode is `co-evolve`.
 
 ## Candidate Sources
 
-Enoch collects exactly six semantic candidate sources:
+Enoch collects exactly five semantic candidate sources. Backlog entries are
+ordinary deferred work, not evolution evidence:
 
-- **backlog** from `.enoch/backlog.json`;
 - **feedback** extracted conservatively from local conversation logs, including corrections, preferences, complaints, and repeated requests;
 - **experience** from the durable task experience journal, failed tasks, recurring workflows, repeated successful user workflows, and successful skill-work artifacts;
 - **inheritance** from direct-parent changes in `.agent/lineage_inbox.json`;
@@ -33,7 +33,7 @@ unavailable or invalid.
 
 The theme is semantic curation context and deterministic pre-ranking pressure, not a seventh source. `/evolve brainstorm` requires a non-empty theme, asks the reasoning engine for a small JSON list, validates the result, and persists only structured candidates in `.enoch/artifacts/evolve_brainstorms.jsonl`.
 
-`/propose` refreshes all six sources, applies deterministic pre-ranking, and
+`/propose` refreshes all five sources, applies deterministic pre-ranking, and
 passes a bounded set of structured candidate fields and provenance to semantic
 curation. It also includes bounded, privacy-cleaned recent completion evidence
 from the structured task and evolution journals: task/candidate linkage,
@@ -138,7 +138,9 @@ and evolve-linked tasks add explicit provenance:
   candidate causality, evidence-task causality, and retry causality respectively.
 
 Cron, recovery, backlog promotion, approval, and evolve scheduling are triggers,
-not extra sources. Legacy `.enoch/experience.jsonl` records remain readable.
+not extra sources. Failures or feedback encountered during backlog execution can
+still enter through experience or feedback. Legacy `.enoch/experience.jsonl`
+records remain readable.
 Only actionable failures, started cancellations, repeated successful user
 workflows, recurring jobs, and skill-work artifacts become evolve candidates.
 

--- a/tests/test_enoch_e2e.py
+++ b/tests/test_enoch_e2e.py
@@ -14,10 +14,10 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from enoch.backlog import add_backlog_item
-from enoch.evolution.core import get_evolve_candidate
+from enoch.evolution.core import collect_evolve_candidates, get_evolve_candidate
 from enoch.identity import load_identity
 from enoch.immune import DoctorDiagnosis, ImmuneResult
+from enoch.logs import log_conversation_turn
 from enoch.tasks.events import load_task_events
 from enoch.tasks.queue import begin_next_task, task_queue_status
 from enoch.app.core import EnochApplication
@@ -80,7 +80,7 @@ class EnochEvolutionEndToEndTests(unittest.TestCase):
     def test_evolve_approve_publishes_ready_pr_from_latest_main_with_one_progress_message(
         self,
     ) -> None:
-        candidate_id = self._add_backlog_candidate("Improve evolve reliability")
+        candidate_id = self._add_feedback_candidate("Improve evolve reliability")
 
         reply = self._command(f"/evolve approve {candidate_id}")
         self.assertIn("queued task #1", reply)
@@ -94,7 +94,7 @@ class EnochEvolutionEndToEndTests(unittest.TestCase):
         self.assertNotIn("--draft", call)
         body = _argument_value(call, "--body")
         self.assertIn(f"- Candidate: `{candidate_id}`", body)
-        self.assertIn("- Evidence source: backlog", body)
+        self.assertIn("- Evidence source: feedback", body)
         self.assertIn("- Signal actor: human", body)
         self.assertIn("- Candidate actor: agent", body)
         self.assertIn("- Approval actor: human", body)
@@ -127,7 +127,7 @@ class EnochEvolutionEndToEndTests(unittest.TestCase):
         self.assertIn(f"- Candidate: `{candidate_id}`", prompt)
 
     def test_evolve_retry_keeps_failed_history_and_links_new_task(self) -> None:
-        candidate_id = self._add_backlog_candidate("Add a retry guardrail")
+        candidate_id = self._add_feedback_candidate("Add a retry guardrail")
         self._command(f"/evolve approve {candidate_id}")
         self.client.clear()
         self._set_codex_mode("error")
@@ -157,7 +157,7 @@ class EnochEvolutionEndToEndTests(unittest.TestCase):
         self.assertIn("- Retry of task: #1", body)
 
     def test_codex_auth_failure_pauses_and_resume_completes_same_task(self) -> None:
-        candidate_id = self._add_backlog_candidate("Handle unavailable Codex access")
+        candidate_id = self._add_feedback_candidate("Handle unavailable Codex access")
         self._command(f"/evolve approve {candidate_id}")
         self.client.clear()
         self._set_codex_mode("auth-fail")
@@ -190,7 +190,7 @@ class EnochEvolutionEndToEndTests(unittest.TestCase):
     def test_failed_evolve_task_creates_experience_candidate_with_causal_provenance(
         self,
     ) -> None:
-        parent_id = self._add_backlog_candidate("Prevent a recurring worker failure")
+        parent_id = self._add_feedback_candidate("Prevent a recurring worker failure")
         self._command(f"/evolve approve {parent_id}")
         self.client.clear()
         self._set_codex_mode("error")
@@ -336,9 +336,19 @@ class EnochEvolutionEndToEndTests(unittest.TestCase):
         )
         executable.chmod(0o755)
 
-    def _add_backlog_candidate(self, text: str) -> str:
-        item = add_backlog_item(CHAT_ID, text, self.instance, priority="p0")
-        candidate_id = f"backlog-{item.id}"
+    def _add_feedback_candidate(self, text: str) -> str:
+        message = f"I want Enoch to {text.lower()}."
+        log_conversation_turn(
+            chat_id=CHAT_ID,
+            message=message,
+            reply="Understood.",
+            root=self.instance,
+        )
+        candidate_id = next(
+            candidate.id
+            for candidate in collect_evolve_candidates(self.instance)
+            if candidate.source == "feedback" and message in candidate.title
+        )
         self.assertEqual(get_evolve_candidate(candidate_id, self.instance).status, "candidate")
         return candidate_id
 

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -57,7 +57,7 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertEqual(state.mode, "co-evolve")
         self.assertEqual(state.theme, "")
 
-    def test_collects_backlog_and_parent_inheritance_candidates(self) -> None:
+    def test_pending_backlog_is_not_evolution_evidence(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
             add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
@@ -66,9 +66,9 @@ class EnochEvolveTests(unittest.TestCase):
             candidates = collect_evolve_candidates(root)
             ranked = rank_evolve_candidates(candidates, theme="Telegram UX")
 
-        self.assertEqual({candidate.source for candidate in candidates}, {"backlog", "inheritance"})
-        self.assertEqual(ranked[0].source, "backlog")
-        self.assertIn("Telegram", ranked[0].title)
+        self.assertEqual({candidate.source for candidate in candidates}, {"inheritance"})
+        self.assertEqual(ranked[0].source, "inheritance")
+        self.assertNotIn("backlog-1", {candidate.id for candidate in candidates})
 
     def test_collects_operational_and_learning_candidates(self) -> None:
         with TemporaryDirectory() as temp:
@@ -131,7 +131,7 @@ class EnochEvolveTests(unittest.TestCase):
 
         self.assertNotIn("task-3", {candidate.id for candidate in candidates})
 
-    def test_collects_exactly_the_six_declared_evolution_sources(self) -> None:
+    def test_collects_exactly_the_five_declared_evolution_sources(self) -> None:
         brainstorm_response = json.dumps(
             [
                 {
@@ -169,12 +169,11 @@ class EnochEvolveTests(unittest.TestCase):
 
         self.assertEqual(
             {candidate.source for candidate in candidates},
-            {"backlog", "feedback", "experience", "inheritance", "learning", "brainstorming"},
+            {"feedback", "experience", "inheritance", "learning", "brainstorming"},
         )
         initiators = {candidate.source: candidate.initiated_by for candidate in candidates}
         self.assertEqual(set(initiators.values()), {"agent"})
         signals = {candidate.source: candidate.signal_actor for candidate in candidates}
-        self.assertEqual(signals["backlog"], "human")
         self.assertEqual(signals["feedback"], "human")
         self.assertEqual(signals["experience"], "system")
         self.assertEqual(signals["inheritance"], "agent")
@@ -265,16 +264,33 @@ class EnochEvolveTests(unittest.TestCase):
     def test_removed_candidate_status_is_persisted_across_reports(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "low value cleanup", root, priority="p2")
+            candidate = _feedback_candidate(root, "I want less low value cleanup.")
 
-            removed = remove_evolve_candidate("backlog-1", root)
+            removed = remove_evolve_candidate(candidate.id, root)
             visible = load_evolve_candidates(root)
             all_candidates = load_evolve_candidates(root, include_inactive=True)
 
         self.assertEqual(removed.status, "removed")
-        self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
+        self.assertNotIn(candidate.id, {item.id for item in visible})
         statuses = {candidate.id: candidate.status for candidate in all_candidates}
-        self.assertEqual(statuses["backlog-1"], "removed")
+        self.assertEqual(statuses[candidate.id], "removed")
+
+    def test_stored_actionable_backlog_candidate_is_retired(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_stored_candidate(root, candidate_id="backlog-7", source="backlog")
+
+            visible = sync_evolve_candidates(root)
+            all_candidates = load_evolve_candidates(root, include_inactive=True)
+            events = load_evolve_events(root, candidate_id="backlog-7")
+
+        self.assertNotIn("backlog-7", {candidate.id for candidate in visible})
+        statuses = {candidate.id: candidate.status for candidate in all_candidates}
+        self.assertEqual(statuses["backlog-7"], "removed")
+        self.assertEqual([event.event for event in events], ["removed"])
+        self.assertEqual(events[0].event_actor, "system")
+        self.assertEqual(events[0].trigger, "candidate-source-retirement")
+        self.assertEqual(events[0].reason, "backlog-is-not-evolution-evidence")
 
     def test_legacy_selected_and_rejected_statuses_are_migrated(self) -> None:
         with TemporaryDirectory() as temp:
@@ -332,47 +348,47 @@ class EnochEvolveTests(unittest.TestCase):
     def test_run_candidate_marks_it_running(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "ship evolve run", root, priority="p1")
+            candidate = _feedback_candidate(root, "I want a clearer evolve run.")
 
-            running = run_evolve_candidate("backlog-1", root)
+            running = run_evolve_candidate(candidate.id, root)
             visible = load_evolve_candidates(root)
 
         self.assertEqual(running.status, "running")
-        self.assertEqual(visible[0].id, "backlog-1")
+        self.assertEqual(visible[0].id, candidate.id)
         self.assertEqual(visible[0].status, "running")
 
     def test_proposal_skips_running_candidate(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "lower priority candidate", root, priority="p2")
-            add_backlog_item(2, "highest priority candidate", root, priority="p0")
-            run_evolve_candidate("backlog-2", root)
+            first = _feedback_candidate(root, "I want a clearer lower priority candidate.")
+            second = _feedback_candidate(root, "I want a clearer highest priority candidate.")
+            run_evolve_candidate(second.id, root)
 
             proposal = propose_evolve(root)
 
-        self.assertEqual([candidate.id for candidate in proposal.candidates], ["backlog-1"])
+        self.assertEqual([candidate.id for candidate in proposal.candidates], [first.id])
         assert proposal.top_candidate is not None
-        self.assertEqual(proposal.top_candidate.id, "backlog-1")
+        self.assertEqual(proposal.top_candidate.id, first.id)
         self.assertEqual(proposal.top_candidate.status, "candidate")
 
     def test_proposal_does_not_brainstorm_when_candidate_exists(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "existing work", root, priority="p1")
+            _feedback_candidate(root, "I want clearer existing work.")
             calls = []
 
             proposal = propose_evolve(root, brainstormer=lambda theme: calls.append(theme) or ())
 
         self.assertEqual(calls, [])
         self.assertFalse(proposal.brainstorm_attempted)
-        self.assertEqual(proposal.top_candidate.source, "backlog")
+        self.assertEqual(proposal.top_candidate.source, "feedback")
 
     def test_proposal_does_not_brainstorm_while_candidate_is_running(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "running evolve work", root, priority="p1")
+            candidate = _feedback_candidate(root, "I want clearer running evolve work.")
             set_evolve_theme("reliable evolution", root)
-            run_evolve_candidate("backlog-1", root, theme="reliable evolution")
+            run_evolve_candidate(candidate.id, root, theme="reliable evolution")
             calls = []
 
             proposal = propose_evolve(root, brainstormer=lambda theme: calls.append(theme) or ())
@@ -439,13 +455,13 @@ class EnochEvolveTests(unittest.TestCase):
     def test_completed_evolve_task_marks_candidate_done(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "ship evolve completion", root, priority="p1")
-            run_evolve_candidate("backlog-1", root)
+            candidate = _feedback_candidate(root, "I want clearer evolve completion.")
+            run_evolve_candidate(candidate.id, root)
             job = enqueue_task(
                 42,
-                "Evolve approved candidate backlog-1",
+                f"Evolve approved candidate {candidate.id}",
                 root,
-                context="\n".join(["Evolve candidate context:", "ID: backlog-1"]),
+                context="\n".join(["Evolve candidate context:", f"ID: {candidate.id}"]),
                 context_source="evolve-approve",
             )
             job = replace(
@@ -464,8 +480,8 @@ class EnochEvolveTests(unittest.TestCase):
 
         assert completed is not None
         self.assertEqual(completed.status, "done")
-        self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
-        self.assertEqual(all_candidates[0].id, "backlog-1")
+        self.assertNotIn(candidate.id, {item.id for item in visible})
+        self.assertEqual(all_candidates[0].id, candidate.id)
         self.assertEqual(all_candidates[0].status, "done")
         self.assertEqual([event.event for event in events], ["completed"])
         self.assertEqual(events[0].event_actor, "agent")
@@ -477,22 +493,22 @@ class EnochEvolveTests(unittest.TestCase):
     def test_failed_candidate_stays_retryable_while_cancelled_candidate_is_inactive(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "ship failing evolve", root, priority="p1")
-            add_backlog_item(2, "ship cancelled evolve", root, priority="p1")
-            run_evolve_candidate("backlog-1", root)
-            run_evolve_candidate("backlog-2", root)
+            failed_candidate = _feedback_candidate(root, "I want clearer failing evolve work.")
+            cancelled_candidate = _feedback_candidate(root, "I want clearer cancelled evolve work.")
+            run_evolve_candidate(failed_candidate.id, root)
+            run_evolve_candidate(cancelled_candidate.id, root)
             failed_job = enqueue_task(
                 42,
-                "Evolve approved candidate backlog-1",
+                f"Evolve approved candidate {failed_candidate.id}",
                 root,
-                context="\n".join(["Evolve candidate context:", "ID: backlog-1"]),
+                context="\n".join(["Evolve candidate context:", f"ID: {failed_candidate.id}"]),
                 context_source="evolve-approve",
             )
             cancelled_job = enqueue_task(
                 42,
-                "Evolve approved candidate backlog-2",
+                f"Evolve approved candidate {cancelled_candidate.id}",
                 root,
-                context="\n".join(["Evolve candidate context:", "ID: backlog-2"]),
+                context="\n".join(["Evolve candidate context:", f"ID: {cancelled_candidate.id}"]),
                 context_source="evolve-approve",
             )
 
@@ -509,27 +525,27 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertEqual(cancelled.status, "cancelled")
         self.assertEqual(
             [(candidate.id, candidate.status) for candidate in visible],
-            [("backlog-1", "failed")],
+            [(failed_candidate.id, "failed")],
         )
         statuses = {candidate.id: candidate.status for candidate in all_candidates}
-        self.assertEqual(statuses["backlog-1"], "failed")
-        self.assertEqual(statuses["backlog-2"], "cancelled")
+        self.assertEqual(statuses[failed_candidate.id], "failed")
+        self.assertEqual(statuses[cancelled_candidate.id], "cancelled")
         self.assertEqual(failed_events[0].event, "failed")
         self.assertEqual(cancelled_events[0].event, "cancelled")
 
     def test_failed_candidate_remains_proposable_and_can_retry(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(1, "ship retryable evolve work", root, priority="p1")
-            run_evolve_candidate("backlog-1", root)
+            candidate = _feedback_candidate(root, "I want clearer retryable evolve work.")
+            run_evolve_candidate(candidate.id, root)
             queued = enqueue_task(
                 42,
-                "Evolve approved candidate backlog-1",
+                f"Evolve approved candidate {candidate.id}",
                 root,
-                context="\n".join(["Evolve candidate context:", "ID: backlog-1"]),
+                context="\n".join(["Evolve candidate context:", f"ID: {candidate.id}"]),
                 context_source="evolve-approve",
-                source="backlog",
-                candidate_id="backlog-1",
+                source="feedback",
+                candidate_id=candidate.id,
             )
             running = begin_next_task(root)
             assert running is not None
@@ -540,13 +556,13 @@ class EnochEvolveTests(unittest.TestCase):
                 root,
                 brainstormer=lambda _theme: self.fail("failed candidate should prevent fallback brainstorming"),
             )
-            failed_task = latest_failed_evolve_task("backlog-1", root)
-            retried = retry_evolve_candidate("backlog-1", root)
+            failed_task = latest_failed_evolve_task(candidate.id, root)
+            retried = retry_evolve_candidate(candidate.id, root)
 
         assert failed is not None
         assert proposal.top_candidate is not None
         assert failed_task is not None
-        self.assertEqual(proposal.top_candidate.id, "backlog-1")
+        self.assertEqual(proposal.top_candidate.id, candidate.id)
         self.assertEqual(proposal.top_candidate.status, "failed")
         self.assertFalse(proposal.brainstorm_attempted)
         self.assertEqual(failed_task.id, queued.id)
@@ -641,6 +657,41 @@ def _write_lineage_candidate(root: Path, candidate: LineageCandidate) -> None:
     lineage.write_text("parent:\n  name: Seth\n  repo: our-ark/enoch\n", encoding="utf-8")
     inbox = root / ".agent" / "lineage_inbox.json"
     inbox.write_text(json.dumps({"schema_version": 1, "candidates": [candidate.__dict__]}), encoding="utf-8")
+
+
+def _feedback_candidate(root: Path, message: str):
+    log_conversation_turn(
+        chat_id=42,
+        message=message,
+        reply="Understood.",
+        root=root,
+    )
+    return next(
+        candidate
+        for candidate in collect_evolve_candidates(root)
+        if candidate.source == "feedback" and message in candidate.title
+    )
+
+
+def _write_stored_candidate(root: Path, *, candidate_id: str, source: str) -> None:
+    path = root / ".enoch" / "evolve_candidates.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "candidates": [
+                    {
+                        "id": candidate_id,
+                        "source": source,
+                        "title": "Legacy candidate",
+                        "status": "candidate",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def _lineage_candidate() -> LineageCandidate:

--- a/tests/test_enoch_evolve_curation.py
+++ b/tests/test_enoch_evolve_curation.py
@@ -58,7 +58,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
         self.assertEqual(candidates, report.candidates)
 
     def test_bounded_curation_retains_one_candidate_from_each_source(self) -> None:
-        candidates = tuple(_candidate("backlog", index, score=100 - index) for index in range(20))
+        candidates = tuple(_candidate("feedback", index, score=100 - index) for index in range(20))
         candidates += tuple(
             _candidate(source, index, score=1)
             for index, source in enumerate(_sources()[1:], start=20)
@@ -120,7 +120,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
         self.assertEqual(stored[0].status, "candidate")
 
     def test_duplicate_and_resolved_suggestions_are_auditable_but_do_not_remove(self) -> None:
-        first = _candidate("backlog", 1)
+        first = _candidate("feedback", 1)
         second = _candidate("experience", 2)
         with TemporaryDirectory() as temp:
             root = Path(temp)
@@ -272,7 +272,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
 
     def test_semantic_resolution_without_direct_link_and_supersession_are_allowed(self) -> None:
         resolved = _candidate("feedback", 1, title="Use LLM semantic candidate curation")
-        superseded = _candidate("backlog", 2, title="Add fixed-score candidate pruning")
+        superseded = _candidate("feedback", 2, title="Add fixed-score candidate pruning")
         completed_candidate = _candidate("brainstorming", 99)
         with TemporaryDirectory() as temp:
             root = Path(temp)
@@ -398,7 +398,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
         self.assertIn("completion-evidence-unavailable", proposal.curation.fallback_reason)
 
     def test_llm_recommendation_overrides_pre_rank_without_state_change(self) -> None:
-        first = _candidate("backlog", 1, score=100)
+        first = _candidate("feedback", 1, score=100)
         second = _candidate("learning", 2, score=1)
         with TemporaryDirectory() as temp:
             root = Path(temp)
@@ -418,7 +418,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
         self.assertEqual(queue.pending_count, 0)
 
     def test_valid_new_candidate_uses_brainstorming_agent_provenance(self) -> None:
-        existing = _candidate("backlog", 1)
+        existing = _candidate("feedback", 1)
         new = {
             "title": "Verify curation journal loading",
             "rationale": "Auditability needs a bounded loader check.",
@@ -447,7 +447,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
         self.assertEqual({item.status for item in candidates}, {"candidate"})
 
     def test_invalid_outputs_use_explicit_deterministic_fallback(self) -> None:
-        candidate = _candidate("backlog", 1)
+        candidate = _candidate("feedback", 1)
         cases = {
             "malformed": "not-json",
             "non-string": None,
@@ -510,7 +510,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
 
     def test_protected_raw_candidate_is_not_recommended_even_by_fallback(self) -> None:
         candidate = _candidate(
-            "backlog",
+            "feedback",
             1,
             title="Change the mission and deploy automatically",
         )
@@ -526,7 +526,7 @@ class EnochEvolveCurationTests(unittest.TestCase):
         self.assertIsNone(proposal.top_candidate)
 
     def test_timeout_and_empty_result_use_fallback(self) -> None:
-        candidate = _candidate("backlog", 1)
+        candidate = _candidate("feedback", 1)
         for label, curator in (
             ("timeout", lambda _prompt: (_ for _ in ()).throw(TimeoutError("timed out"))),
             ("empty", lambda _prompt: _response()),
@@ -627,11 +627,11 @@ class EnochEvolveCurationTests(unittest.TestCase):
 
 
 def _sources() -> tuple[str, ...]:
-    return ("backlog", "feedback", "experience", "inheritance", "learning", "brainstorming")
+    return ("feedback", "experience", "inheritance", "learning", "brainstorming")
 
 
 def _candidate(source: str, index: int, *, title: str = "", score: int = 10) -> EvolveCandidate:
-    signal_actor = "human" if source in {"backlog", "feedback", "learning"} else "agent"
+    signal_actor = "human" if source in {"feedback", "learning"} else "agent"
     if source == "experience":
         signal_actor = "system"
     return EvolveCandidate(

--- a/tests/test_enoch_evolve_lifecycle.py
+++ b/tests/test_enoch_evolve_lifecycle.py
@@ -9,8 +9,8 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from enoch.backlog import add_backlog_item
 from enoch.evolution.core import (
+    collect_evolve_candidates,
     complete_evolve_candidate,
     get_evolve_candidate,
     run_evolve_candidate,
@@ -24,6 +24,7 @@ from enoch.evolution.lifecycle import (
     stage_promoted_evolve_adoptions,
 )
 from enoch.providers import register_provider
+from enoch.logs import log_conversation_turn
 from our_ark_github.workflow import PullRequestMergeStatus
 from enoch.tasks.queue import (
     begin_next_task,
@@ -211,8 +212,13 @@ class EnochEvolveLifecycleTests(unittest.TestCase):
 
 
 def _completed_candidate_with_pr(root: Path) -> str:
-    item = add_backlog_item(42, "Improve governed evolution evidence", root, priority="p0")
-    candidate_id = f"backlog-{item.id}"
+    message = "I want improved governed evolution evidence."
+    log_conversation_turn(chat_id=42, message=message, reply="Understood.", root=root)
+    candidate_id = next(
+        candidate.id
+        for candidate in collect_evolve_candidates(root)
+        if candidate.source == "feedback" and message in candidate.title
+    )
     run_evolve_candidate(candidate_id, root)
     complete_evolve_candidate(candidate_id, root)
     candidate = get_evolve_candidate(candidate_id, root)

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -1692,10 +1692,10 @@ class EnochTelegramTests(unittest.TestCase):
     def test_task_retry_restores_linked_evolve_candidate(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "retry evolve work", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "retry evolve work")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
-            bot._evolve_approve("backlog-1")
+            bot._evolve_approve("feedback-1")
             original = begin_next_task(root)
             with patch.object(
                 bot,
@@ -1704,7 +1704,7 @@ class EnochTelegramTests(unittest.TestCase):
             ):
                 bot._run_task_job(original)
             self.assertEqual(
-                get_evolve_candidate("backlog-1", root).status,
+                get_evolve_candidate("feedback-1", root).status,
                 "failed",
             )
             client.sent.clear()
@@ -1714,11 +1714,11 @@ class EnochTelegramTests(unittest.TestCase):
                 _message_update(chat_id=42, text="/task retry 1")
             )
             status = task_queue_status(root)
-            candidate = get_evolve_candidate("backlog-1", root)
-            evolve_events = load_evolve_events(root, candidate_id="backlog-1")
+            candidate = get_evolve_candidate("feedback-1", root)
+            evolve_events = load_evolve_events(root, candidate_id="feedback-1")
 
         self.assertEqual(candidate.status, "running")
-        self.assertEqual(status.pending[0].candidate_id, "backlog-1")
+        self.assertEqual(status.pending[0].candidate_id, "feedback-1")
         self.assertEqual(status.pending[0].parent_task_id, 1)
         self.assertEqual(status.pending[0].approval_actor, "human")
         self.assertEqual(evolve_events[-1].event, "queued")
@@ -2014,11 +2014,11 @@ class EnochTelegramTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "ship evolve status updates", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "ship evolve status updates")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
             _handle_update(bot,
-                _message_update(chat_id=42, text="/evolve approve backlog-1")
+                _message_update(chat_id=42, text="/evolve approve feedback-1")
             )
             job = begin_next_task(root)
             assert job is not None
@@ -2034,7 +2034,7 @@ class EnochTelegramTests(unittest.TestCase):
             completed = task_queue_status(root).history[-1]
 
         self.assertEqual(len(client.sent), 3)
-        self.assertIn("Approved evolve candidate backlog-1", client.sent[0][1])
+        self.assertIn("Approved evolve candidate feedback-1", client.sent[0][1])
         self.assertIn("Task #1", client.sent[1][1])
         self.assertIn("Task #1 final update", client.sent[2][1])
         self.assertFalse(
@@ -2422,10 +2422,10 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("Backlog:", client.sent[1][1])
         self.assertIn("#1 [p0 pending] first", client.sent[1][1])
 
-    def test_evolve_reports_top_candidate_from_backlog(self) -> None:
+    def test_evolve_reports_top_feedback_candidate(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "improve Telegram work UX")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
@@ -2434,8 +2434,8 @@ class EnochTelegramTests(unittest.TestCase):
         reply = client.sent[0][1]
         self.assertIn("Evolve:", reply)
         self.assertIn("Mode: co-evolve", reply)
-        self.assertIn("- backlog: 1", reply)
-        self.assertIn("backlog-1 [candidate backlog] improve Telegram work UX", reply)
+        self.assertIn("- feedback: 1", reply)
+        self.assertIn("feedback-1 [candidate feedback] improve Telegram work UX", reply)
         self.assertIn("wait for human approval", reply)
 
     @patch(
@@ -2536,7 +2536,7 @@ class EnochTelegramTests(unittest.TestCase):
     def test_propose_ranks_all_sources_without_selecting_candidate(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "improve Telegram work UX")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
@@ -2547,16 +2547,16 @@ class EnochTelegramTests(unittest.TestCase):
 
         reply = client.sent[0][1]
         self.assertIn("Enoch proposes:", reply)
-        self.assertIn("Ranked 1 actionable candidate(s) from the six evolve sources.", reply)
+        self.assertIn("Ranked 1 actionable candidate(s) from the five evolve sources.", reply)
         self.assertIn("Deterministic fallback recommendation", reply)
-        self.assertIn("backlog-1 [candidate backlog] improve Telegram work UX", reply)
-        self.assertIn("Approve with /evolve approve backlog-1.", reply)
-        self.assertIn("Remove with /evolve remove backlog-1.", reply)
+        self.assertIn("feedback-1 [candidate feedback] improve Telegram work UX", reply)
+        self.assertIn("Approve with /evolve approve feedback-1.", reply)
+        self.assertIn("Remove with /evolve remove feedback-1.", reply)
         self.assertEqual(candidates[0].status, "candidate")
         self.assertEqual([event.event for event in events], ["checked", "proposed"])
         self.assertEqual([event.event_actor for event in events], ["human", "human"])
         self.assertEqual(events[-1].trigger, "/propose")
-        self.assertEqual(events[-1].candidate_id, "backlog-1")
+        self.assertEqual(events[-1].candidate_id, "feedback-1")
         self.assertTrue(events[-1].proposal_id.startswith("proposal-"))
         self.assertTrue(events[-1].curation_id.startswith("curation-"))
         self.assertEqual(events[-1].recommendation_kind, "deterministic-fallback")
@@ -2564,18 +2564,22 @@ class EnochTelegramTests(unittest.TestCase):
     def test_propose_displays_llm_recommendation_and_remove_suggestions_without_mutation(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "context-only background note", root, priority="p0")
-            add_backlog_item(42, "add bounded curation coverage", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "context-only background note")
+            _add_feedback_evolve_candidate(
+                root,
+                "add bounded curation coverage",
+                candidate_id="feedback-2",
+            )
             response = json.dumps(
                 {
-                    "recommended_candidate_id": "backlog-2",
+                    "recommended_candidate_id": "feedback-2",
                     "recommendation_reason": "This is the clearest bounded code change.",
                     "scope_guidance": "Limit the work to curation tests.",
                     "risk_guidance": "Avoid broad refactors.",
                     "test_plan_guidance": "Run focused tests and doctor.",
                     "remove_suggestions": [
                         {
-                            "candidate_id": "backlog-1",
+                            "candidate_id": "feedback-1",
                             "classification": "context-only",
                             "reason": "The note does not request an implementation change.",
                             "evidence_refs": ["task:17"],
@@ -2604,9 +2608,9 @@ class EnochTelegramTests(unittest.TestCase):
 
         reply = client.sent[0][1]
         self.assertIn("LLM recommended candidate:", reply)
-        self.assertIn("backlog-2 [candidate backlog]", reply)
+        self.assertIn("feedback-2 [candidate feedback]", reply)
         self.assertIn("LLM remove suggestions (no status changed):", reply)
-        self.assertIn("backlog-1 [context-only]", reply)
+        self.assertIn("feedback-1 [context-only]", reply)
         self.assertIn("Evidence: task:17", reply)
         self.assertEqual({candidate.status for candidate in candidates}, {"candidate"})
         self.assertEqual(queued.pending_count, 0)
@@ -2617,7 +2621,7 @@ class EnochTelegramTests(unittest.TestCase):
     def test_repeated_proposal_marks_previous_one_no_action(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "improve Telegram work UX")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
@@ -2645,7 +2649,7 @@ class EnochTelegramTests(unittest.TestCase):
     def test_removed_candidate_closes_latest_proposal(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "remove proposed cleanup", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "remove proposed cleanup")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
@@ -2654,10 +2658,10 @@ class EnochTelegramTests(unittest.TestCase):
                 _message_update(
                     update_id=2,
                     chat_id=42,
-                    text="/evolve remove backlog-1",
+                    text="/evolve remove feedback-1",
                 )
             )
-            events = load_evolve_events(root, candidate_id="backlog-1")
+            events = load_evolve_events(root, candidate_id="feedback-1")
 
         self.assertEqual([event.event for event in events], ["proposed", "removed"])
         self.assertEqual(events[0].proposal_id, events[1].proposal_id)
@@ -2665,7 +2669,7 @@ class EnochTelegramTests(unittest.TestCase):
     def test_human_remove_applies_recorded_curation_classification_and_refs(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "add bounded curation evidence", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "add bounded curation evidence")
             response = json.dumps(
                 {
                     "recommended_candidate_id": None,
@@ -2675,7 +2679,7 @@ class EnochTelegramTests(unittest.TestCase):
                     "test_plan_guidance": "",
                     "remove_suggestions": [
                         {
-                            "candidate_id": "backlog-1",
+                            "candidate_id": "feedback-1",
                             "classification": "already-resolved",
                             "reason": "Task 17 was merged into the authoritative body.",
                             "evidence_refs": ["task:17", "merge:e536d32"],
@@ -2704,10 +2708,10 @@ class EnochTelegramTests(unittest.TestCase):
                 _message_update(
                     update_id=2,
                     chat_id=42,
-                    text="/evolve remove backlog-1 already-resolved",
+                    text="/evolve remove feedback-1 already-resolved",
                 ),
             )
-            removed = load_evolve_events(root, candidate_id="backlog-1")[-1]
+            removed = load_evolve_events(root, candidate_id="feedback-1")[-1]
 
         self.assertEqual(removed.event, "removed")
         self.assertEqual(removed.event_actor, "human")
@@ -2760,23 +2764,27 @@ class EnochTelegramTests(unittest.TestCase):
     def test_evolve_can_list_and_remove_candidates(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "low value cleanup", root, priority="p2")
-            add_backlog_item(42, "important Telegram recovery", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "low value cleanup")
+            _add_feedback_evolve_candidate(
+                root,
+                "important Telegram recovery",
+                candidate_id="feedback-2",
+            )
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
             _handle_update(bot, _message_update(chat_id=42, text="/evolve list"))
-            _handle_update(bot, _message_update(update_id=2, chat_id=42, text="/evolve remove backlog-1"))
+            _handle_update(bot, _message_update(update_id=2, chat_id=42, text="/evolve remove feedback-1"))
             _handle_update(bot, _message_update(update_id=3, chat_id=42, text="/evolve list"))
             _handle_update(bot, _message_update(update_id=4, chat_id=42, text="/evolve list all"))
             events = load_evolve_events(root)
 
         self.assertIn("Evolve candidates:", client.sent[0][1])
-        self.assertIn("backlog-1 [candidate backlog] low value cleanup", client.sent[0][1])
+        self.assertIn("feedback-1 [candidate feedback] low value cleanup", client.sent[0][1])
         self.assertIn("Removed evolve candidate.", client.sent[1][1])
-        self.assertIn("backlog-1 [removed backlog] low value cleanup", client.sent[1][1])
-        self.assertNotIn("backlog-1", client.sent[2][1])
-        self.assertIn("backlog-1 [removed backlog] low value cleanup", client.sent[3][1])
+        self.assertIn("feedback-1 [removed feedback] low value cleanup", client.sent[1][1])
+        self.assertNotIn("feedback-1", client.sent[2][1])
+        self.assertIn("feedback-1 [removed feedback] low value cleanup", client.sent[3][1])
         self.assertEqual(events[-1].event, "removed")
         self.assertEqual(events[-1].event_actor, "human")
         self.assertEqual(events[-1].trigger, "/evolve remove")
@@ -2785,12 +2793,12 @@ class EnochTelegramTests(unittest.TestCase):
         for index, command in enumerate(("select", "run", "reject"), start=1):
             with self.subTest(command=command), TemporaryDirectory() as temp:
                 root = Path(temp)
-                add_backlog_item(42, "keep this candidate", root, priority="p1")
+                _add_feedback_evolve_candidate(root, "keep this candidate")
                 client = FakeTelegramClient(allowed_chat_id=42)
                 bot = EnochApplication(load_identity(), root, client)
 
                 _handle_update(bot,
-                    _message_update(update_id=index, chat_id=42, text=f"/evolve {command} backlog-1")
+                    _message_update(update_id=index, chat_id=42, text=f"/evolve {command} feedback-1")
                 )
                 candidates = evolve_report(root).candidates
                 queued = task_queue_status(root)
@@ -2802,33 +2810,33 @@ class EnochTelegramTests(unittest.TestCase):
     def test_evolve_approve_queues_candidate_as_task(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "ship evolve approval", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "ship evolve approval")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             queued = task_queue_status(root)
             events = load_evolve_events(root)
 
         self.assertEqual(queued.pending_count, 1)
-        self.assertIn("Approved evolve candidate backlog-1 and queued task #1.", client.sent[0][1])
-        self.assertIn("backlog-1 [running backlog] ship evolve approval", client.sent[0][1])
-        self.assertIn("Evolve candidate backlog-1", queued.pending[0].text)
+        self.assertIn("Approved evolve candidate feedback-1 and queued task #1.", client.sent[0][1])
+        self.assertIn("feedback-1 [running feedback] ship evolve approval", client.sent[0][1])
+        self.assertIn("Evolve candidate feedback-1", queued.pending[0].text)
         self.assertIn("open a ready-for-review PR", queued.pending[0].text)
         self.assertNotIn("Open a PR for human review", queued.pending[0].text)
         self.assertEqual(queued.pending[0].context_source, "evolve-approve")
-        self.assertEqual(queued.pending[0].source, "backlog")
+        self.assertEqual(queued.pending[0].source, "feedback")
         self.assertEqual(queued.pending[0].initiated_by, "human")
-        self.assertEqual(queued.pending[0].candidate_id, "backlog-1")
-        self.assertEqual(queued.pending[0].evidence_source, "backlog")
+        self.assertEqual(queued.pending[0].candidate_id, "feedback-1")
+        self.assertEqual(queued.pending[0].evidence_source, "feedback")
         self.assertEqual(queued.pending[0].signal_actor, "human")
         self.assertEqual(queued.pending[0].candidate_actor, "agent")
         self.assertEqual(queued.pending[0].approval_actor, "human")
         self.assertIn("Evolve candidate context:", queued.pending[0].context)
         worker_context = telegram._task_worker_context(queued.pending[0])
         self.assertIn("## Evolution provenance", worker_context)
-        self.assertIn("- Candidate: `backlog-1`", worker_context)
-        self.assertIn("- Evidence source: backlog", worker_context)
+        self.assertIn("- Candidate: `feedback-1`", worker_context)
+        self.assertIn("- Evidence source: feedback", worker_context)
         self.assertIn("- Signal actor: human", worker_context)
         self.assertIn("- Candidate actor: agent", worker_context)
         self.assertIn("- Approval actor: human", worker_context)
@@ -2915,12 +2923,12 @@ class EnochTelegramTests(unittest.TestCase):
     def test_evolve_cannot_approve_removed_candidate(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "remove this candidate", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "remove this candidate")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve remove backlog-1"))
-            _handle_update(bot, _message_update(update_id=2, chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve remove feedback-1"))
+            _handle_update(bot, _message_update(update_id=2, chat_id=42, text="/evolve approve feedback-1"))
             queued = task_queue_status(root)
 
         self.assertIn("cannot be approved from status removed", client.sent[1][1])
@@ -2929,13 +2937,13 @@ class EnochTelegramTests(unittest.TestCase):
     def test_queued_evolve_task_cancellation_is_journaled(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "cancel queued evolution", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "cancel queued evolution")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             _handle_update(bot, _message_update(update_id=2, chat_id=42, text="/task cancel 1"))
-            events = load_evolve_events(root, candidate_id="backlog-1")
+            events = load_evolve_events(root, candidate_id="feedback-1")
             candidate = load_evolve_candidates(root, include_inactive=True)[0]
 
         self.assertEqual([event.event for event in events], ["selected", "queued", "cancelled"])
@@ -2952,11 +2960,11 @@ class EnochTelegramTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "ship evolve completion", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "ship evolve completion")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             job = begin_next_task(root)
             assert job is not None
             with patch.object(bot, "_run_direct_work", return_value="Done with evolve work."):
@@ -2964,8 +2972,8 @@ class EnochTelegramTests(unittest.TestCase):
             visible = load_evolve_candidates(root)
             all_candidates = load_evolve_candidates(root, include_inactive=True)
 
-        self.assertNotIn("backlog-1", {candidate.id for candidate in visible})
-        self.assertEqual(all_candidates[0].id, "backlog-1")
+        self.assertNotIn("feedback-1", {candidate.id for candidate in visible})
+        self.assertEqual(all_candidates[0].id, "feedback-1")
         self.assertEqual(all_candidates[0].status, "done")
         self.assertIn("Final status: completed", client.sent[-1][1])
 
@@ -2978,7 +2986,7 @@ class EnochTelegramTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "ship tracked proposal", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "ship tracked proposal")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
@@ -2987,7 +2995,7 @@ class EnochTelegramTests(unittest.TestCase):
                 _message_update(
                     update_id=2,
                     chat_id=42,
-                    text="/evolve approve backlog-1",
+                    text="/evolve approve feedback-1",
                 )
             )
             job = begin_next_task(root)
@@ -2997,7 +3005,7 @@ class EnochTelegramTests(unittest.TestCase):
             _handle_update(bot,
                 _message_update(update_id=3, chat_id=42, text="/experience")
             )
-            events = load_evolve_events(root, candidate_id="backlog-1")
+            events = load_evolve_events(root, candidate_id="feedback-1")
 
         proposal_id = next(
             event.proposal_id for event in events if event.event == "proposed"
@@ -3024,11 +3032,11 @@ class EnochTelegramTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "ship failing evolve", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "ship failing evolve")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             job = begin_next_task(root)
             assert job is not None
             with patch.object(bot, "_run_direct_work", return_value="Enoch could not publish this edit as a pull request: GH007"):
@@ -3037,9 +3045,9 @@ class EnochTelegramTests(unittest.TestCase):
             all_candidates = load_evolve_candidates(root, include_inactive=True)
             report = evolve_report(root)
 
-        self.assertIn("backlog-1", {candidate.id for candidate in visible})
+        self.assertIn("feedback-1", {candidate.id for candidate in visible})
         statuses = {candidate.id: candidate.status for candidate in all_candidates}
-        self.assertEqual(statuses["backlog-1"], "failed")
+        self.assertEqual(statuses["feedback-1"], "failed")
         self.assertIn("experience", report.counts_by_source)
         self.assertIn("Final status: failed", client.sent[-1][1])
 
@@ -3052,11 +3060,11 @@ class EnochTelegramTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "ship retryable evolve work", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "ship retryable evolve work")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             failed_job = begin_next_task(root)
             assert failed_job is not None
             with patch.object(
@@ -3072,25 +3080,25 @@ class EnochTelegramTests(unittest.TestCase):
                 _message_update(
                     update_id=3,
                     chat_id=42,
-                    text="/evolve retry backlog-1",
+                    text="/evolve retry feedback-1",
                 )
             )
             queued = task_queue_status(root)
             candidates = load_evolve_candidates(root)
             task_events = load_task_events(root, task_id=2)
-            evolve_events = load_evolve_events(root, candidate_id="backlog-1")
+            evolve_events = load_evolve_events(root, candidate_id="feedback-1")
 
-        self.assertIn("backlog-1 [failed backlog]", proposal_reply)
-        self.assertIn("Retry with /evolve retry backlog-1.", proposal_reply)
-        self.assertNotIn("Approve with /evolve approve backlog-1.", proposal_reply)
+        self.assertIn("feedback-1 [failed feedback]", proposal_reply)
+        self.assertIn("Retry with /evolve retry feedback-1.", proposal_reply)
+        self.assertNotIn("Approve with /evolve approve feedback-1.", proposal_reply)
         self.assertEqual(queued.pending_count, 1)
         self.assertEqual(queued.pending[0].id, 2)
-        self.assertEqual(queued.pending[0].candidate_id, "backlog-1")
+        self.assertEqual(queued.pending[0].candidate_id, "feedback-1")
         self.assertEqual(queued.pending[0].parent_task_id, failed_job.id)
         self.assertEqual(queued.pending[0].context_source, "evolve-retry")
         worker_context = telegram._task_worker_context(queued.pending[0])
-        self.assertIn("- Candidate: `backlog-1`", worker_context)
-        self.assertIn("- Evidence source: backlog", worker_context)
+        self.assertIn("- Candidate: `feedback-1`", worker_context)
+        self.assertIn("- Evidence source: feedback", worker_context)
         self.assertIn("- Signal actor: human", worker_context)
         self.assertIn("- Candidate actor: agent", worker_context)
         self.assertIn("- Approval actor: human", worker_context)
@@ -3108,7 +3116,7 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertEqual(evolve_events[-1].approval_actor, "human")
         self.assertEqual(evolve_events[-1].reason, "retry-of-task-1")
         self.assertIn(
-            "Retrying evolve candidate backlog-1 as task #2, linked to failed task #1.",
+            "Retrying evolve candidate feedback-1 as task #2, linked to failed task #1.",
             client.sent[-1][1],
         )
 
@@ -3121,12 +3129,12 @@ class EnochTelegramTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "ship regressing evolve work", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "ship regressing evolve work")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
             _handle_update(bot,
-                _message_update(chat_id=42, text="/evolve approve backlog-1")
+                _message_update(chat_id=42, text="/evolve approve feedback-1")
             )
             job = begin_next_task(root)
             assert job is not None
@@ -3147,11 +3155,11 @@ class EnochTelegramTests(unittest.TestCase):
                         text="that evolve change regressed behavior; revert it",
                     )
                 )
-            events = load_evolve_events(root, candidate_id="backlog-1")
+            events = load_evolve_events(root, candidate_id="feedback-1")
             candidate = next(
                 item
                 for item in load_evolve_candidates(root, include_inactive=True)
-                if item.id == "backlog-1"
+                if item.id == "feedback-1"
             )
 
         self.assertEqual(
@@ -3345,7 +3353,7 @@ class EnochTelegramTests(unittest.TestCase):
     def test_due_evolve_schedule_reports_in_co_evolve_mode(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "improve Telegram work UX")
             set_evolve_schedule(
                 60,
                 root,
@@ -3360,8 +3368,8 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIsNone(job)
         self.assertIn("Scheduled evolve check", client.sent[0][1])
         self.assertIn("Enoch proposes:", client.sent[0][1])
-        self.assertIn("Ranked 1 actionable candidate(s) from the six evolve sources.", client.sent[0][1])
-        self.assertIn("backlog-1 [candidate backlog] improve Telegram work UX", client.sent[0][1])
+        self.assertIn("Ranked 1 actionable candidate(s) from the five evolve sources.", client.sent[0][1])
+        self.assertIn("feedback-1 [candidate feedback] improve Telegram work UX", client.sent[0][1])
         self.assertEqual([event.event for event in events], ["checked", "proposed", "skipped"])
         self.assertEqual(events[-1].reason, "awaiting-human-approval")
         self.assertEqual(events[-1].proposal_id, events[-2].proposal_id)
@@ -3369,7 +3377,7 @@ class EnochTelegramTests(unittest.TestCase):
     def test_due_evolve_schedule_auto_mode_still_requires_human_approval(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "improve Telegram work UX")
             set_evolve_mode(MODE_AUTO_EVOLVE, root)
             set_evolve_schedule(
                 60,
@@ -3413,10 +3421,10 @@ class EnochTelegramTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "retry only with human approval", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "retry only with human approval")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             failed_job = begin_next_task(root)
             assert failed_job is not None
             with patch.object(
@@ -3435,25 +3443,25 @@ class EnochTelegramTests(unittest.TestCase):
 
             retry_job = bot._run_due_evolve_schedule()
             queued = task_queue_status(root)
-            events = load_evolve_events(root, candidate_id="backlog-1")
+            events = load_evolve_events(root, candidate_id="feedback-1")
 
         self.assertIsNone(retry_job)
         self.assertEqual(queued.pending_count, 0)
-        self.assertIn("Retry with /evolve retry backlog-1.", client.sent[0][1])
+        self.assertIn("Retry with /evolve retry feedback-1.", client.sent[0][1])
         self.assertEqual(events[-1].event, "skipped")
         self.assertEqual(events[-1].reason, "retry-requires-human")
 
     def test_due_auto_evolve_schedule_does_not_requeue_running_candidate(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "improve Telegram work UX", root, priority="p0")
+            _add_feedback_evolve_candidate(root, "improve Telegram work UX")
             set_evolve_mode(MODE_AUTO_EVOLVE, root)
             set_evolve_schedule(60, root, now=datetime(2020, 1, 1, tzinfo=timezone.utc))
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
             first = bot._run_due_evolve_schedule()
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             set_evolve_schedule(60, root, now=datetime(2020, 1, 1, tzinfo=timezone.utc))
             second = bot._run_due_evolve_schedule()
             queued = task_queue_status(root)
@@ -3755,10 +3763,10 @@ class EnochTelegramTests(unittest.TestCase):
     def test_evolve_task_timeout_is_journaled_as_system_failure(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "time out evolution safely", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "time out evolution safely")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             job = begin_next_task(root)
             assert job is not None
 
@@ -3775,10 +3783,10 @@ class EnochTelegramTests(unittest.TestCase):
     def test_evolve_task_pause_and_resume_keep_candidate_running(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
-            add_backlog_item(42, "pause evolution safely", root, priority="p1")
+            _add_feedback_evolve_candidate(root, "pause evolution safely")
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
-            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve backlog-1"))
+            _handle_update(bot, _message_update(chat_id=42, text="/evolve approve feedback-1"))
             job = begin_next_task(root)
             assert job is not None
 
@@ -3801,7 +3809,7 @@ class EnochTelegramTests(unittest.TestCase):
             candidate = next(
                 item
                 for item in load_evolve_candidates(root, include_inactive=True)
-                if item.id == "backlog-1"
+                if item.id == "feedback-1"
             )
 
         self.assertEqual(
@@ -5389,6 +5397,40 @@ class EnochTelegramTests(unittest.TestCase):
 
         schedule_restart.assert_called_once_with(root)
         self.assertEqual(bot.offset, 11)
+
+
+def _add_feedback_evolve_candidate(
+    root: Path,
+    title: str,
+    *,
+    candidate_id: str = "feedback-1",
+) -> str:
+    path = root / ".enoch" / "evolve_candidates.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        raw = {"schema_version": 4, "candidates": []}
+    candidates = raw.setdefault("candidates", [])
+    candidates.append(
+        {
+            "id": candidate_id,
+            "source": "feedback",
+            "title": title,
+            "rationale": "Explicit human feedback identified a durable improvement.",
+            "proposed_change": title,
+            "expected_benefit": "Addresses the reported feedback.",
+            "risk": "The change could alter adjacent behavior.",
+            "test_plan": "Run focused tests and doctor.",
+            "evidence_source": "feedback",
+            "signal_actor": "human",
+            "candidate_actor": "agent",
+            "status": "candidate",
+            "score": 24,
+        }
+    )
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    return candidate_id
 
 
 class FakeTelegramClient:


### PR DESCRIPTION
## What changed

- stop collecting pending backlog items as evolution candidates
- retire stored actionable backlog-derived candidates with an auditable system event
- preserve legacy event compatibility so already-running backlog-derived evolution tasks can finish
- update evolution reporting, skill guidance, documentation, and tests from six active sources to five

## Why

Backlog entries are ordinary deferred work. Treating them as evolution evidence created a duplicate execution path and allowed stale backlog candidates to linger after the backlog work was otherwise handled.

## User impact

`/backlog` continues to work normally, including idle and manual promotion. Backlog items no longer appear in `/evolve` or `/propose`. Failures or explicit feedback encountered while executing backlog work can still enter evolution through the experience or feedback pathways.

## Validation

- `python -m unittest discover -s tests -t .` — 717 tests passed in a disposable venv with the repository's hash-locked build prerequisite
- `git diff --check`