### PR TITLE
Improve cron scheduling reliability

### DIFF
--- a/docs/evolve-skill.md
+++ b/docs/evolve-skill.md
@@ -118,9 +118,9 @@ actual histories justify it.
 
 ## Scan timing and cursor rules
 
-The daemon checks thresholds on each event-loop pass after receiving chat
-updates and enqueueing due cron work, but before the evolve scheduler and task
-worker start.
+The chat event loop checks thresholds after receiving chat updates but before
+the evolve scheduler and task worker start. Task cron due checks run
+independently and may enqueue work concurrently.
 
 An automatic threshold scan runs only when:
 

--- a/docs/workflow-reliability.md
+++ b/docs/workflow-reliability.md
@@ -76,6 +76,20 @@ succeed; only then does Enoch acknowledge the claim and advance the schedule.
 After a crash, the same claim is returned and its idempotency key prevents a
 duplicate task.
 
+Task cron runs from an independent scheduler thread, so blocked or failed chat
+polling does not delay due checks. A due cron task is inserted at the front of
+the pending task queue without interrupting the running task. Each schedule may
+have at most one pending, running, or paused task; an additional due occurrence
+remains claimed until that task reaches a terminal state.
+
+Task cron intervals use fixed-rate UTC targets. `next_run_at` is the next
+anchored target, `last_scheduled_at` is the target represented by the latest
+admitted task, and `last_run_at` is when that task was handed to the queue.
+After daemon downtime, all missed targets are coalesced into one task that is
+admitted as soon as the scheduler starts. The following target is the first
+anchored interval strictly in the future, preventing acknowledgement-time
+drift and unbounded catch-up work.
+
 ## State safety
 
 All replace-style JSON writes use a unique sibling temporary file, `fsync`, and

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -50,9 +50,11 @@ from enoch.channel import (
     temporary_image_attachment,
 )
 from enoch.cron import (
+    CronJob,
     add_cron_job,
     cancel_cron_job,
     claim_due_cron_jobs,
+    cron_scheduler_wait_seconds,
     format_cron_interval,
     parse_cron_interval,
     record_cron_task,
@@ -510,7 +512,12 @@ class EnochApplication:
         self._restart_after_reply = False
         self._pending_session_syncs: list[tuple[int, str]] = []
         self._task_worker: threading.Thread | None = None
+        self._task_worker_lock = threading.Lock()
         self._direct_workers: dict[int, threading.Thread] = {}
+        self._cron_scheduler_thread: threading.Thread | None = None
+        self._cron_scheduler_lock = threading.Lock()
+        self._cron_scheduler_stop = threading.Event()
+        self._cron_scheduler_wake = threading.Event()
         self._lineage_worker: threading.Thread | None = None
         self._lineage_worker_lock = threading.Lock()
         self._task_cancellations: dict[int, threading.Event] = {}
@@ -561,16 +568,20 @@ class EnochApplication:
         return load_provider(kind, self.root)
 
     def run_forever(self) -> None:
-        while True:
-            try:
-                self.run_once()
-            except ShutdownRequested:
-                raise
-            except StaleDaemonEpoch:
-                raise
-            except Exception as error:
-                print(f"Enoch {provider_label(self.channel_name)} polling error: {error}")
-                time.sleep(5)
+        self._start_cron_scheduler()
+        try:
+            while True:
+                try:
+                    self.run_once()
+                except ShutdownRequested:
+                    raise
+                except StaleDaemonEpoch:
+                    raise
+                except Exception as error:
+                    print(f"Enoch {provider_label(self.channel_name)} polling error: {error}")
+                    time.sleep(5)
+        finally:
+            self._stop_cron_scheduler()
 
     def notify_startup(self) -> None:
         chat_id = _allowed_conversation_id(self.client)
@@ -631,7 +642,6 @@ class EnochApplication:
             )
             for event in self.client.receive(self.offset):
                 self.handle_event(event)
-            self._enqueue_due_cron_jobs()
             self._run_due_evidence_scans()
             self._run_due_evolve_schedule()
             self._maybe_start_task_worker()
@@ -1607,8 +1617,63 @@ class EnochApplication:
             failure_prefix=f"Enoch could not complete direct task #{job.id}",
         )
 
