### PR TITLE
Fix recurring Doctor build-backend failures

### DIFF
--- a/src/enoch/immune.py
+++ b/src/enoch/immune.py
@@ -19,13 +19,19 @@ from enoch.providers.contracts import (
 )
 from enoch.providers.registry import ProviderError, load_provider, provider_name
 from enoch.state import StateCorruptionError, load_json_object
+from enoch.validation_environment import (
+    VALIDATION_REQUIREMENTS,
+    ValidationEnvironmentError,
+    ensure_validation_environment,
+    existing_validation_environment,
+)
 
 
 DEFAULT_TEST_ARGS = ["-m", "unittest", "discover", "-s", "tests", "-t", "."]
 DEFAULT_TIMEOUT_SECONDS = 120
 MAX_OUTPUT_CHARS = 12000
 MIN_PYTHON_VERSION = (3, 11)
-TEST_BUILD_REQUIREMENTS = Path(".github/requirements/test-build.txt")
+TEST_BUILD_REQUIREMENTS = VALIDATION_REQUIREMENTS
 STATE_OBJECT_FIELDS: dict[str, dict[str, type]] = {
     "backlog.json": {"pending": list, "history": list},
     "codex_sessions.json": {"sessions": dict},
@@ -82,15 +88,23 @@ def run_immune_system(
     ]
     test_check: DoctorCheckResult
     if os.environ.get("ENOCH_TEST_COMMAND") is None:
-        build_backend = _build_backend_check(root_path, timeout)
+        validation_python, build_backend = _validation_python_and_backend_check(
+            root_path,
+            timeout,
+        )
         checks.append(build_backend)
         if build_backend.passed:
-            test_check = _run_check("tests", _test_command(), root_path, timeout)
+            test_check = _run_check(
+                "tests",
+                _test_command(validation_python),
+                root_path,
+                timeout,
+            )
         else:
             test_check = DoctorCheckResult(
                 name="tests",
                 passed=True,
-                command=shlex.join(_test_command()),
+                command=shlex.join(_test_command(validation_python)),
                 output="",
                 summary="not run until the build-backend prerequisite passes",
                 skipped=True,
@@ -118,11 +132,11 @@ def run_immune_system(
     )
 
 
-def _test_command() -> list[str]:
+def _test_command(python: str | None = None) -> list[str]:
     configured = os.environ.get("ENOCH_TEST_COMMAND")
     if configured is not None:
         return _split_configured_command(configured)
-    return [_python_executable(), *DEFAULT_TEST_ARGS]
+    return [python or _python_executable(), *DEFAULT_TEST_ARGS]
 
 
 def _split_configured_command(command: str) -> list[str]:
@@ -176,10 +190,76 @@ def _python_runtime_check(root: Path, timeout: float) -> DoctorCheckResult:
     )
 
 
-def _build_backend_check(root: Path, timeout: float) -> DoctorCheckResult:
+def _validation_python_and_backend_check(
+    root: Path,
+    timeout: float,
+) -> tuple[str, DoctorCheckResult]:
+    base_python = _python_executable()
+    try:
+        existing = existing_validation_environment(
+            root,
+            base_python=base_python,
+        )
+    except ValidationEnvironmentError:
+        existing = None
+    validation_python = str(existing.python) if existing else base_python
+    check = _build_backend_check(
+        root,
+        timeout,
+        python=validation_python,
+    )
+    if check.passed or not _managed_environment_can_repair(check):
+        return validation_python, check
+
+    try:
+        managed = ensure_validation_environment(
+            root,
+            base_python=base_python,
+        )
+    except ValidationEnvironmentError as error:
+        return validation_python, DoctorCheckResult(
+            name=check.name,
+            passed=False,
+            command="provision Enoch-managed validation environment",
+            output=_join_output(
+                "Enoch could not prepare its managed validation environment.",
+                str(error),
+                "Original build-backend check:",
+                check.output,
+            ),
+            category="environment readiness",
+            summary="managed validation environment unavailable",
+        )
+
+    validation_python = str(managed.python)
+    return validation_python, _build_backend_check(
+        root,
+        timeout,
+        python=validation_python,
+    )
+
+
+def _managed_environment_can_repair(check: DoctorCheckResult) -> bool:
+    return (
+        check.name == "build backend"
+        and check.category == "environment readiness"
+        and (
+            check.summary.startswith("missing ")
+            or "requires >=" in check.summary
+        )
+    )
+
+
+def _build_backend_check(
+    root: Path,
+    timeout: float,
+    *,
+    python: str | None = None,
+) -> DoctorCheckResult:
     backend, distribution, minimum_version = _project_build_backend(root)
+    executable = python or _python_executable()
     command = [
-        _python_executable(),
+        executable,
         "-c",
         (
             "import importlib, importlib.metadata; "
@@ -188,7 +268,10 @@ def _build_backend_check(root: Path, timeout: float) -> DoctorCheckResult:
         ),
     ]
     check = _run_check("build backend", command, root, timeout)
-    install_command = _test_prerequisite_install_command(root)
+    install_command = _test_prerequisite_install_command(
+        root,
+        python=executable,
+    )
     if not check.passed:
         return DoctorCheckResult(
             name=check.name,
@@ -285,15 +368,20 @@ def _distribution_version(output: str, distribution: str) -> str:
     return match.group(1) if match else ""
 
 
-def _test_prerequisite_install_command(root: Path) -> str:
+def _test_prerequisite_install_command(
+    root: Path,
+    *,
+    python: str | None = None,
+) -> str:
+    executable = python or _python_executable()
     requirements = root / TEST_BUILD_REQUIREMENTS
     if requirements.is_file():
         return (
-            f"{shlex.quote(_python_executable())} -m pip install "
+            f"{shlex.quote(executable)} -m pip install "
             "--disable-pip-version-check --require-hashes "
             f"-r {TEST_BUILD_REQUIREMENTS.as_posix()}"
         )
-    return f"{shlex.quote(_python_executable())} -m pip install setuptools"
+    return f"{shlex.quote(executable)} -m pip install setuptools"
 
 
 def _python_version(output: str) -> tuple[int, int] | None:

--- a/src/enoch/validation_environment.py
+++ b/src/enoch/validation_environment.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tomllib
+from uuid import uuid4
+
+from enoch.paths import repo_root
+from enoch.state import atomic_write, file_transaction
+
+
+VALIDATION_ENVIRONMENT_SCHEMA_VERSION = 1
+VALIDATION_REQUIREMENTS = Path(".github/requirements/test-build.txt")
+VALIDATION_ENVIRONMENTS_DIRECTORY = "validation"
+VALIDATION_ENVIRONMENT_HOME = "ENOCH_VALIDATION_ENVIRONMENT_HOME"
+PROVISION_TIMEOUT_SECONDS = 180
+VERIFY_TIMEOUT_SECONDS = 30
+
+
+class ValidationEnvironmentError(RuntimeError):
+    """Raised when Enoch cannot prepare its isolated test environment."""
+
+
+@dataclass(frozen=True)
+class ValidationEnvironment:
+    root: Path
+    python: Path
+    fingerprint: str
+    created: bool = False
+
+
+@dataclass(frozen=True)
+class _EnvironmentSpec:
+    root: Path
+    parent: Path
+    target: Path
+    fingerprint: str
+    base_python: str
+    backend: str
+    requirements_file: Path | None
+    requirements: tuple[str, ...]
+    requirements_digest: str
+
+
+def existing_validation_environment(
+    root: Path,
+    *,
+    base_python: str,
+) -> ValidationEnvironment | None:
+    spec = _environment_spec(
+        root,
+        base_python=base_python,
+    )
+    if not _environment_is_complete(spec):
+        return None
+    return _environment_result(spec, created=False)
+
+
+def ensure_validation_environment(
+    root: Path,
+    *,
+    base_python: str,
+) -> ValidationEnvironment:
+    """Create or repair the content-addressed environment used by Doctor tests."""
+
+    try:
+        spec = _environment_spec(
+            root,
+            base_python=base_python,
+        )
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        with file_transaction(spec.parent / ".provision"):
+            if _environment_is_complete(spec) and _backend_is_available(
+                _venv_python(spec.target),
+                spec.backend,
+                root=spec.root,
+            ):
+                return _environment_result(spec, created=False)
+
+            if spec.target.exists():
+                shutil.rmtree(spec.target)
+            temporary = spec.parent / f".{spec.fingerprint}.tmp-{uuid4().hex}"
+            try:
+                _create_environment(spec, temporary)
+                temporary.replace(spec.target)
+            except BaseException:
+                shutil.rmtree(temporary, ignore_errors=True)
+                raise
+        return _environment_result(spec, created=True)
+    except ValidationEnvironmentError:
+        raise
+    except OSError as error:
+        raise ValidationEnvironmentError(
+            f"Could not prepare Enoch's managed validation environment: {error}"
+        ) from error
+
+
+def _environment_spec(
+    root: Path,
+    *,
+    base_python: str,
+) -> _EnvironmentSpec:
+    root_path = repo_root(root)
+    requirements_file, requirements, requirements_digest = _build_requirements(
+        root_path
+    )
+    backend = _build_backend(root_path)
+    resolved_python = _resolved_executable(base_python)
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "schema": VALIDATION_ENVIRONMENT_SCHEMA_VERSION,
+                "python": resolved_python,
+                "backend": backend,
+                "requirements": requirements,
+                "requirements_digest": requirements_digest,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    parent = _environment_parent()
+    return _EnvironmentSpec(
+        root=root_path,
+        parent=parent,
+        target=parent / fingerprint,
+        fingerprint=fingerprint,
+        base_python=resolved_python,
+        backend=backend,
+        requirements_file=requirements_file,
+        requirements=requirements,
+        requirements_digest=requirements_digest,
+    )
+
+
+def _environment_parent() -> Path:
+    override = os.environ.get(VALIDATION_ENVIRONMENT_HOME, "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path.home() / ".enoch" / VALIDATION_ENVIRONMENTS_DIRECTORY
+
+
+def _build_requirements(
+    root: Path,
+) -> tuple[Path | None, tuple[str, ...], str]:
+    locked = root / VALIDATION_REQUIREMENTS
+    if locked.is_file():
+        try:
+            content = locked.read_bytes()
+        except OSError as error:
+            raise ValidationEnvironmentError(
+                f"Could not read locked validation requirements at {locked}: {error}"
+            ) from error
+        return (
+            locked,
+            (),
+            hashlib.sha256(content).hexdigest(),
+        )
+
+    requirements = _pyproject_build_requirements(root)
+    rendered = json.dumps(requirements, sort_keys=True).encode("utf-8")
+    return None, requirements, hashlib.sha256(rendered).hexdigest()
+
+
+def _pyproject_build_requirements(root: Path) -> tuple[str, ...]:
+    path = root / "pyproject.toml"
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ValidationEnvironmentError(
+            f"Could not read validation build requirements from {path}: {error}"
+        ) from error
+    build_system = data.get("build-system")
+    raw_requirements = (
+        build_system.get("requires")
+        if isinstance(build_system, dict)
+        else None
+    )
+    if not isinstance(raw_requirements, list):
+        raise ValidationEnvironmentError(
+            f"{path} does not define build-system.requires."
+        )
+    requirements = tuple(
+        str(requirement).strip()
+        for requirement in raw_requirements
+        if str(requirement).strip()
+    )
+    if not requirements:
+        raise ValidationEnvironmentError(
+            f"{path} has no usable build-system requirements."
+        )
+    return requirements
+
+
+def _build_backend(root: Path) -> str:
+    path = root / "pyproject.toml"
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ValidationEnvironmentError(
+            f"Could not read validation build backend from {path}: {error}"
+        ) from error
+    build_system = data.get("build-system")
+    backend = (
+        build_system.get("build-backend")
+        if isinstance(build_system, dict)
+        else None
+    )
+    rendered = str(backend or "").strip()
+    if not rendered:
+        raise ValidationEnvironmentError(
+            f"{path} does not define build-system.build-backend."
+        )
+    return rendered
+
+
+def _resolved_executable(executable: str) -> str:
+    configured = executable.strip()
+    if not configured:
+        raise ValidationEnvironmentError(
+            "The configured Python executable is empty."
+        )
+    candidate = Path(configured).expanduser()
+    if not candidate.is_absolute():
+        located = shutil.which(configured)
+        if located is None:
+            raise ValidationEnvironmentError(
+                f"Could not find configured Python executable {configured!r}."
+            )
+        candidate = Path(located)
+    try:
+        return str(candidate.resolve(strict=True))
+    except OSError as error:
+        raise ValidationEnvironmentError(
+            f"Could not resolve configured Python executable {candidate}: {error}"
+        ) from error
+
+
+def _create_environment(spec: _EnvironmentSpec, temporary: Path) -> None:
+    environment = _isolated_subprocess_environment()
+    creation = _run(
+        [spec.base_python, "-m", "venv", str(temporary)],
+        root=spec.root,
+        environment=environment,
+        timeout=PROVISION_TIMEOUT_SECONDS,
+    )
+    if creation.returncode != 0:
+        raise ValidationEnvironmentError(
+            "Could not create Enoch's managed validation environment: "
+            + _command_error(creation)
+        )
+
+    python = _venv_python(temporary)
+    cache = spec.parent / "wheel-cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    command = [
+        str(python),
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-input",
+        "--cache-dir",
+        str(cache),
+    ]
+    if spec.requirements_file is not None:
+        command.extend(
+            [
+                "--require-hashes",
+                "-r",
+                str(spec.requirements_file),
+            ]
+        )
+    else:
+        command.extend(spec.requirements)
+    installation = _run(
+        command,
+        root=spec.root,
+        environment=environment,
+        timeout=PROVISION_TIMEOUT_SECONDS,
+    )
+    if installation.returncode != 0:
+        raise ValidationEnvironmentError(
+            "Could not install Enoch's validation prerequisites: "
+            + _command_error(installation)
+        )
+    if not _backend_is_available(
+        python,
+        spec.backend,
+        root=spec.root,
+        environment=environment,
+    ):
+        raise ValidationEnvironmentError(
+            "The managed validation environment was created, but build backend "
+            f"{spec.backend} is still unavailable."
+        )
+    atomic_write(
+        temporary / ".complete.json",
+        json.dumps(
+            {
+                "schema": VALIDATION_ENVIRONMENT_SCHEMA_VERSION,
+                "fingerprint": spec.fingerprint,
+                "python": spec.base_python,
+                "backend": spec.backend,
+                "requirements_digest": spec.requirements_digest,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+
+
+def _environment_is_complete(spec: _EnvironmentSpec) -> bool:
+    marker = spec.target / ".complete.json"
+    python = _venv_python(spec.target)
+    if not marker.is_file() or not python.is_file():
+        return False
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("schema") == VALIDATION_ENVIRONMENT_SCHEMA_VERSION
+        and payload.get("fingerprint") == spec.fingerprint
+        and payload.get("requirements_digest") == spec.requirements_digest
+    )
+
+
+def _environment_result(
+    spec: _EnvironmentSpec,
+    *,
+    created: bool,
+) -> ValidationEnvironment:
+    return ValidationEnvironment(
+        root=spec.target,
+        python=_venv_python(spec.target),
+        fingerprint=spec.fingerprint,
+        created=created,
+    )
+
+
+def _venv_python(root: Path) -> Path:
+    if os.name == "nt":
+        return root / "Scripts" / "python.exe"
+    return root / "bin" / "python"
+
+
+def _backend_is_available(
+    python: Path,
+    backend: str,
+    *,
+    root: Path,
+    environment: dict[str, str] | None = None,
+) -> bool:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            f"import importlib; importlib.import_module({backend!r})",
+        ],
+        root=root,
+        environment=environment or _isolated_subprocess_environment(),
+        timeout=VERIFY_TIMEOUT_SECONDS,
+    )
+    return result.returncode == 0
+
+
+def _isolated_subprocess_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.pop("PYTHONHOME", None)
+    environment.pop("PYTHONPATH", None)
+    return environment
+
+
+def _run(
+    command: list[str],
+    *,
+    root: Path,
+    environment: dict[str, str],
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            cwd=root,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise ValidationEnvironmentError(str(error)) from error
+
+
+def _command_error(result: subprocess.CompletedProcess[str]) -> str:
+    return (
+        result.stderr.strip()
+        or result.stdout.strip()
+        or f"command exited with status {result.returncode}"
+    )

--- a/tests/test_enoch_immune.py
+++ b/tests/test_enoch_immune.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from pathlib import Path
 import subprocess
 import sys
@@ -18,10 +19,15 @@ from enoch.immune import (
     _forge_provider_check,
     _limit_output,
     _memory_storage_check,
+    _validation_python_and_backend_check,
     diagnose_output,
     run_immune_system,
 )
 from enoch.providers.registry import ProviderError
+from enoch.validation_environment import (
+    ValidationEnvironment,
+    ValidationEnvironmentError,
+)
 
 
 def _check(
@@ -416,6 +422,83 @@ FAILED (failures=1)
         self.assertFalse(check.passed)
         self.assertIn("requires >= 77", check.summary)
         self.assertIn("requires at least 77", check.output)
+
+    @patch("enoch.immune.ensure_validation_environment")
+    @patch("enoch.immune.existing_validation_environment", return_value=None)
+    @patch("enoch.immune._build_backend_check")
+    def test_missing_backend_is_repaired_with_managed_environment(
+        self,
+        build_backend_check: MagicMock,
+        _existing_environment: MagicMock,
+        ensure_environment: MagicMock,
+    ) -> None:
+        missing = _check(
+            "build backend",
+            passed=False,
+            category="environment readiness",
+        )
+        missing = replace(
+            missing,
+            summary="missing setuptools.build_meta",
+        )
+        passed = _check(
+            "build backend",
+            category="environment readiness",
+        )
+        ensure_environment.return_value = ValidationEnvironment(
+            root=Path("/managed"),
+            python=Path("/managed/bin/python"),
+            fingerprint="abc",
+            created=True,
+        )
+        build_backend_check.side_effect = [missing, passed]
+
+        python, check = _validation_python_and_backend_check(
+            ROOT,
+            120,
+        )
+
+        self.assertEqual(python, "/managed/bin/python")
+        self.assertTrue(check.passed)
+        ensure_environment.assert_called_once()
+        self.assertEqual(
+            build_backend_check.call_args_list[-1].kwargs["python"],
+            "/managed/bin/python",
+        )
+
+    @patch(
+        "enoch.immune.ensure_validation_environment",
+        side_effect=ValidationEnvironmentError("network unavailable"),
+    )
+    @patch("enoch.immune.existing_validation_environment", return_value=None)
+    @patch("enoch.immune._build_backend_check")
+    def test_managed_environment_failure_is_reported_as_doctor_failure(
+        self,
+        build_backend_check: MagicMock,
+        _existing_environment: MagicMock,
+        _ensure_environment: MagicMock,
+    ) -> None:
+        missing = _check(
+            "build backend",
+            passed=False,
+            category="environment readiness",
+        )
+        build_backend_check.return_value = replace(
+            missing,
+            summary="missing setuptools.build_meta",
+        )
+
+        _python, check = _validation_python_and_backend_check(
+            ROOT,
+            120,
+        )
+
+        self.assertFalse(check.passed)
+        self.assertEqual(
+            check.summary,
+            "managed validation environment unavailable",
+        )
+        self.assertIn("network unavailable", check.output)
 
     def test_environment_failure_outranks_resulting_test_failure(self) -> None:
         output = """

--- a/tests/test_enoch_validation_environment.py
+++ b/tests/test_enoch_validation_environment.py
@@ -1,0 +1,222 @@
+from pathlib import Path
+import os
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from enoch.validation_environment import (
+    VALIDATION_ENVIRONMENT_HOME,
+    ValidationEnvironmentError,
+    ensure_validation_environment,
+    existing_validation_environment,
+)
+
+
+class EnochValidationEnvironmentTests(unittest.TestCase):
+    def test_provisions_locked_environment_once_and_reuses_it(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _write_project(root)
+            environment_home = root / "managed"
+            commands: list[list[str]] = []
+
+            def run(command, **_kwargs):
+                commands.append(command)
+                if command[1:3] == ["-m", "venv"]:
+                    _write_fake_venv_python(Path(command[3]))
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with patch.dict(
+                os.environ,
+                {VALIDATION_ENVIRONMENT_HOME: str(environment_home)},
+            ), patch(
+                "enoch.validation_environment.subprocess.run",
+                side_effect=run,
+            ):
+                first = ensure_validation_environment(
+                    root,
+                    base_python=sys.executable,
+                )
+                second = ensure_validation_environment(
+                    root,
+                    base_python=sys.executable,
+                )
+                discovered = existing_validation_environment(
+                    root,
+                    base_python=sys.executable,
+                )
+                marker_exists = (first.root / ".complete.json").is_file()
+
+        self.assertTrue(first.created)
+        self.assertFalse(second.created)
+        self.assertEqual(first.root, second.root)
+        self.assertEqual(discovered, second)
+        self.assertTrue(marker_exists)
+        install_commands = [
+            command
+            for command in commands
+            if len(command) > 3 and command[1:4] == ["-m", "pip", "install"]
+        ]
+        self.assertEqual(len(install_commands), 1)
+        self.assertIn("--require-hashes", install_commands[0])
+        requirements_argument = Path(
+            install_commands[0][install_commands[0].index("-r") + 1]
+        )
+        self.assertEqual(
+            requirements_argument.resolve(),
+            (root / ".github" / "requirements" / "test-build.txt").resolve(),
+        )
+
+    def test_lock_change_creates_a_new_content_addressed_environment(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            locked = _write_project(root)
+            environment_home = root / "managed"
+
+            def run(command, **_kwargs):
+                if command[1:3] == ["-m", "venv"]:
+                    _write_fake_venv_python(Path(command[3]))
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with patch.dict(
+                os.environ,
+                {VALIDATION_ENVIRONMENT_HOME: str(environment_home)},
+            ), patch(
+                "enoch.validation_environment.subprocess.run",
+                side_effect=run,
+            ):
+                first = ensure_validation_environment(
+                    root,
+                    base_python=sys.executable,
+                )
+                locked.write_text(
+                    "setuptools==84.0.0 --hash=sha256:changed\n",
+                    encoding="utf-8",
+                )
+                second = ensure_validation_environment(
+                    root,
+                    base_python=sys.executable,
+                )
+                first_exists = first.root.is_dir()
+                second_exists = second.root.is_dir()
+
+        self.assertNotEqual(first.fingerprint, second.fingerprint)
+        self.assertNotEqual(first.root, second.root)
+        self.assertTrue(first_exists)
+        self.assertTrue(second_exists)
+
+    def test_failed_install_does_not_publish_partial_environment(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _write_project(root)
+            environment_home = root / "managed"
+
+            def run(command, **_kwargs):
+                if command[1:3] == ["-m", "venv"]:
+                    _write_fake_venv_python(Path(command[3]))
+                    return subprocess.CompletedProcess(command, 0, "", "")
+                if len(command) > 3 and command[1:4] == ["-m", "pip", "install"]:
+                    return subprocess.CompletedProcess(
+                        command,
+                        1,
+                        "",
+                        "download failed",
+                    )
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with patch.dict(
+                os.environ,
+                {VALIDATION_ENVIRONMENT_HOME: str(environment_home)},
+            ), patch(
+                "enoch.validation_environment.subprocess.run",
+                side_effect=run,
+            ):
+                with self.assertRaisesRegex(
+                    ValidationEnvironmentError,
+                    "download failed",
+                ):
+                    ensure_validation_environment(
+                        root,
+                        base_python=sys.executable,
+                    )
+
+            partials = list(environment_home.glob(".*.tmp-*"))
+            completed = list(environment_home.glob("*/.complete.json"))
+
+        self.assertEqual(partials, [])
+        self.assertEqual(completed, [])
+
+    def test_falls_back_to_pyproject_requirements_without_repository_lock(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _write_project(root, locked=False)
+            environment_home = root / "managed"
+            commands: list[list[str]] = []
+
+            def run(command, **_kwargs):
+                commands.append(command)
+                if command[1:3] == ["-m", "venv"]:
+                    _write_fake_venv_python(Path(command[3]))
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with patch.dict(
+                os.environ,
+                {VALIDATION_ENVIRONMENT_HOME: str(environment_home)},
+            ), patch(
+                "enoch.validation_environment.subprocess.run",
+                side_effect=run,
+            ):
+                ensure_validation_environment(
+                    root,
+                    base_python=sys.executable,
+                )
+
+        install = next(
+            command
+            for command in commands
+            if len(command) > 3 and command[1:4] == ["-m", "pip", "install"]
+        )
+        self.assertNotIn("--require-hashes", install)
+        self.assertIn("setuptools>=77", install)
+
+
+def _write_project(root: Path, *, locked: bool = True) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[build-system]",
+                'requires = ["setuptools>=77"]',
+                'build-backend = "setuptools.build_meta"',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    path = root / ".github" / "requirements" / "test-build.txt"
+    if locked:
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "setuptools==83.0.0 --hash=sha256:locked\n",
+            encoding="utf-8",
+        )
+    return path
+
+
+def _write_fake_venv_python(root: Path) -> None:
+    directory = root / ("Scripts" if os.name == "nt" else "bin")
+    directory.mkdir(parents=True)
+    executable = directory / ("python.exe" if os.name == "nt" else "python")
+    executable.write_text("", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable, content-addressed validation environment under ~/.enoch
- provision hash-locked build prerequisites without modifying Homebrew Python
- make Doctor retry build-backend checks and run tests with the managed interpreter
- atomically publish complete environments and remove failed partial installs

## Validation
- bin/enoch doctor
- 731 tests passed
- Codex and GitHub operational checks passed
- Homebrew Python remained without setuptools while the managed environment supplied setuptools 83.0.0