### PR TITLE
Run inheritance assessment in background

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ and validation boundary.
 | `enoch.workflows` | Versioned queue lifecycle contract and fenced local engine |
 | `enoch.conformance` | Reusable provider, runtime, workflow, and profile contract tests |
 | `enoch.memory` | Durable memory paths, prompts, and storage |
-| `enoch.lineage` | Ancestor discovery, durable Codex assessments, explicit task linkage, and verified adoption |
+| `enoch.lineage` | Ancestor discovery, durable background Codex assessments, explicit task linkage, and verified adoption |
 | `enoch.skills` | Skill catalog code and packaged skill assets |
 
 Small, cohesive capabilities such as backlog and cron remain single top-level

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -171,16 +171,35 @@ from enoch.learn import (
 )
 from enoch.lineage.core import (
     ASSESSMENT_ASSESSED,
+    ASSESSMENT_FAILED,
     find_parent_inbox_candidate,
+    format_inheritance_scan_queued,
+    format_lineage_assessment_complete,
+    format_parent_inherit_report,
     LineageError,
     STATUS_ADOPTED,
     STATUS_LINKED,
     lineage_adaptation_request,
     lineage_candidate_context,
     link_inbox_candidate,
+    load_inbox_candidates,
+    load_lineage_inbox_report,
+    refresh_lineage_inbox,
     resolve_lineage,
 )