+    def _start_cron_scheduler(self) -> None:
+        with self._cron_scheduler_lock:
+            if self._stopping:
+                return
+            if (
+                self._cron_scheduler_thread is not None
+                and self._cron_scheduler_thread.is_alive()
+            ):
+                return
+            self._cron_scheduler_stop.clear()
+            self._cron_scheduler_wake.clear()
+            self._cron_scheduler_thread = threading.Thread(
+                target=self._run_cron_scheduler,
+                name="enoch-cron-scheduler",
+                daemon=True,
+            )
+            self._cron_scheduler_thread.start()
+
+    def _stop_cron_scheduler(self, timeout_seconds: float = 7.0) -> None:
+        self._cron_scheduler_stop.set()
+        self._cron_scheduler_wake.set()
+        with self._cron_scheduler_lock:
+            worker = self._cron_scheduler_thread
+        if (
+            worker is not None
+            and worker is not threading.current_thread()
+            and worker.is_alive()
+        ):
+            worker.join(timeout=max(0.0, timeout_seconds))
+        with self._cron_scheduler_lock:
+            if (
+                self._cron_scheduler_thread is worker
+                and (worker is None or not worker.is_alive())
+            ):
+                self._cron_scheduler_thread = None
+
+    def _run_cron_scheduler(self) -> None:
+        while not self._stopping and not self._cron_scheduler_stop.is_set():
+            self._cron_scheduler_wake.clear()
+            try:
+                require_current_daemon_epoch(self.daemon_epoch, self.root)
+                self._enqueue_due_cron_jobs()
+                self._maybe_start_task_worker()
+                wait_seconds = cron_scheduler_wait_seconds(self.root)
+            except StaleDaemonEpoch:
+                return
+            except Exception as error:
+                print(f"Enoch cron scheduler error: {error}")
+                wait_seconds = 1.0
+            self._cron_scheduler_wake.wait(timeout=wait_seconds)
+
     def stop_workers(self, timeout_seconds: float = 7.0) -> None:
         self._stopping = True
+        deadline = time.monotonic() + max(0.0, timeout_seconds)
+        self._stop_cron_scheduler(
+            timeout_seconds=max(0.0, deadline - time.monotonic())
+        )
         for cancellation in tuple(self._task_cancellations.values()):
             cancellation.set()
         current = threading.current_thread()
@@ -1617,7 +1682,6 @@ class EnochApplication:
             workers.append(self._task_worker)
         if self._lineage_worker is not None:
             workers.append(self._lineage_worker)
-        deadline = time.monotonic() + max(0.0, timeout_seconds)
         for worker in workers:
             if worker is current or not worker.is_alive():
                 continue
@@ -3062,6 +3126,7 @@ class EnochApplication:
             cancelled = cancel_cron_job(job_id, self.root)
             if cancelled is None:
                 return f"Enoch could not cancel cron #{job_id}. It may already be cancelled or missing."
+            self._cron_scheduler_wake.set()
             return f"Cancelled cron #{cancelled.id}."
         if subcommand != "every":
             return _cron_usage()
@@ -3074,6 +3139,11 @@ class EnochApplication:
         except ValueError as error:
             return str(error)
         snapshot = self._resolve_task_context_snapshot(chat_id, request)
+        if snapshot.codex_unavailable_reason:
+            return (
+                "Enoch could not prepare conversation context for that scheduled "
+                f"job, so no cron job was created: {snapshot.codex_unavailable_reason}"
+            )
         if snapshot.error:
             return f"Enoch could not prepare conversation context for that scheduled job yet: {snapshot.error}"
         if snapshot.clarification:
@@ -3090,6 +3160,7 @@ class EnochApplication:
             )
         except (OSError, ValueError):
             return "Enoch could not schedule that cron job."
