### PR TITLE
Preserve brainstorm state compatibility

### DIFF
--- a/src/enoch/evolution/core.py
+++ b/src/enoch/evolution/core.py
@@ -163,6 +163,12 @@ def evolve_brainstorm_schedule_path(root: Path | None = None) -> Path:
     return private_state_path("evolve_brainstorm_schedule.json", root)
 
 
+def _legacy_evolve_brainstorm_schedule_path(
+    root: Path | None = None,
+) -> Path:
+    return private_state_path("evolve_brainstorm_fallback.json", root)
+
+
 def load_evolve_state(root: Path | None = None) -> EvolveState:
     with file_transaction(evolve_state_path(root)):
         return _load_evolve_state_unlocked(root)
@@ -580,6 +586,10 @@ def claim_scheduled_brainstorm(
     path = evolve_brainstorm_schedule_path(root)
     with file_transaction(path):
         raw = load_json_object(path)
+        if not path.exists():
+            raw = load_json_object(
+                _legacy_evolve_brainstorm_schedule_path(root)
+            )
         raw_attempts = raw.get("attempts") if raw else None
         if raw_attempts is not None and not isinstance(raw_attempts, dict):
             raise StateCorruptionError(path, "expected attempts to be an object")

--- a/src/enoch/private_state.py
+++ b/src/enoch/private_state.py
@@ -24,6 +24,9 @@ PRIVATE_STATE_MANIFEST_SCHEMA_VERSION = 1
 PRIVATE_STATE_VERSION = 1
 MANIFEST_NAME = "state_manifest.json"
 BACKUP_DIRECTORY = "backups"
+LEGACY_STATE_SCHEMA_ALIASES = {
+    "evolve_brainstorm_fallback.json": "evolve_brainstorm_schedule.json",
+}
 
 
 class PrivateStateError(RuntimeError):
@@ -427,7 +430,11 @@ def _manifest_status(root: Path | None) -> tuple[str, tuple[str, ...]]:
         or schemas != expected
     ):
         for pattern, version in schemas.items():
-            expected_version = expected.get(pattern)
+            canonical_pattern = LEGACY_STATE_SCHEMA_ALIASES.get(
+                pattern,
+                pattern,
+            )
+            expected_version = expected.get(canonical_pattern)
             if expected_version is None:
                 return (
                     "invalid",

--- a/tests/test_enoch_evolve.py
+++ b/tests/test_enoch_evolve.py
@@ -468,6 +468,50 @@ class EnochEvolveTests(unittest.TestCase):
         self.assertTrue(other_theme)
         self.assertTrue(after_cooldown)
 
+    def test_scheduled_brainstorm_preserves_legacy_cooldown_attempts(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            state = root / ".enoch" / "evolve_brainstorm_fallback.json"
+            state.parent.mkdir(parents=True)
+            state.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "attempts": {
+                            "reliable task telemetry": (
+                                "2026-07-18T09:00:00+00:00"
+                            ),
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            blocked = claim_scheduled_brainstorm(
+                "reliable task telemetry",
+                root,
+                now=datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc),
+            )
+            claimed = claim_scheduled_brainstorm(
+                "reliable task telemetry",
+                root,
+                now=datetime(2026, 7, 19, 10, 0, tzinfo=timezone.utc),
+            )
+            migrated = json.loads(
+                (
+                    root
+                    / ".enoch"
+                    / "evolve_brainstorm_schedule.json"
+                ).read_text(encoding="utf-8")
+            )
+
+        self.assertFalse(blocked)
+        self.assertTrue(claimed)
+        self.assertIn(
+            "reliable task telemetry",
+            migrated["attempts"],
+        )
+
     def test_completed_evolve_task_marks_candidate_done(self) -> None:
         with TemporaryDirectory() as temp:
             root = Path(temp)

--- a/tests/test_enoch_private_state.py
+++ b/tests/test_enoch_private_state.py
@@ -116,6 +116,41 @@ class EnochPrivateStateTests(unittest.TestCase):
         self.assertFalse(second.applied)
         self.assertFalse(second.plan.migration_required)
 
+    def test_renamed_brainstorm_schema_is_a_migratable_manifest_alias(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            migrate_private_state(root)
+            manifest_path = private_state_manifest_path(root)
+            legacy = json.loads(manifest_path.read_text(encoding="utf-8"))
+            brainstorm_version = legacy["schemas"].pop(
+                "evolve_brainstorm_schedule.json"
+            )
+            legacy["schemas"]["evolve_brainstorm_fallback.json"] = (
+                brainstorm_version
+            )
+            manifest_path.write_text(
+                json.dumps(legacy),
+                encoding="utf-8",
+            )
+
+            plan = assert_private_state_supported(root)
+            result = migrate_private_state(root)
+            migrated = json.loads(
+                manifest_path.read_text(encoding="utf-8")
+            )
+
+        self.assertTrue(plan.valid)
+        self.assertEqual(plan.manifest_status, "outdated")
+        self.assertTrue(result.applied)
+        self.assertIn(
+            "evolve_brainstorm_schedule.json",
+            migrated["schemas"],
+        )
+        self.assertNotIn(
+            "evolve_brainstorm_fallback.json",
+            migrated["schemas"],
+        )
+
     def test_future_file_schema_is_rejected_without_mutation(self) -> None:
         with TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## What changed

- recognize the previous `evolve_brainstorm_fallback.json` manifest entry as the specific legacy alias of `evolve_brainstorm_schedule.json`
- classify that manifest as safely outdated and migratable instead of unsupported
- preserve cooldown attempts from an existing legacy state file when the new scheduler state is first claimed
- add regressions for manifest migration and legacy cooldown continuity

## Root cause

PR #47 renamed a registered private-state path without teaching manifest validation about the old name. Existing installations therefore failed startup before Telegram polling with `manifest contains unsupported state schema evolve_brainstorm_fallback.json`.

## Impact

Existing Enoch installations can start on the new build, migrate their manifest through the normal backed-up migration workflow, and retain any prior automatic-brainstorm cooldown data. Unknown and future schemas remain rejected.

## Validation

- actual resident manifest: valid, `outdated`, migration required, no errors
- `python -m unittest tests.test_enoch_private_state tests.test_enoch_evolve` — 40 tests passed
- `python -m unittest discover -s tests -t .` — 754 tests passed
- `git diff --check` — passed
