### PR TITLE
add the word test3 to end of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,3 +347,5 @@ guidelines.
 ## License
 
 Enoch is licensed under the [Apache License 2.0](LICENSE).
+
+test3


### PR DESCRIPTION
## Summary
- Prepared Enoch evolution from `enoch/main-task-11-0aafa07b-add-the-word-test3-to-end-of-rea`.
- Latest commit: add the word test3 to end of readme

## Validation
- Run `bin/enoch` and `doctor` locally as needed before review.

## Human Review
- PR created for review.