-from enoch.lineage.assessment import refresh_and_assess_lineage_inbox
+from enoch.lineage.assessment import (
+    LineageAssessmentProgress,
+    assess_lineage_inbox,
+    lineage_assessment_candidates,
+)
+from enoch.lineage.assessment_queue import (
+    LineageAssessmentJob,
+    claim_lineage_assessment,
+    complete_lineage_assessment,
+    enqueue_lineage_assessment,
+    fail_lineage_assessment,
+    load_lineage_assessment_queue,
+)
 from enoch.lineage.lifecycle import (
     lineage_context_source,
     reconcile_lineage_adoptions,
@@ -495,6 +514,8 @@ class EnochApplication:
         self._pending_session_syncs: list[tuple[int, str]] = []
         self._task_worker: threading.Thread | None = None
         self._direct_workers: dict[int, threading.Thread] = {}
+        self._lineage_worker: threading.Thread | None = None
+        self._lineage_worker_lock = threading.Lock()
         self._task_cancellations: dict[int, threading.Event] = {}
         self._stopping = False
         self._resident_branch = instance_branch(root)
@@ -597,6 +618,7 @@ class EnochApplication:
 
     def run_once(self) -> None:
         require_current_daemon_epoch(self.daemon_epoch, self.root)
+        self._maybe_start_lineage_worker()
         self._run_profile_hook("before_run")
         try:
             recovered = _recover_running_task_from_direct_action_log(
@@ -616,6 +638,7 @@ class EnochApplication:
             self._run_due_evidence_scans()
             self._run_due_evolve_schedule()
             self._maybe_start_task_worker()
+            self._maybe_start_lineage_worker()
         finally:
             self._run_profile_hook("after_run")
 
@@ -750,6 +773,8 @@ class EnochApplication:
         if self._restart_after_reply:
             self._restart_after_reply = False
             _schedule_daemon_restart(self.root)
+            return
+        self._maybe_start_lineage_worker()
 
     def _remember_update_offset(self, offset: Cursor | None) -> None:
         if offset is None:
@@ -1601,6 +1626,8 @@ class EnochApplication:
         workers = [*self._direct_workers.values()]
         if self._task_worker is not None:
             workers.append(self._task_worker)
+        if self._lineage_worker is not None:
+            workers.append(self._lineage_worker)
         deadline = time.monotonic() + max(0.0, timeout_seconds)
         for worker in workers:
             if worker is current or not worker.is_alive():
@@ -3672,32 +3699,200 @@ class EnochApplication:
         )
 
     def _inherit(self, chat_id: int, text: str) -> str:
-        self._reconcile_lineage_adoptions()
         parts = text.split(maxsplit=2)
         subcommand = parts[1].lower() if len(parts) >= 2 else ""
         argument = parts[2].strip() if len(parts) >= 3 else ""
-        if subcommand and subcommand not in {"inspect", "ignore"}:
+        if subcommand != "inbox":
+            self._reconcile_lineage_adoptions()
+        if not subcommand:
+            return self._scan_and_queue_lineage_assessment(chat_id)
+        if subcommand not in {"inbox", "inspect", "ignore"}:
             return self._adopt_lineage_candidate(chat_id, subcommand)
         reply = inherit_command(
             text,
             self.root,
             command_name="inherit",
-            refresh_lineage_fn=lambda root, scope: refresh_and_assess_lineage_inbox(
-                root,
-                scope=scope,
-                generator=lambda prompt: self._respond_isolated_evidence_turn(
-                    chat_id,
-                    prompt,
-                    phase="lineage-assessment",
-                ),
-                mission=self.identity.mission,
-            ),
         )
         if subcommand == "inspect":
             candidate = find_parent_inbox_candidate(argument, self.root)
             if candidate is not None:
                 self._queue_session_sync(chat_id, lineage_candidate_context(candidate))
         return reply
+
+    def _scan_and_queue_lineage_assessment(self, chat_id: int) -> str:
+        try:
+            active = load_lineage_assessment_queue(self.root).current
+            if active is not None:
+                return "\n".join(
+                    [
+                        (
+                            "Inheritance assessment is already "
+                            f"{active.status} for {active.total_count} change(s)."
+                        ),
+                        "No additional scan was started.",
+                        "Use /inherit inbox to view the stored inbox while it runs.",
+                    ]
+                )
+            report = refresh_lineage_inbox(self.root, scope="parent")
+            candidates = lineage_assessment_candidates(report, self.root)
+            if not candidates:
+                return format_parent_inherit_report(report)
+            job, created = enqueue_lineage_assessment(
+                chat_id,
+                tuple(candidate.id for candidate in candidates),
+                self.root,
+                new_count=report.new_count,
+            )
+        except (LineageError, OSError, RuntimeError, ValueError) as error:
+            return f"Enoch could not scan the inheritance inbox: {error}"
+        if not created:
+            return (
+                f"Inheritance assessment is already {job.status}. "
+                "Use /inherit inbox to view the stored inbox."
+            )
+        return format_inheritance_scan_queued(report, job.total_count)
+
+    def _maybe_start_lineage_worker(self) -> None:
+        if self._stopping:
+            return
+        with self._lineage_worker_lock:
+            if self._lineage_worker is not None and self._lineage_worker.is_alive():
+                return
+            job = claim_lineage_assessment(
+                self.daemon_epoch.token,
+                self.root,
+            )
+            if job is None:
+                return
+            worker = threading.Thread(
+                target=self._run_lineage_assessment_worker,
+                args=(job,),
+                name=f"enoch-lineage-assessment-{job.id[-8:]}",
+                daemon=True,
+            )
+            self._lineage_worker = worker
+            worker.start()
+
+    def _run_lineage_assessment_worker(
+        self,
+        job: LineageAssessmentJob,
+    ) -> None:
+        try:
+            report = load_lineage_inbox_report(self.root, scope="parent")
+            assess_lineage_inbox(
+                report,
+                self.root,
+                generator=lambda prompt: self._respond_isolated_evidence_turn(
+                    job.conversation_id,
+                    prompt,
+                    phase="lineage-assessment",
+                ),
+                mission=self.identity.mission,
+                candidate_ids=job.candidate_ids,
+                progress_callback=lambda progress: self._lineage_assessment_progress(
+                    job,
+                    progress,
+                ),
+                guard=lambda: require_current_daemon_epoch(
+                    self.daemon_epoch,
+                    self.root,
+                ),
+            )
+            require_current_daemon_epoch(self.daemon_epoch, self.root)
+            assessed_count, failed_count = self._lineage_assessment_counts(job)
+            final_report = load_lineage_inbox_report(self.root, scope="parent")
+            self._safe_send_message(
+                job.conversation_id,
+                format_lineage_assessment_complete(
+                    final_report.candidates,
+                    assessed_count=assessed_count,
+                    failed_count=failed_count,
+                ),
+                notification_key=f"lineage-assessment:{job.id}:final",
+            )
+            complete_lineage_assessment(
+                job.id,
+                self.root,
+                owner_epoch=job.owner_epoch,
+                assessed_count=assessed_count,
+                failed_count=failed_count,
+            )
+        except StaleDaemonEpoch:
+            return
+        except Exception as error:
+            failed = fail_lineage_assessment(
+                job.id,
+                str(error),
+                self.root,
+                owner_epoch=job.owner_epoch,
+            )
+            if failed is not None:
+                self._safe_send_message(
+                    job.conversation_id,
+                    "\n".join(
+                        [
+                            "Inheritance assessment stopped.",
+                            f"Failure: {' '.join(str(error).split())[:1000]}",
+                            "The inbox was preserved. Run /inherit to retry.",
+                        ]
+                    ),
+                    notification_key=f"lineage-assessment:{job.id}:failed",
+                )
+        finally:
+            with self._lineage_worker_lock:
+                if self._lineage_worker is threading.current_thread():
+                    self._lineage_worker = None
+
+    def _lineage_assessment_progress(
+        self,
+        job: LineageAssessmentJob,
+        progress: LineageAssessmentProgress,
+    ) -> None:
+        if progress.processed_count >= progress.total_count:
+            return
+        stride = max(1, (progress.batch_count + 3) // 4)
+        if progress.batch_index != 1 and progress.batch_index % stride:
+            return
+        require_current_daemon_epoch(self.daemon_epoch, self.root)
+        assessed_count, failed_count = self._lineage_assessment_counts(job)
+        processed = min(job.total_count, assessed_count + failed_count)
+        self._safe_send_message(
+            job.conversation_id,
+            "\n".join(
+                [
+                    "Inheritance assessment progress",
+                    f"Processed: {processed}/{job.total_count}",
+                    f"Assessed: {assessed_count}",
+                    f"Failed: {failed_count}",
+                    "Enoch remains available for other messages.",
+                ]
+            ),
+            notification_key=(
+                f"lineage-assessment:{job.id}:progress:{processed}"
+            ),
+        )
+
+    def _lineage_assessment_counts(
+        self,
+        job: LineageAssessmentJob,
+    ) -> tuple[int, int]:
+        selected = set(job.candidate_ids)
+        candidates = (
+            candidate
+            for candidate in load_inbox_candidates(
+                self.root,
+                include_inactive=True,
+            )
+            if candidate.id in selected
+        )
+        assessed_count = 0
+        failed_count = 0
+        for candidate in candidates:
+            if candidate.assessment_status == ASSESSMENT_ASSESSED:
+                assessed_count += 1
+            elif candidate.assessment_status == ASSESSMENT_FAILED:
+                failed_count += 1
+        return assessed_count, failed_count
 
     def _adopt_lineage_candidate(self, chat_id: int, candidate_id: str) -> str:
         if not candidate_id:

--- a/src/enoch/cli.py
+++ b/src/enoch/cli.py
@@ -86,8 +86,8 @@ ADMIN_COMMANDS = (
     ),
     AdminCommand(
         "inherit",
-        "Scan and inspect direct-parent changes.",
-        "inherit [inspect <change_id>|ignore <change_id>]",
+        "Scan or inspect stored direct-parent changes.",
+        "inherit [inbox|inspect <change_id>|ignore <change_id>]",
         "_admin_inherit",
     ),
     AdminCommand(

--- a/src/enoch/command_surface.py
+++ b/src/enoch/command_surface.py
@@ -12,7 +12,8 @@ def lineage_usage(prefix: str = "", *, command_name: str = "ancestors") -> str:
         return "\n".join(
             [
                 "Inherit commands:",
-                f"{command} - scan, assess, and show direct-parent changes",
+                f"{command} - scan direct-parent changes and assess them in the background",
+                f"{command} inbox - show the stored inbox without scanning",
                 f"{command} inspect <change_id> - show the complete stored assessment",
                 f"{command} <change_id> - adapt one change through the standard task workflow",
                 f"{command} ignore <change_id> - dismiss a change",

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -25,12 +25,14 @@ from enoch.lineage.core import (
     format_candidate,
     format_lineage,
     format_parent_inherit_report,
+    format_parent_inbox,
     load_current_agent_profile,
     load_inbox_candidates,
+    load_parent_inbox_candidates,
     mark_inbox_candidate,
+    refresh_lineage_inbox,
     resolve_lineage,
 )
-from enoch.lineage.assessment import refresh_and_assess_lineage_inbox
 from enoch.providers.contracts import AgentRuntime
 from enoch.providers.contracts import ConversationId
 from enoch.providers.registry import (
@@ -697,7 +699,7 @@ def inherit_command(
     *,
     prefix: str = "/",
     command_name: str = "inherit",
-    refresh_lineage_fn: RefreshLineageFn = refresh_and_assess_lineage_inbox,
+    refresh_lineage_fn: RefreshLineageFn = refresh_lineage_inbox,
 ) -> str:
     parts = text.split(maxsplit=2)
     subcommand = parts[1].lower() if len(parts) >= 2 else ""
@@ -706,6 +708,17 @@ def inherit_command(
         if not subcommand:
             report = refresh_lineage_fn(root, scope="parent")
             return format_parent_inherit_report(report)
+        if subcommand == "inbox":
+            return "\n".join(
+                [
+                    format_parent_inbox(load_parent_inbox_candidates(root)),
+                    "",
+                    "Next:",
+                    f"- {prefix}{command_name} inspect <change_id>",
+                    f"- {prefix}{command_name} <change_id>",
+                    f"- {prefix}{command_name} ignore <change_id>",
+                ]
+            )
         if subcommand == "inspect":
             if not argument:
                 return f"Use {prefix}{command_name} inspect <candidate>."
@@ -1001,7 +1014,7 @@ CORE_COMMANDS = (
         "inherit",
         "Inherit",
         "",
-        "scan and assess direct-parent changes",
+        "scan direct-parent changes and assess them in the background",
         lambda prefix: lineage_usage(prefix, command_name="inherit"),
     ),
     CoreCommand(

--- a/src/enoch/lineage/assessment.py
+++ b/src/enoch/lineage/assessment.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import json
 from pathlib import Path
 from typing import Any
@@ -30,6 +30,7 @@ from enoch.providers.runtime import invoke_runtime_respond
 
 
 LineageAssessmentGenerator = Callable[[str], str]
+LineageAssessmentGuard = Callable[[], None]
 ASSESSMENT_DIFF_CHARS = 6_000
 ASSESSMENT_TEXT_LIMIT = 2_000
 ASSESSMENT_LIST_LIMIT = 12
@@ -37,6 +38,19 @@ ASSESSMENT_LIST_LIMIT = 12
 
 class LineageAssessmentError(ValueError):
     pass
+
+
+@dataclass(frozen=True)
+class LineageAssessmentProgress:
+    processed_count: int
+    total_count: int
+    assessed_count: int
+    failed_count: int
+    batch_index: int
+    batch_count: int
+
+
+LineageAssessmentProgressCallback = Callable[[LineageAssessmentProgress], None]
 
 
 def refresh_and_assess_lineage_inbox(
@@ -62,6 +76,9 @@ def assess_lineage_inbox(
     *,
     generator: LineageAssessmentGenerator,
     mission: str,
+    candidate_ids: Iterable[str] | None = None,
+    progress_callback: LineageAssessmentProgressCallback | None = None,
+    guard: LineageAssessmentGuard | None = None,
 ) -> LineageInboxReport:
     if not report.ancestors:
         return replace(
@@ -70,16 +87,10 @@ def assess_lineage_inbox(
             assessed_count=0,
             assessment_failed_count=0,
         )
-    ancestor_repos = {ancestor.repo for ancestor in report.ancestors}
-    candidates = tuple(
-        candidate
-        for candidate in load_inbox_candidates(root)
-        if candidate.status == STATUS_PENDING
-        and candidate.repo in ancestor_repos
-        and (
-            candidate.assessment_status != ASSESSMENT_ASSESSED
-            or candidate.assessment_version != ASSESSMENT_SCHEMA_VERSION
-        )
+    candidates = lineage_assessment_candidates(
+        report,
+        root,
+        candidate_ids=candidate_ids,
     )
     if not candidates:
         return replace(
@@ -90,9 +101,13 @@ def assess_lineage_inbox(
         )
 
     batch_size = lineage_settings(root).assessment_batch_size
+    batches = tuple(_batches(candidates, batch_size))
     assessed_count = 0
     failed_count = 0
-    for batch in _batches(candidates, batch_size):
+    processed_count = 0
+    for batch_index, batch in enumerate(batches, start=1):
+        if guard is not None:
+            guard()
         try:
             raw = generator(
                 lineage_assessment_prompt(
@@ -101,10 +116,16 @@ def assess_lineage_inbox(
                     current_context=_current_enoch_context(root),
                 )
             )
+            if guard is not None:
+                guard()
             assessments = _parse_assessment_response(raw, batch)
         except (LineageAssessmentError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as error:
+            if guard is not None:
+                guard()
             detail = _clean_text(str(error)) or error.__class__.__name__
             for candidate in batch:
+                if guard is not None:
+                    guard()
                 update_inbox_candidate(
                     candidate.id,
                     root,
@@ -114,9 +135,21 @@ def assess_lineage_inbox(
                     assessment_version=ASSESSMENT_SCHEMA_VERSION,
                 )
             failed_count += len(batch)
+            processed_count += len(batch)
+            _report_progress(
+                progress_callback,
+                processed_count=processed_count,
+                total_count=len(candidates),
+                assessed_count=assessed_count,
+                failed_count=failed_count,
+                batch_index=batch_index,
+                batch_count=len(batches),
+            )
             continue
 
         for candidate in batch:
+            if guard is not None:
+                guard()
             assessment = assessments[candidate.id]
             update_inbox_candidate(
                 candidate.id,
@@ -138,12 +171,51 @@ def assess_lineage_inbox(
                 assessment_error="",
             )
             assessed_count += 1
+        processed_count += len(batch)
+        _report_progress(
+            progress_callback,
+            processed_count=processed_count,
+            total_count=len(candidates),
+            assessed_count=assessed_count,
+            failed_count=failed_count,
+            batch_index=batch_index,
+            batch_count=len(batches),
+        )
 
     return replace(
         report,
         candidates=_active_report_candidates(report, root),
         assessed_count=assessed_count,
         assessment_failed_count=failed_count,
+    )
+
+
+def lineage_assessment_candidates(
+    report: LineageInboxReport,
+    root: Path | None = None,
+    *,
+    candidate_ids: Iterable[str] | None = None,
+) -> tuple[LineageCandidate, ...]:
+    ancestor_repos = {ancestor.repo for ancestor in report.ancestors}
+    selected_ids = (
+        {
+            candidate_id.strip()
+            for candidate_id in candidate_ids
+            if candidate_id.strip()
+        }
+        if candidate_ids is not None
+        else None
+    )
+    return tuple(
+        candidate
+        for candidate in load_inbox_candidates(root)
+        if candidate.status == STATUS_PENDING
+        and candidate.repo in ancestor_repos
+        and (selected_ids is None or candidate.id in selected_ids)
+        and (
+            candidate.assessment_status != ASSESSMENT_ASSESSED
+            or candidate.assessment_version != ASSESSMENT_SCHEMA_VERSION
+        )
     )
 
 
@@ -330,6 +402,30 @@ def _batches(
 ) -> Iterable[tuple[LineageCandidate, ...]]:
     for index in range(0, len(candidates), max(1, size)):
         yield candidates[index : index + max(1, size)]
+
+
+def _report_progress(
+    callback: LineageAssessmentProgressCallback | None,
+    *,
+    processed_count: int,
+    total_count: int,
+    assessed_count: int,
+    failed_count: int,
+    batch_index: int,
+    batch_count: int,
+) -> None:
+    if callback is None:
+        return
+    callback(
+        LineageAssessmentProgress(
+            processed_count=processed_count,
+            total_count=total_count,
+            assessed_count=assessed_count,
+            failed_count=failed_count,
+            batch_index=batch_index,
+            batch_count=batch_count,
+        )
+    )
 
 
 def _required_text(raw: Mapping[str, object], key: str, *, limit: int) -> str:

--- a/src/enoch/lineage/assessment_queue.py
+++ b/src/enoch/lineage/assessment_queue.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from enoch.memory.paths import now as current_time
+from enoch.paths import private_state_path
+from enoch.providers.contracts import ConversationId, normalize_conversation_id
+from enoch.state import StateCorruptionError, atomic_write, file_transaction, load_json_object
+
+
+SCHEMA_VERSION = 1
+QUEUE_PATH = Path("lineage") / "assessment_queue.json"
+PENDING = "pending"
+RUNNING = "running"
+COMPLETED = "completed"
+FAILED = "failed"
+JOB_STATUSES = {PENDING, RUNNING, COMPLETED, FAILED}
+
+
+@dataclass(frozen=True)
+class LineageAssessmentJob:
+    id: str
+    conversation_id: ConversationId
+    candidate_ids: tuple[str, ...]
+    requested_at: str
+    status: str = PENDING
+    new_count: int = 0
+    started_at: str = ""
+    completed_at: str = ""
+    owner_epoch: str = ""
+    attempts: int = 0
+    assessed_count: int = 0
+    failed_count: int = 0
+    error: str = ""
+
+    @property
+    def total_count(self) -> int:
+        return len(self.candidate_ids)
+
+
+@dataclass(frozen=True)
+class LineageAssessmentQueue:
+    current: LineageAssessmentJob | None = None
+    last: LineageAssessmentJob | None = None
+
+
+def lineage_assessment_queue_file(root: Path | None = None) -> Path:
+    return private_state_path(QUEUE_PATH, root)
+
+
+def load_lineage_assessment_queue(
+    root: Path | None = None,
+) -> LineageAssessmentQueue:
+    path = lineage_assessment_queue_file(root)
+    with file_transaction(path):
+        return _load_queue(path)
+
+
+def enqueue_lineage_assessment(
+    conversation_id: ConversationId,
+    candidate_ids: tuple[str, ...],
+    root: Path | None = None,
+    *,
+    new_count: int = 0,
+) -> tuple[LineageAssessmentJob, bool]:
+    normalized_ids = tuple(
+        dict.fromkeys(
+            candidate_id.strip()
+            for candidate_id in candidate_ids
+            if candidate_id.strip()
+        )
+    )
+    if not normalized_ids:
+        raise ValueError("An inheritance assessment requires at least one change.")
+    normalized_conversation_id = normalize_conversation_id(conversation_id)
+    if normalized_conversation_id is None:
+        raise ValueError("An inheritance assessment requires a conversation id.")
+    path = lineage_assessment_queue_file(root)
+    with file_transaction(path):
+        queue = _load_queue(path)
+        if queue.current is not None:
+            return queue.current, False
+        job = LineageAssessmentJob(
+            id=f"lineage-{uuid4().hex}",
+            conversation_id=normalized_conversation_id,
+            candidate_ids=normalized_ids,
+            requested_at=current_time(),
+            new_count=max(0, int(new_count)),
+        )
+        _write_queue(path, LineageAssessmentQueue(current=job, last=queue.last))
+        return job, True
+
+
+def claim_lineage_assessment(
+    owner_epoch: str,
+    root: Path | None = None,
+) -> LineageAssessmentJob | None:
+    owner = owner_epoch.strip()
+    if not owner:
+        raise ValueError("A daemon epoch is required to claim inheritance assessment.")
+    path = lineage_assessment_queue_file(root)
+    with file_transaction(path):
+        queue = _load_queue(path)
+        job = queue.current
+        if job is None:
+            return None
+        if job.status == RUNNING and job.owner_epoch == owner:
+            return None
+        claimed = replace(
+            job,
+            status=RUNNING,
+            started_at=current_time(),
+            completed_at="",
+            owner_epoch=owner,
+            attempts=job.attempts + 1,
+            error="",
+        )
+        _write_queue(path, replace(queue, current=claimed))
+        return claimed
+
+
+def complete_lineage_assessment(
+    job_id: str,
+    root: Path | None = None,
+    *,
+    owner_epoch: str,
+    assessed_count: int,
+    failed_count: int,
+) -> LineageAssessmentJob | None:
+    return _finish_lineage_assessment(
+        job_id,
+        COMPLETED,
+        root,
+        owner_epoch=owner_epoch,
+        assessed_count=assessed_count,
+        failed_count=failed_count,
+    )
+
+
+def fail_lineage_assessment(
+    job_id: str,
+    error: str,
+    root: Path | None = None,
+    *,
+    owner_epoch: str,
+) -> LineageAssessmentJob | None:
+    return _finish_lineage_assessment(
+        job_id,
+        FAILED,
+        root,
+        owner_epoch=owner_epoch,
+        error=" ".join(error.split())[:1000],
+    )
+
+
+def _finish_lineage_assessment(
+    job_id: str,
+    status: str,
+    root: Path | None,
+    *,
+    owner_epoch: str,
+    assessed_count: int = 0,
+    failed_count: int = 0,
+    error: str = "",
+) -> LineageAssessmentJob | None:
+    if status not in {COMPLETED, FAILED}:
+        raise ValueError(f"Invalid inheritance assessment completion status: {status}")
+    owner = owner_epoch.strip()
+    if not owner:
+        raise ValueError("A daemon epoch is required to finish inheritance assessment.")
+    path = lineage_assessment_queue_file(root)
+    with file_transaction(path):
+        queue = _load_queue(path)
+        job = queue.current
+        if (
+            job is None
+            or job.id != job_id.strip()
+            or job.owner_epoch != owner
+        ):
+            return None
+        finished = replace(
+            job,
+            status=status,
+            completed_at=current_time(),
+            owner_epoch="",
+            assessed_count=max(0, int(assessed_count)),
+            failed_count=max(0, int(failed_count)),
+            error=error,
+        )
+        _write_queue(
+            path,
+            LineageAssessmentQueue(current=None, last=finished),
+        )
+        return finished
+
+
+def _load_queue(path: Path) -> LineageAssessmentQueue:
+    raw = load_json_object(
+        path,
+        default_factory=lambda: {
+            "schema_version": SCHEMA_VERSION,
+            "current": None,
+            "last": None,
+        },
+    )
+    schema_version = _int(raw.get("schema_version"))
+    if schema_version != SCHEMA_VERSION:
+        raise StateCorruptionError(
+            path,
+            f"unsupported schema version {schema_version}",
+        )
+    current = _job_from_json(raw.get("current"))
+    last = _job_from_json(raw.get("last"))
+    if raw.get("current") is not None and current is None:
+        raise StateCorruptionError(path, "found an invalid current assessment job")
+    if raw.get("last") is not None and last is None:
+        raise StateCorruptionError(path, "found an invalid last assessment job")
+    if current is not None and current.status not in {PENDING, RUNNING}:
+        raise StateCorruptionError(path, "current assessment job is not pending or running")
+    if last is not None and last.status not in {COMPLETED, FAILED}:
+        raise StateCorruptionError(path, "last assessment job is not completed or failed")
+    return LineageAssessmentQueue(current=current, last=last)
+
+
+def _write_queue(path: Path, queue: LineageAssessmentQueue) -> None:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "current": _job_to_json(queue.current),
+        "last": _job_to_json(queue.last),
+    }
+    atomic_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _job_to_json(job: LineageAssessmentJob | None) -> dict[str, Any] | None:
+    if job is None:
+        return None
+    payload = asdict(job)
+    payload["candidate_ids"] = list(job.candidate_ids)
+    return payload
+
+
+def _job_from_json(raw: object) -> LineageAssessmentJob | None:
+    if not isinstance(raw, dict):
+        return None
+    job_id = str(raw.get("id") or "").strip()
+    requested_at = str(raw.get("requested_at") or "").strip()
+    status = str(raw.get("status") or "").strip()
+    raw_candidate_ids = raw.get("candidate_ids")
+    if not isinstance(raw_candidate_ids, list):
+        return None
+    candidate_ids = tuple(
+        dict.fromkeys(
+            str(item or "").strip()
+            for item in raw_candidate_ids
+            if str(item or "").strip()
+        )
+    )
+    conversation_id = normalize_conversation_id(raw.get("conversation_id"))
+    if (
+        not job_id
+        or not requested_at
+        or conversation_id is None
+        or status not in JOB_STATUSES
+        or not candidate_ids
+    ):
+        return None
+    return LineageAssessmentJob(
+        id=job_id,
+        conversation_id=conversation_id,
+        candidate_ids=candidate_ids,
+        requested_at=requested_at,
+        status=status,
+        new_count=max(0, _int(raw.get("new_count"))),
+        started_at=str(raw.get("started_at") or ""),
+        completed_at=str(raw.get("completed_at") or ""),
+        owner_epoch=str(raw.get("owner_epoch") or ""),
+        attempts=max(0, _int(raw.get("attempts"))),
+        assessed_count=max(0, _int(raw.get("assessed_count"))),
+        failed_count=max(0, _int(raw.get("failed_count"))),
+        error=str(raw.get("error") or ""),
+    )
+
+
+def _int(value: object) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/src/enoch/lineage/core.py
+++ b/src/enoch/lineage/core.py
@@ -555,6 +555,44 @@ def load_inbox_candidates(root: Path | None = None, *, include_inactive: bool = 
     return _candidates_from_payload(payload, include_inactive=include_inactive)
 
 
+def load_lineage_inbox_report(
+    root: Path | None = None,
+    *,
+    scope: str = "parent",
+) -> LineageInboxReport:
+    normalized_scope = scope.strip().lower() or "parent"
+    if normalized_scope not in {"all", "parent"}:
+        raise LineageError("Lineage inbox scope must be all or parent.")
+    payload = _load_inbox_payload(root)
+    ancestors = tuple(
+        ancestor
+        for item in payload.get("ancestors", [])
+        if isinstance(item, dict)
+        and (ancestor := _ancestor_from_json(item)) is not None
+    )
+    if normalized_scope == "parent":
+        ancestors = ancestors[:1]
+    ancestor_repos = {ancestor.repo for ancestor in ancestors}
+    candidates = tuple(
+        candidate
+        for candidate in _candidates_from_payload(payload, include_inactive=False)
+        if candidate.repo in ancestor_repos
+    )
+    latest_heads = {
+        str(repo): str(head)
+        for repo, head in dict(payload.get("latest_heads") or {}).items()
+        if str(repo).strip() and str(head).strip()
+    }
+    return LineageInboxReport(
+        scope=normalized_scope,
+        ancestors=ancestors,
+        candidates=candidates,
+        latest_heads=latest_heads,
+        errors=tuple(str(item) for item in payload.get("errors", []) if str(item)),
+        refreshed_at=str(payload.get("refreshed_at") or ""),
+    )
+
+
 def load_parent_inbox_candidates(
     root: Path | None = None,
     *,
@@ -830,6 +868,62 @@ def format_parent_inherit_report(report: LineageInboxReport) -> str:
             "- /inherit ignore <change_id>",
         ]
     )
+    return "\n".join(lines)
+
+
+def format_inheritance_scan_queued(
+    report: LineageInboxReport,
+    assessment_count: int,
+) -> str:
+    if not report.ancestors:
+        return format_parent_inherit_report(report)
+    parent = report.ancestors[0]
+    lines = [
+        "Direct parent inheritance scan completed.",
+        "",
+        f"Parent: {parent.name} ({parent.repo}@{parent.branch})",
+    ]
+    if report.errors:
+        lines.extend(["", "Warnings:", *(f"- {error}" for error in report.errors)])
+    lines.extend(
+        [
+            "",
+            (
+                "Added 1 new direct-parent change."
+                if report.new_count == 1
+                else f"Added {report.new_count} new direct-parent changes."
+            ),
+            (
+                "Queued 1 change for background Codex assessment."
+                if assessment_count == 1
+                else f"Queued {assessment_count} changes for background Codex assessment."
+            ),
+            "Enoch will remain available while assessment runs.",
+            "",
+            "Use /inherit inbox to view the stored inbox at any time.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def format_lineage_assessment_complete(
+    candidates: tuple[LineageCandidate, ...],
+    *,
+    assessed_count: int,
+    failed_count: int,
+) -> str:
+    lines = [
+        "Inheritance assessment finished.",
+        f"Assessed: {max(0, assessed_count)}",
+        f"Failed: {max(0, failed_count)}",
+        "",
+        format_parent_inbox(candidates),
+        "",
+        "Next:",
+        "- /inherit inspect <change_id>",
+        "- /inherit <change_id>",
+        "- /inherit ignore <change_id>",
+    ]
     return "\n".join(lines)
 
 
@@ -1181,6 +1275,23 @@ def _candidate_from_json(data: dict[str, Any]) -> LineageCandidate:
         linked_at=str(data.get("linked_at") or ""),
         adopted_revision=str(data.get("adopted_revision") or ""),
         adopted_at=str(data.get("adopted_at") or ""),
+    )
+
+
+def _ancestor_from_json(data: dict[str, Any]) -> AncestorLink | None:
+    name = str(data.get("name") or "").strip()
+    repo = str(data.get("repo") or "").strip()
+    branch = str(data.get("branch") or DEFAULT_BRANCH).strip() or DEFAULT_BRANCH
+    depth = _positive_int(data.get("depth"))
+    if not name or not repo or depth is None:
+        return None
+    return AncestorLink(
+        name=name,
+        repo=repo,
+        branch=branch,
+        depth=depth,
+        skills=_string_tuple(data.get("skills")),
+        commit_at_birth=str(data.get("commit_at_birth") or ""),
     )
 
 

--- a/src/enoch/private_state.py
+++ b/src/enoch/private_state.py
@@ -156,6 +156,15 @@ STATE_FILE_SCHEMAS = (
         (("candidates", (list,)), ("latest_heads", (dict,))),
     ),
     StateFileSchema(
+        "lineage/assessment_queue.json",
+        1,
+        (("current", None), ("last", None)),
+        (
+            ("current", (dict, type(None))),
+            ("last", (dict, type(None))),
+        ),
+    ),
+    StateFileSchema(
         "pending_evolve_adoptions.json",
         1,
         (("adoptions", []),),

--- a/src/enoch/skills/inherit/SKILL.md
+++ b/src/enoch/skills/inherit/SKILL.md
@@ -16,6 +16,7 @@ Enoch uses this skill through ancestor commands:
 
 - `/ancestors`
 - `/inherit`
+- `/inherit inbox`
 - `/inherit inspect <change_id>`
 - `/inherit <change_id>`
 - `/inherit ignore <change_id>`
@@ -24,7 +25,11 @@ Enoch uses this skill through ancestor commands:
 
 Inheritance only flows through Enoch's direct parent. If Enoch's parent has not inherited a grandparent change, Enoch should not inherit it directly.
 
-`/inherit` discovers direct-parent PRs and commits, stores them in private state, and asks a fresh Codex assessment session for a factual summary, applicability judgment, risks, likely files, and tests. Assessment is advisory and never starts work.
+`/inherit` discovers direct-parent PRs and commits, stores them in private state,
+and queues fresh Codex assessment sessions in a durable background worker. The
+Telegram handler replies immediately and remains available while assessment
+runs. Progress and the completed inbox are delivered as durable notifications.
+Assessment is advisory and never starts implementation work.
 
 Discovery advances a durable per-parent commit cursor only after a complete
 scan. It paginates up to `lineage.scan_limit` (default `500`) and reports an
@@ -37,6 +42,11 @@ The initial cursor starts at `parent.commit_at_birth` when lineage metadata
 provides it. For older descendants without that provenance, the first scan
 intentionally baselines from the newest 20 parent commits rather than treating
 the parent's entire history as new.
+
+An interrupted running assessment is reclaimed by the next daemon epoch and
+continues with only records that still need assessment. `/inherit inbox` reads
+the stored inbox without contacting the forge or Codex and without advancing
+the scan cursor.
 
 `/inherit inspect <change_id>` displays the durable assessment and adds it to the normal conversation context for follow-up questions. `/inherit <change_id>` is explicit human authorization to queue one adaptation through the standard task, worktree, validation, commit, push, and PR workflow. `/inherit ignore <change_id>` dismisses a pending change without deleting its history.
 

--- a/src/enoch/skills/inherit/skill.yaml
+++ b/src/enoch/skills/inherit/skill.yaml
@@ -16,8 +16,10 @@ permissions:
       - .agent/lineage.yaml
       - .agent/lineage_inbox.json
       - .enoch/lineage/inbox.json
+      - .enoch/lineage/assessment_queue.json
     write:
       - .enoch/lineage/inbox.json
+      - .enoch/lineage/assessment_queue.json
   forge:
     read_repo: true
 validation:

--- a/tests/test_enoch_cli.py
+++ b/tests/test_enoch_cli.py
@@ -40,7 +40,7 @@ class EnochCliTests(unittest.TestCase):
         self.assertIn("mission     Show or update Enoch's mission.", output)
         self.assertNotIn("memory      Manage long-term memory", output)
         self.assertIn("ancestors   Inspect ancestor chain and inheritable updates.", output)
-        self.assertIn("inherit     Scan and inspect direct-parent changes.", output)
+        self.assertIn("inherit     Scan or inspect stored direct-parent changes.", output)
         self.assertIn("skills      Show declared skills for Enoch or another local agent.", output)
         self.assertNotIn("teach       Package local changes as a portable lesson.", output)
         self.assertIn("learn       Inspect a published skill for adaptation.", output)

--- a/tests/test_enoch_lineage.py
+++ b/tests/test_enoch_lineage.py
@@ -30,6 +30,7 @@ from enoch.lineage.core import (
     load_birth_commit,
     load_current_agent_profile,
     load_inbox_candidates,
+    load_lineage_inbox_report,
     load_parent,
     mark_inbox_candidate,
     parse_declared_skills,
@@ -40,6 +41,7 @@ from enoch.lineage.core import (
     resolve_lineage,
 )
 from enoch.lineage.assessment import assess_lineage_inbox
+from enoch.commands import inherit_command
 from enoch.lineage.lifecycle import (
     lineage_context_source,
     reconcile_lineage_adoptions,
@@ -602,6 +604,7 @@ class EnochLineageTests(unittest.TestCase):
 
     def test_assessment_uses_configurable_fresh_batches(self) -> None:
         calls = 0
+        progress = []
         with TemporaryDirectory() as temp:
             root = _root_with_parent(Path(temp))
             config = root / ".enoch" / "config.yaml"
@@ -637,10 +640,55 @@ class EnochLineageTests(unittest.TestCase):
                 root,
                 generator=generator,
                 mission="Help Roy operate Enoch.",
+                progress_callback=progress.append,
             )
 
         self.assertEqual(calls, 2)
         self.assertEqual(assessed.assessed_count, 3)
+        self.assertEqual(
+            [update.processed_count for update in progress],
+            [2, 3],
+        )
+        self.assertEqual(
+            [update.batch_index for update in progress],
+            [1, 2],
+        )
+
+    def test_stored_inherit_inbox_does_not_refresh(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = _root_with_parent(Path(temp))
+            refresh_lineage_inbox(root, scope="parent", client=FakeLineageClient())
+
+            reply = inherit_command(
+                "/inherit inbox",
+                root,
+                refresh_lineage_fn=lambda *_args, **_kwargs: self.fail(
+                    "/inherit inbox must not scan the forge"
+                ),
+            )
+
+        self.assertIn("Direct parent inheritance inbox:", reply)
+        self.assertIn("our-ark/enoch#32", reply)
+        self.assertIn("/inherit inspect <change_id>", reply)
+
+    def test_stored_lineage_report_reconstructs_scan_context(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = _root_with_parent(Path(temp))
+            refreshed = refresh_lineage_inbox(
+                root,
+                scope="parent",
+                client=FakeLineageClient(),
+            )
+
+            loaded = load_lineage_inbox_report(root, scope="parent")
+
+        self.assertEqual(loaded.scope, "parent")
+        self.assertEqual(loaded.ancestors, refreshed.ancestors)
+        self.assertEqual(
+            tuple(candidate.id for candidate in loaded.candidates),
+            tuple(candidate.id for candidate in refreshed.candidates),
+        )
+        self.assertEqual(loaded.latest_heads, refreshed.latest_heads)
 
     def test_legacy_inbox_is_read_then_migrated_to_private_state(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_lineage_assessment_queue.py
+++ b/tests/test_enoch_lineage_assessment_queue.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from enoch.lineage.assessment_queue import (
+    COMPLETED,
+    FAILED,
+    PENDING,
+    RUNNING,
+    claim_lineage_assessment,
+    complete_lineage_assessment,
+    enqueue_lineage_assessment,
+    fail_lineage_assessment,
+    load_lineage_assessment_queue,
+)
+
+
+class EnochLineageAssessmentQueueTests(unittest.TestCase):
+    def test_job_lifecycle_is_durable(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            job, created = enqueue_lineage_assessment(
+                42,
+                ("our-ark/enoch#32", "our-ark/enoch#32", " parent@abc "),
+                root,
+                new_count=2,
+            )
+
+            pending = load_lineage_assessment_queue(root)
+            claimed = claim_lineage_assessment("epoch-a", root)
+            duplicate_claim = claim_lineage_assessment("epoch-a", root)
+            finished = complete_lineage_assessment(
+                job.id,
+                root,
+                owner_epoch="epoch-a",
+                assessed_count=1,
+                failed_count=1,
+            )
+            saved = load_lineage_assessment_queue(root)
+
+        self.assertTrue(created)
+        self.assertEqual(job.status, PENDING)
+        self.assertEqual(job.candidate_ids, ("our-ark/enoch#32", "parent@abc"))
+        self.assertEqual(pending.current, job)
+        assert claimed is not None
+        self.assertEqual(claimed.status, RUNNING)
+        self.assertEqual(claimed.owner_epoch, "epoch-a")
+        self.assertEqual(claimed.attempts, 1)
+        self.assertIsNone(duplicate_claim)
+        assert finished is not None
+        self.assertEqual(finished.status, COMPLETED)
+        self.assertEqual(finished.assessed_count, 1)
+        self.assertEqual(finished.failed_count, 1)
+        self.assertIsNone(saved.current)
+        self.assertEqual(saved.last, finished)
+
+    def test_new_daemon_reclaims_an_interrupted_running_job(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            job, _ = enqueue_lineage_assessment(
+                "telegram:42",
+                ("our-ark/enoch#32",),
+                root,
+            )
+            first = claim_lineage_assessment("old-epoch", root)
+            recovered = claim_lineage_assessment("new-epoch", root)
+
+        assert first is not None
+        assert recovered is not None
+        self.assertEqual(first.id, job.id)
+        self.assertEqual(recovered.id, job.id)
+        self.assertEqual(recovered.status, RUNNING)
+        self.assertEqual(recovered.owner_epoch, "new-epoch")
+        self.assertEqual(recovered.attempts, 2)
+
+    def test_only_one_assessment_job_can_be_queued(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            first, first_created = enqueue_lineage_assessment(
+                42,
+                ("our-ark/enoch#32",),
+                root,
+            )
+            second, second_created = enqueue_lineage_assessment(
+                42,
+                ("our-ark/enoch#33",),
+                root,
+            )
+
+        self.assertTrue(first_created)
+        self.assertFalse(second_created)
+        self.assertEqual(second, first)
+
+    def test_failed_job_is_preserved_as_the_last_result(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            job, _ = enqueue_lineage_assessment(
+                42,
+                ("our-ark/enoch#32",),
+                root,
+            )
+            claim_lineage_assessment("epoch-a", root)
+
+            failed = fail_lineage_assessment(
+                job.id,
+                " runtime  unavailable ",
+                root,
+                owner_epoch="epoch-a",
+            )
+            saved = load_lineage_assessment_queue(root)
+
+        assert failed is not None
+        self.assertEqual(failed.status, FAILED)
+        self.assertEqual(failed.error, "runtime unavailable")
+        self.assertIsNone(saved.current)
+        self.assertEqual(saved.last, failed)
+
+    def test_stale_daemon_cannot_finish_a_reclaimed_job(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            job, _ = enqueue_lineage_assessment(
+                42,
+                ("our-ark/enoch#32",),
+                root,
+            )
+            claim_lineage_assessment("old-epoch", root)
+            recovered = claim_lineage_assessment("new-epoch", root)
+
+            stale_result = complete_lineage_assessment(
+                job.id,
+                root,
+                owner_epoch="old-epoch",
+                assessed_count=1,
+                failed_count=0,
+            )
+            current = load_lineage_assessment_queue(root).current
+
+        self.assertIsNone(stale_result)
+        self.assertEqual(current, recovered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -57,6 +57,7 @@ from enoch.immune import DoctorDiagnosis
 from enoch.lineage.core import (
     AncestorLink,
     LineageCandidate,
+    LineageInboxReport,
     LineageResolution,
     load_inbox_candidates,
 )
@@ -747,7 +748,10 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertNotIn("/thinking", client.sent[0][1])
         self.assertNotIn("/lineage", client.sent[0][1])
         self.assertIn("/ancestors - show ancestor chain and ancestor skills", client.sent[0][1])
-        self.assertIn("/inherit - scan and assess direct-parent changes", client.sent[0][1])
+        self.assertIn(
+            "/inherit - scan direct-parent changes and assess them in the background",
+            client.sent[0][1],
+        )
         self.assertNotIn("/memory", client.sent[0][1])
         self.assertIn("/skills [agent-or-path] - show declared skills", client.sent[0][1])
         self.assertNotIn("/teach", client.sent[0][1])
@@ -1297,7 +1301,14 @@ class EnochTelegramTests(unittest.TestCase):
 
         reply = client.sent[0][1]
         self.assertIn("Inherit commands:", reply)
-        self.assertIn("/inherit - scan, assess, and show direct-parent changes", reply)
+        self.assertIn(
+            "/inherit - scan direct-parent changes and assess them in the background",
+            reply,
+        )
+        self.assertIn(
+            "/inherit inbox - show the stored inbox without scanning",
+            reply,
+        )
         self.assertIn("/inherit inspect <change_id>", reply)
         self.assertIn("/inherit <change_id> - adapt one change", reply)
         self.assertIn("/inherit ignore <change_id> - dismiss a change", reply)
@@ -4252,20 +4263,104 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("private repo", client.sent[0][1])
         self.assertIn("Ancestor commands:", client.sent[0][1])
 
-    @patch("enoch.app.core.inherit_command", return_value="Direct parent inheritance checked.\nour-ark/enoch#32")
-    def test_inherit_uses_shared_command(self, inherit_command: MagicMock) -> None:
+    @patch(
+        "enoch.app.core.inherit_command",
+        return_value="Direct parent inheritance inbox.\nour-ark/enoch#32",
+    )
+    def test_inherit_inbox_is_read_only(self, inherit_command: MagicMock) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)
             client = FakeTelegramClient(allowed_chat_id=42)
             bot = EnochApplication(load_identity(), root, client)
 
-            _handle_update(bot, _message_update(chat_id=42, text="/inherit"))
+            with (
+                patch.object(bot, "_reconcile_lineage_adoptions") as reconcile,
+                patch("enoch.app.core.refresh_lineage_inbox") as refresh,
+                patch.object(bot, "_respond_isolated_evidence_turn") as assess,
+            ):
+                _handle_update(bot, _message_update(chat_id=42, text="/inherit inbox"))
 
         inherit_command.assert_called_once()
-        self.assertEqual(inherit_command.call_args.args[:2], ("/inherit", root))
+        self.assertEqual(inherit_command.call_args.args[:2], ("/inherit inbox", root))
         self.assertEqual(inherit_command.call_args.kwargs["command_name"], "inherit")
-        self.assertIn("Direct parent inheritance checked", client.sent[0][1])
+        reconcile.assert_not_called()
+        refresh.assert_not_called()
+        assess.assert_not_called()
+        self.assertIn("Direct parent inheritance inbox", client.sent[0][1])
         self.assertIn("our-ark/enoch#32", client.sent[0][1])
+
+    def test_inherit_assessment_runs_in_background_while_chat_stays_responsive(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            candidate = replace(
+                _lineage_candidate(),
+                assessment_status="pending",
+                assessment_version=0,
+                applicability="unknown",
+                summary="",
+            )
+            _write_lineage_inbox(root, candidate)
+            report = LineageInboxReport(
+                scope="parent",
+                ancestors=(
+                    AncestorLink(
+                        name="Enoch",
+                        repo="our-ark/enoch",
+                        branch="main",
+                        depth=1,
+                    ),
+                ),
+                candidates=(candidate,),
+                latest_heads={"our-ark/enoch": "abc123"},
+                new_count=1,
+            )
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochApplication(load_identity(), root, client)
+            worker_started = threading.Event()
+            release_worker = threading.Event()
+            reply_present_at_start = []
+
+            def hold_worker(_job) -> None:
+                reply_present_at_start.append(
+                    bool(client.sent and "Queued 1 change" in client.sent[0][1])
+                )
+                worker_started.set()
+                release_worker.wait(timeout=3)
+
+            with (
+                patch.object(bot, "_reconcile_lineage_adoptions"),
+                patch("enoch.app.core.refresh_lineage_inbox", return_value=report),
+                patch.object(
+                    bot,
+                    "_run_lineage_assessment_worker",
+                    side_effect=hold_worker,
+                ),
+            ):
+                _handle_update(
+                    bot,
+                    _message_update(
+                        update_id=1,
+                        chat_id=42,
+                        text="/inherit",
+                    ),
+                )
+                self.assertTrue(worker_started.wait(timeout=1))
+
+                _handle_update(
+                    bot,
+                    _message_update(
+                        update_id=2,
+                        chat_id=42,
+                        text="/help",
+                    ),
+                )
+
+                release_worker.set()
+                bot.stop_workers()
+
+        self.assertEqual(reply_present_at_start, [True])
+        self.assertIn("background Codex assessment", client.sent[0][1])
+        self.assertIn("Enoch commands:", client.sent[1][1])
 
     def test_inherit_inspect_syncs_candidate_context_to_codex_session(self) -> None:
         with TemporaryDirectory() as temp:
@@ -5601,6 +5696,39 @@ def _lineage_candidate():
         suggested_tests=("Verify supported levels.",),
         assessed_at="2026-07-26T00:00:00+00:00",
         assessment_version=1,
+    )
+
+
+def _write_lineage_inbox(root: Path, candidate: LineageCandidate) -> None:
+    lineage = root / ".agent" / "lineage.yaml"
+    lineage.parent.mkdir(parents=True, exist_ok=True)
+    lineage.write_text(
+        "parent:\n  name: Enoch\n  repo: our-ark/enoch\n  branch: main\n",
+        encoding="utf-8",
+    )
+    inbox = root / ".enoch" / "lineage" / "inbox.json"
+    inbox.parent.mkdir(parents=True, exist_ok=True)
+    inbox.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "ancestors": [
+                    {
+                        "name": "Enoch",
+                        "repo": "our-ark/enoch",
+                        "branch": "main",
+                        "depth": 1,
+                        "skills": [],
+                        "commit_at_birth": "",
+                    }
+                ],
+                "latest_heads": {"our-ark/enoch": "abc123"},
+                "errors": [],
+                "refreshed_at": "2026-07-26T00:00:00+00:00",
+                "candidates": [candidate.__dict__],
+            }
+        ),
+        encoding="utf-8",
     )
 
 


### PR DESCRIPTION
## Summary

- move Codex inheritance assessment off the Telegram polling thread
- persist and recover one daemon-owned assessment job across restarts
- add a read-only /inherit inbox view that performs no forge scan or Codex work
- send durable progress and completion notifications

## Validation

- bin/enoch doctor
- 750 repository tests passed in the managed validation environment
- focused lineage, Telegram, CLI, and private-state suite: 300 tests passed