+        self._cron_scheduler_wake.set()
         return "\n".join(
             [
                 f"Cron #{job.id} scheduled every {format_cron_interval(job.interval_seconds)}.",
@@ -3098,21 +3169,22 @@ class EnochApplication:
         )
 
     def _maybe_start_task_worker(self) -> None:
-        if self._stopping:
-            return
-        if self._task_worker is not None and self._task_worker.is_alive():
-            return
-        status = self.workflow.inspect()
-        if status.running is not None or status.paused_count:
-            return
-        if status.pending_count == 0 and self._promote_next_backlog_if_idle() is None:
-            return
-        self._task_worker = threading.Thread(
-            target=self._run_task_worker,
-            name="enoch-task-worker",
-            daemon=True,
-        )
-        self._task_worker.start()
+        with self._task_worker_lock:
+            if self._stopping:
+                return
+            if self._task_worker is not None and self._task_worker.is_alive():
+                return
+            status = self.workflow.inspect()
+            if status.running is not None or status.paused_count:
+                return
+            if status.pending_count == 0 and self._promote_next_backlog_if_idle() is None:
+                return
+            self._task_worker = threading.Thread(
+                target=self._run_task_worker,
+                name="enoch-task-worker",
+                daemon=True,
+            )
+            self._task_worker.start()
 
     def _run_task_worker(self) -> None:
         try:
@@ -3125,6 +3197,11 @@ class EnochApplication:
                     if job is None:
                         return
                 self._run_task_job(job)
+                self._cron_scheduler_wake.set()
+                try:
+                    self._enqueue_due_cron_jobs()
+                except Exception as error:
+                    print(f"Enoch cron scheduler error after task completion: {error}")
                 if self.workflow.inspect().paused_count:
                     return
         except StaleDaemonEpoch:
@@ -3184,12 +3261,24 @@ class EnochApplication:
         return job
 
     def _enqueue_due_cron_jobs(self) -> tuple[TaskJob, ...]:
-        jobs: list[TaskJob] = []
-        for cron in claim_due_cron_jobs(self.root):
+        claimed = tuple(
+            sorted(
+                claim_due_cron_jobs(self.root),
+                key=lambda cron: (cron.next_run_at, cron.id),
+            )
+        )
+        eligible = tuple(
+            cron
+            for cron in claimed
+            if not self._cron_task_is_outstanding(cron)
+        )
+        enqueued: dict[int, TaskJob] = {}
+        for cron in reversed(eligible):
             try:
                 job = self.workflow.enqueue(
                     cron.chat_id,
                     cron.text,
+                    mode="front",
                     context=cron.context,
                     context_source=f"cron:{cron.context_source}" if cron.context_source else "cron",
                     source="task",
@@ -3207,6 +3296,13 @@ class EnochApplication:
                 self.root,
                 claim_id=cron.claim_id,
             )
+            enqueued[cron.id] = job
+
+        jobs: list[TaskJob] = []
+        for cron in eligible:
+            job = enqueued.get(cron.id)
+            if job is None:
+                continue
             jobs.append(job)
             message = self._format_work_status(
                 WorkStatusMessage(
@@ -3229,6 +3325,12 @@ class EnochApplication:
                 self._work_status_messages[job.id] = message_id
                 self.workflow.record_status_message(job.id, message_id)
         return tuple(jobs)
+
+    def _cron_task_is_outstanding(self, cron: CronJob) -> bool:
+        if cron.last_task_id is None:
+            return False
+        task = self.workflow.find(cron.last_task_id)
+        return task is not None and task.status in {"pending", "running", "paused"}
 
     def _scan_evidence_sources(
         self,

--- a/src/enoch/app/presentation.py
+++ b/src/enoch/app/presentation.py
@@ -209,6 +209,8 @@ def cron_usage() -> str:
         [
             "Use /cron every <interval> <request> to schedule recurring work.",
             "Intervals can be like 10m, 2h, or 1d.",
+            "Intervals stay anchored; missed runs coalesce into one run as soon as Enoch returns.",
+            "A schedule keeps at most one task outstanding, and due work goes to the front of the queue.",
             "Use /cron cancel <id> to cancel a scheduled job.",
             "Use /cron to show scheduled jobs.",
         ]

--- a/src/enoch/cron.py
+++ b/src/enoch/cron.py
@@ -13,7 +13,7 @@ from enoch.providers.contracts import ConversationId, normalize_conversation_id
 from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 _INTERVAL_PATTERN = re.compile(
     r"^\s*(?P<count>\d+)\s*(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
     re.IGNORECASE,
@@ -22,12 +22,21 @@ _INTERVAL_PATTERN = re.compile(
 
 @dataclass(frozen=True)
 class CronJob:
+    """A fixed-rate recurring task schedule.
+
+    ``next_run_at`` is the next anchored target time. ``last_scheduled_at`` is
+    the target represented by the most recently admitted occurrence, while
+    ``last_run_at`` is when that occurrence was actually handed to the task
+    queue. Missed target times are coalesced into one immediate occurrence.
+    """
+
     id: int
     chat_id: ConversationId
     text: str
     interval_seconds: int
     created_at: str
     next_run_at: str
+    last_scheduled_at: str = ""
     last_run_at: str = ""
     completed_at: str = ""
     status: str = "active"
@@ -184,6 +193,13 @@ def record_cron_task(
     claim_id: str = "",
     now: datetime | None = None,
 ) -> CronJob | None:
+    """Acknowledge one claimed occurrence after its task is durable.
+
+    Interval schedules are fixed-rate rather than fixed-delay: the following
+    target is calculated from the acknowledged occurrence's scheduled target,
+    skipping missed slots until the first target strictly after ``now``.
+    """
+
     current = _coerce_utc(now) if now is not None else _utc_now()
     with _cron_transaction(root):
         data = _load_cron(root)
@@ -196,11 +212,21 @@ def record_cron_task(
                     continue
                 changes: dict[str, object] = {"last_task_id": task_id}
                 if job.claim_id and claim_id:
+                    scheduled_for = _parse_time(job.next_run_at)
                     changes.update(
                         {
-                            "last_run_at": job.claimed_at or _iso(current),
+                            "last_scheduled_at": (
+                                _iso(scheduled_for)
+                                if scheduled_for is not None
+                                else job.next_run_at
+                            ),
+                            "last_run_at": _iso(current),
                             "next_run_at": _iso(
-                                current + timedelta(seconds=job.interval_seconds)
+                                _next_interval_run(
+                                    scheduled_for,
+                                    job.interval_seconds,
+                                    current,
+                                )
                             ),
                             "claim_id": "",
                             "claimed_at": "",
@@ -225,6 +251,33 @@ def cron_status(root: Path | None = None) -> CronStatus:
             active=active,
             history=tuple(_history_jobs(data)),
         )
+
+
+def cron_scheduler_wait_seconds(
+    root: Path | None = None,
+    *,
+    now: datetime | None = None,
+    max_wait_seconds: float = 5.0,
+    claimed_retry_seconds: float = 1.0,
+) -> float:
+    """Return a bounded independent-scheduler sleep interval."""
+
+    if max_wait_seconds <= 0 or claimed_retry_seconds <= 0:
+        raise ValueError("Cron scheduler wait intervals must be greater than zero.")
+    current = _coerce_utc(now) if now is not None else _utc_now()
+    waits: list[float] = []
+    for job in cron_status(root).active:
+        if job.claim_id:
+            waits.append(claimed_retry_seconds)
+            continue
+        next_run_at = _parse_time(job.next_run_at)
+        if next_run_at is None:
+            waits.append(claimed_retry_seconds)
+            continue
+        waits.append(max(0.0, (next_run_at - current).total_seconds()))
+    if not waits:
+        return max_wait_seconds
+    return max(0.05, min(max_wait_seconds, *waits))
 
 
 def _load_cron(root: Path | None = None) -> dict:
@@ -288,6 +341,7 @@ def _parse_job(raw: object) -> CronJob | None:
     interval_seconds = _int(raw.get("interval_seconds"))
     created_at = str(raw.get("created_at") or "").strip()
     next_run_at = str(raw.get("next_run_at") or "").strip()
+    last_scheduled_at = str(raw.get("last_scheduled_at") or "").strip()
     last_run_at = str(raw.get("last_run_at") or "").strip()
     completed_at = str(raw.get("completed_at") or "").strip()
     status = str(raw.get("status") or "").strip() or "active"
@@ -306,6 +360,7 @@ def _parse_job(raw: object) -> CronJob | None:
         interval_seconds=interval_seconds,
         created_at=created_at,
         next_run_at=next_run_at,
+        last_scheduled_at=last_scheduled_at,
         last_run_at=last_run_at,
         completed_at=completed_at,
         status=status,
@@ -328,6 +383,7 @@ def _job_to_dict(job: CronJob | None) -> dict:
         "interval_seconds": job.interval_seconds,
         "created_at": job.created_at,
         "next_run_at": job.next_run_at,
+        "last_scheduled_at": job.last_scheduled_at,
         "last_run_at": job.last_run_at,
         "completed_at": job.completed_at,
         "status": job.status,
@@ -348,6 +404,7 @@ def _replace_job(job: CronJob, **changes: object) -> CronJob:
         "interval_seconds": job.interval_seconds,
         "created_at": job.created_at,
         "next_run_at": job.next_run_at,
+        "last_scheduled_at": job.last_scheduled_at,
         "last_run_at": job.last_run_at,
         "completed_at": job.completed_at,
         "status": job.status,
@@ -370,6 +427,23 @@ def _parse_time(value: str) -> datetime | None:
     except ValueError:
         return None
     return _coerce_utc(parsed)
+
+
+def _next_interval_run(
+    scheduled_for: datetime | None,
+    interval_seconds: int,
+    current: datetime,
+) -> datetime:
+    """Return the first anchored interval target strictly after ``current``."""
+
+    current = _coerce_utc(current)
+    if scheduled_for is None:
+        return current + timedelta(seconds=interval_seconds)
+    candidate = _coerce_utc(scheduled_for) + timedelta(seconds=interval_seconds)
+    if candidate > current:
+        return candidate
+    missed = int((current - candidate).total_seconds() // interval_seconds) + 1
+    return candidate + timedelta(seconds=missed * interval_seconds)
 
 
 def _utc_now() -> datetime:

--- a/src/enoch/private_state.py
+++ b/src/enoch/private_state.py
@@ -108,7 +108,7 @@ STATE_FILE_SCHEMAS = (
     ),
     StateFileSchema(
         "cron.json",
-        3,
+        4,
         (("next_id", 1), ("active", []), ("history", [])),
         (("next_id", (int,)), ("active", (list,)), ("history", (list,))),
     ),

--- a/src/enoch/skills/work/SKILL.md
+++ b/src/enoch/skills/work/SKILL.md
@@ -36,7 +36,12 @@ When work is queued:
    failed, elapsed time, latest update, and review URLs.
 4. Run queued work through the same authorized repository workflow as foreground `/do` work.
 5. Promote backlog items only when the task queue is idle.
-6. Claim due cron jobs atomically before enqueueing them, so one due event creates one task.
+6. Run cron checks in an independent scheduler rather than after chat polling.
+   Claim due occurrences atomically and enqueue them at the front of the task
+   queue. Keep at most one pending, running, or paused task per schedule.
+   Interval targets are fixed-rate: after downtime, coalesce missed targets
+   into one immediate task and advance to the first anchored target still in
+   the future.
 7. When agent runtime authentication, quota, or rate limits are unavailable, move the
    active task to `paused`, stop the worker before it consumes later tasks, and
    warn the human. `/task resume <id|all>` moves selected paused tasks back to

--- a/tests/test_enoch_cron.py
+++ b/tests/test_enoch_cron.py
@@ -12,6 +12,7 @@ from enoch.cron import (
     add_cron_job,
     cancel_cron_job,
     claim_due_cron_jobs,
+    cron_scheduler_wait_seconds,
     cron_status,
     format_cron_interval,
     parse_cron_interval,
@@ -76,8 +77,52 @@ class EnochCronTests(unittest.TestCase):
         self.assertEqual(still_claimed[0].claim_id, claimed[0].claim_id)
         self.assertIsNotNone(recorded)
         self.assertEqual(after_ack, ())
+        self.assertEqual(status.active[0].last_scheduled_at, "2026-06-30T12:10:00+00:00")
         self.assertEqual(status.active[0].last_run_at, "2026-06-30T12:10:00+00:00")
         self.assertEqual(status.active[0].next_run_at, "2026-06-30T12:20:00+00:00")
+
+    def test_missed_runs_coalesce_and_preserve_fixed_rate_anchor(self) -> None:
+        start = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+        restarted = datetime(2026, 6, 30, 12, 37, tzinfo=timezone.utc)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            job = add_cron_job(42, "run scheduled work", 600, root, now=start)
+
+            claimed = claim_due_cron_jobs(root, now=restarted)
+            recorded = record_cron_task(
+                job.id,
+                7,
+                root,
+                claim_id=claimed[0].claim_id,
+                now=restarted,
+            )
+
+        assert recorded is not None
+        self.assertEqual(recorded.last_scheduled_at, "2026-06-30T12:10:00+00:00")
+        self.assertEqual(recorded.last_run_at, "2026-06-30T12:37:00+00:00")
+        self.assertEqual(recorded.next_run_at, "2026-06-30T12:40:00+00:00")
+
+    def test_scheduler_wait_is_bounded_by_next_target_and_claim_retry(self) -> None:
+        start = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            add_cron_job(42, "run scheduled work", 10, root, now=start)
+
+            before_due = cron_scheduler_wait_seconds(
+                root,
+                now=datetime(2026, 6, 30, 12, 0, 8, tzinfo=timezone.utc),
+            )
+            claim_due_cron_jobs(
+                root,
+                now=datetime(2026, 6, 30, 12, 0, 10, tzinfo=timezone.utc),
+            )
+            claimed = cron_scheduler_wait_seconds(
+                root,
+                now=datetime(2026, 6, 30, 12, 0, 10, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(before_due, 2.0)
+        self.assertEqual(claimed, 1.0)
 
     def test_cancel_and_record_last_task(self) -> None:
         with TemporaryDirectory() as temp:

--- a/tests/test_enoch_private_state.py
+++ b/tests/test_enoch_private_state.py
@@ -116,6 +116,40 @@ class EnochPrivateStateTests(unittest.TestCase):
         self.assertFalse(second.applied)
         self.assertFalse(second.plan.migration_required)
 
+    def test_cron_state_migration_adds_fixed_rate_timing_metadata(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = root / ".enoch"
+            state.mkdir()
+            cron = state / "cron.json"
+            cron.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 3,
+                        "next_id": 2,
+                        "active": [
+                            {
+                                "id": 1,
+                                "chat_id": 42,
+                                "text": "scheduled work",
+                                "interval_seconds": 600,
+                                "created_at": "2026-07-25T00:00:00+00:00",
+                                "next_run_at": "2026-07-25T00:10:00+00:00",
+                            }
+                        ],
+                        "history": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = migrate_private_state(root)
+            migrated = json.loads(cron.read_text(encoding="utf-8"))
+
+        self.assertTrue(result.applied)
+        self.assertEqual(migrated["schema_version"], 4)
+        self.assertEqual(migrated["active"][0]["last_scheduled_at"], "")
+
     def test_renamed_brainstorm_schema_is_a_migratable_manifest_alias(self) -> None:
         with TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -3551,6 +3551,34 @@ class EnochTelegramTests(unittest.TestCase):
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")
+    def test_cron_command_does_not_ignore_unavailable_context_snapshot(
+        self,
+        _log_conversation_turn: MagicMock,
+        _update_memory: MagicMock,
+    ) -> None:
+        self.resolve_task_context_snapshot.return_value = TaskContextSnapshot(
+            codex_unavailable_reason="Codex authentication is unavailable.",
+        )
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochApplication(load_identity(), root, client)
+
+            _handle_update(
+                bot,
+                _message_update(
+                    chat_id=42,
+                    text="/cron every 10m run scheduled cleanup",
+                ),
+            )
+            status = cron_status(root)
+
+        self.assertEqual(status.active, ())
+        self.assertIn("no cron job was created", client.sent[0][1])
+        self.assertIn("Codex authentication is unavailable", client.sent[0][1])
+
+    @patch("enoch.app.core.ensure_long_term_memory")
+    @patch("enoch.app.core.log_conversation_turn")
     def test_cron_command_can_cancel_and_report(
         self,
         _log_conversation_turn: MagicMock,
@@ -3606,6 +3634,91 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertEqual(cron_after.active[0].last_task_id, queued.pending[0].id)
         self.assertIn("Task #1", client.sent[0][1])
         self.assertIn("Latest update: Scheduled by cron #1.", client.sent[0][1])
+
+    def test_due_cron_runs_at_front_with_only_one_outstanding_task(self) -> None:
+        start = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        first_due = datetime(2020, 1, 1, 0, 1, tzinfo=timezone.utc)
+        second_due = datetime(2020, 1, 1, 0, 2, tzinfo=timezone.utc)
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochApplication(load_identity(), root, client)
+            ordinary = enqueue_task(42, "ordinary queued work", root)
+            cron = add_cron_job(
+                42,
+                "scheduled cleanup",
+                60,
+                root,
+                now=start,
+            )
+
+            with patch("enoch.cron._utc_now", return_value=first_due):
+                first = bot._enqueue_due_cron_jobs()
+            first_queue = task_queue_status(root)
+
+            with patch("enoch.cron._utc_now", return_value=second_due):
+                duplicate = bot._enqueue_due_cron_jobs()
+            blocked_queue = task_queue_status(root)
+
+            running = begin_next_task(root)
+            assert running is not None
+            complete_task(running.id, root, result="Done.")
+            with patch(
+                "enoch.cron._utc_now",
+                return_value=datetime(2020, 1, 1, 0, 2, 30, tzinfo=timezone.utc),
+            ):
+                second = bot._enqueue_due_cron_jobs()
+            resumed_queue = task_queue_status(root)
+            cron_after = cron_status(root).active[0]
+
+        self.assertEqual([job.id for job in first], [ordinary.id + 1])
+        self.assertEqual(
+            [job.id for job in first_queue.pending],
+            [first[0].id, ordinary.id],
+        )
+        self.assertEqual(duplicate, ())
+        self.assertEqual(
+            [job.id for job in blocked_queue.pending],
+            [first[0].id, ordinary.id],
+        )
+        self.assertEqual([job.id for job in second], [first[0].id + 1])
+        self.assertEqual(
+            [job.id for job in resumed_queue.pending],
+            [second[0].id, ordinary.id],
+        )
+        self.assertEqual(cron_after.id, cron.id)
+        self.assertEqual(cron_after.last_task_id, second[0].id)
+        self.assertEqual(cron_after.last_scheduled_at, "2020-01-01T00:02:00+00:00")
+        self.assertEqual(cron_after.next_run_at, "2020-01-01T00:03:00+00:00")
+
+    def test_cron_scheduler_runs_independently_of_chat_polling(self) -> None:
+        scheduled = threading.Event()
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            client = FakeTelegramClient(allowed_chat_id=42)
+            bot = EnochApplication(load_identity(), root, client)
+            add_cron_job(
+                42,
+                "scheduled cleanup",
+                60,
+                root,
+                now=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            )
+
+            try:
+                with patch.object(
+                    bot,
+                    "_maybe_start_task_worker",
+                    side_effect=scheduled.set,
+                ):
+                    bot._start_cron_scheduler()
+                    self.assertTrue(scheduled.wait(timeout=2.0))
+            finally:
+                bot._stop_cron_scheduler(timeout_seconds=1.0)
+            queued = task_queue_status(root)
+
+        self.assertEqual(queued.pending_count, 1)
+        self.assertEqual(queued.pending[0].trigger, "cron:1")
 
     @patch("enoch.app.core.ensure_long_term_memory")
     @patch("enoch.app.core.log_conversation_turn")


### PR DESCRIPTION
## Summary

- run task-cron checks in an independent scheduler instead of after chat polling
- enqueue due cron work at the front while allowing only one pending, running, or paused task per schedule
- define fixed-rate anchored interval semantics and coalesce missed runs into one ASAP occurrence after restart
- reject cron creation when Codex cannot produce the requested conversation-context snapshot
- migrate cron state to schema 4 and document the scheduling guarantees

## Why

Cron timing was coupled to the chat provider's blocking receive loop, due work could accumulate without bounds, delayed acknowledgements caused schedule drift, and one runtime-access error path silently created a schedule without context.

## Validation

- `bin/enoch doctor` — passed
- focused cron, migration, Telegram integration, and daemon-loop tests — 25 passed
- direct host-Python suite — 752 tests passed; one unrelated portable-wheel test could not import the host interpreter's missing `setuptools.build_meta`; the managed Doctor environment passed that test and build-backend check
- `git diff --check` — passed