### PR TITLE
Add interactive Telegram help navigation

### DIFF
--- a/libraries/telegram/src/our_ark_telegram/__init__.py
+++ b/libraries/telegram/src/our_ark_telegram/__init__.py
@@ -10,8 +10,12 @@ from our_ark_telegram.core import (
 )
 from our_ark_telegram.integration import load_config, setup_provider
 from our_ark_telegram.presentation import (
+    HELP_CALLBACK_PREFIX,
+    HELP_NAVIGATION_MODES,
     TelegramMessageChunk,
     render_telegram_html,
+    telegram_help_callback_command,
+    telegram_help_reply_markup,
     telegram_message_chunks,
 )
 
@@ -34,6 +38,8 @@ OUR_ARK_PROVIDERS = (
 
 
 __all__ = [
+    "HELP_CALLBACK_PREFIX",
+    "HELP_NAVIGATION_MODES",
     "MAX_TELEGRAM_MESSAGE",
     "READ_ACK_EMOJI",
     "TELEGRAM_API",
@@ -46,6 +52,8 @@ __all__ = [
     "setup_provider",
     "chunks",
     "render_telegram_html",
+    "telegram_help_callback_command",
+    "telegram_help_reply_markup",
     "telegram_message_chunks",
     "telegram_event",
 ]

--- a/libraries/telegram/src/our_ark_telegram/core.py
+++ b/libraries/telegram/src/our_ark_telegram/core.py
@@ -16,6 +16,8 @@ from our_ark_provider_kit import (
 from our_ark_telegram.presentation import (
     is_formatting_error,
     render_telegram_html,
+    telegram_help_callback_command,
+    telegram_help_reply_markup,
     telegram_message_chunks,
 )
 
@@ -44,17 +46,29 @@ class TelegramClient:
 
     def __init__(self, config: TelegramConfig) -> None:
         self.config = config
+        self._help_navigation: tuple[
+            str,
+            tuple[tuple[str, str], ...],
+        ] | None = None
 
     @property
     def allowed_conversation_id(self) -> ConversationId | None:
         return self.config.allowed_chat_id
 
     def receive(self, cursor: int | None = None) -> list[ChatEvent]:
-        return [
-            event
-            for update in self.get_updates(cursor)
-            if (event := telegram_event(update)) is not None
-        ]
+        events: list[ChatEvent] = []
+        for update in self.get_updates(cursor):
+            event = telegram_event(update)
+            if event is None:
+                continue
+            callback_id = _help_callback_id(update)
+            if callback_id:
+                self._call(
+                    "answerCallbackQuery",
+                    {"callback_query_id": callback_id},
+                )
+            events.append(event)
+        return events
 
     def get_updates(self, offset: int | None = None) -> list[dict[str, Any]]:
         payload: dict[str, Any] = {"timeout": self.config.poll_timeout}
@@ -68,15 +82,29 @@ class TelegramClient:
         conversation_id: ConversationId,
         text: str,
     ) -> MessageId | None:
+        navigation = self._take_help_navigation()
+        reply_markup = (
+            telegram_help_reply_markup(*navigation)
+            if navigation is not None
+            else None
+        )
         first_message_id: int | None = None
-        for chunk in telegram_message_chunks(text, MAX_TELEGRAM_MESSAGE):
+        message_chunks = telegram_message_chunks(text, MAX_TELEGRAM_MESSAGE)
+        for index, chunk in enumerate(message_chunks):
+            payload: dict[str, Any] = {
+                "chat_id": conversation_id,
+                "text": chunk.html,
+                "parse_mode": "HTML",
+            }
+            if reply_markup is not None and index == len(message_chunks) - 1:
+                payload["reply_markup"] = json.dumps(
+                    reply_markup,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
             data = self._call_with_plain_fallback(
                 "sendMessage",
-                {
-                    "chat_id": conversation_id,
-                    "text": chunk.html,
-                    "parse_mode": "HTML",
-                },
+                payload,
                 plain_text=chunk.plain,
             )
             message_id = _message_id(data)
@@ -123,16 +151,43 @@ class TelegramClient:
         message_id: MessageId,
         text: str,
     ) -> None:
-        self._call_with_plain_fallback(
-            "editMessageText",
-            {
-                "chat_id": conversation_id,
-                "message_id": message_id,
-                "text": render_telegram_html(text),
-                "parse_mode": "HTML",
-            },
-            plain_text=text,
-        )
+        navigation = self._take_help_navigation()
+        payload: dict[str, Any] = {
+            "chat_id": conversation_id,
+            "message_id": message_id,
+            "text": render_telegram_html(text),
+            "parse_mode": "HTML",
+        }
+        if navigation is not None:
+            payload["reply_markup"] = json.dumps(
+                telegram_help_reply_markup(*navigation),
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        try:
+            self._call_with_plain_fallback(
+                "editMessageText",
+                payload,
+                plain_text=text,
+            )
+        except TelegramError as error:
+            if "message is not modified" not in str(error).lower():
+                raise
+
+    def prepare_help_navigation(
+        self,
+        mode: str,
+        entries: tuple[tuple[str, str], ...],
+    ) -> None:
+        self._help_navigation = (mode, tuple(entries))
+
+    def clear_help_navigation(self) -> None:
+        self._help_navigation = None
+
+    def interaction_reply_target(self, event: ChatEvent) -> MessageId | None:
+        if _help_callback_id(event.raw):
+            return event.message_id
+        return None
 
     def send_read_ack(
         self,
@@ -151,6 +206,13 @@ class TelegramClient:
                 "reaction": reaction,
             },
         )
+
+    def _take_help_navigation(
+        self,
+    ) -> tuple[str, tuple[tuple[str, str], ...]] | None:
+        navigation = self._help_navigation
+        self._help_navigation = None
+        return navigation
 
     def _call(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
         url = f"{TELEGRAM_API}/bot{self.config.token}/{method}"
@@ -185,11 +247,23 @@ class TelegramClient:
 
 def telegram_event(update: dict[str, Any]) -> ChatEvent | None:
     update_id = update.get("update_id")
-    message = update.get("message") or {}
+    callback = update.get("callback_query")
+    callback_command = (
+        telegram_help_callback_command(str(callback.get("data") or ""))
+        if isinstance(callback, dict)
+        else None
+    )
+    message = (
+        callback.get("message") or {}
+        if callback_command is not None and isinstance(callback, dict)
+        else update.get("message") or {}
+    )
     chat = message.get("chat") or {}
     chat_id = chat.get("id")
     message_id = message.get("message_id")
-    text = str(message.get("text") or message.get("caption") or "").strip()
+    text = callback_command or str(
+        message.get("text") or message.get("caption") or ""
+    ).strip()
     attachments = _attachments(message)
     has_supported_image = any(
         item.kind == "image" and item.file_id for item in attachments
@@ -209,6 +283,16 @@ def telegram_event(update: dict[str, Any]) -> ChatEvent | None:
         raw=update,
         attachments=attachments,
     )
+
+
+def _help_callback_id(update: dict[str, Any]) -> str:
+    callback = update.get("callback_query")
+    if not isinstance(callback, dict):
+        return ""
+    if telegram_help_callback_command(str(callback.get("data") or "")) is None:
+        return ""
+    callback_id = callback.get("id")
+    return callback_id if isinstance(callback_id, str) else ""
 
 
 def chunks(text: str, size: int = MAX_TELEGRAM_MESSAGE) -> list[str]:

--- a/libraries/telegram/src/our_ark_telegram/presentation/__init__.py
+++ b/libraries/telegram/src/our_ark_telegram/presentation/__init__.py
@@ -1,3 +1,9 @@
+from our_ark_telegram.presentation.help import (
+    HELP_CALLBACK_PREFIX,
+    HELP_NAVIGATION_MODES,
+    telegram_help_callback_command,
+    telegram_help_reply_markup,
+)
 from our_ark_telegram.presentation.model import TelegramMessageChunk
 from our_ark_telegram.presentation.renderer import (
     is_formatting_error,
@@ -7,8 +13,12 @@ from our_ark_telegram.presentation.renderer import (
 
 
 __all__ = [
+    "HELP_CALLBACK_PREFIX",
+    "HELP_NAVIGATION_MODES",
     "TelegramMessageChunk",
     "is_formatting_error",
     "render_telegram_html",
+    "telegram_help_callback_command",
+    "telegram_help_reply_markup",
     "telegram_message_chunks",
 ]

--- a/libraries/telegram/src/our_ark_telegram/presentation/help.py
+++ b/libraries/telegram/src/our_ark_telegram/presentation/help.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+
+HELP_CALLBACK_PREFIX = "enoch:help"
+HELP_NAVIGATION_MODES = frozenset({"overview", "section", "command"})
+_HELP_TARGET_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+_HELP_CALLBACK_RE = re.compile(
+    rf"^{re.escape(HELP_CALLBACK_PREFIX)}:(?P<kind>[sc]):"
+    r"(?P<target>[a-z][a-z0-9_-]{0,31})$"
+)
+
+
+def telegram_help_reply_markup(
+    mode: str,
+    entries: Iterable[tuple[str, str]],
+) -> dict[str, list[list[dict[str, str]]]]:
+    """Build a Telegram inline keyboard for one registry-backed help view."""
+
+    normalized_mode = mode.strip().lower()
+    if normalized_mode not in HELP_NAVIGATION_MODES:
+        raise ValueError(f"Unsupported Telegram help navigation mode: {mode!r}")
+
+    kind = "s" if normalized_mode == "overview" else "c"
+    buttons = [
+        {
+            "text": _button_label(label),
+            "callback_data": _callback_data(kind, target),
+        }
+        for label, target in entries
+    ]
+    rows = [buttons[index : index + 2] for index in range(0, len(buttons), 2)]
+    if normalized_mode != "overview":
+        rows.append(
+            [
+                {
+                    "text": "← All commands",
+                    "callback_data": f"{HELP_CALLBACK_PREFIX}:h",
+                }
+            ]
+        )
+    return {"inline_keyboard": rows}
+
+
+def telegram_help_callback_command(data: str) -> str | None:
+    """Translate a validated Telegram help callback into internal command text."""
+
+    normalized = data.strip().lower()
+    if normalized == f"{HELP_CALLBACK_PREFIX}:h":
+        return "/help"
+    match = _HELP_CALLBACK_RE.fullmatch(normalized)
+    if match is None:
+        return None
+    target = match.group("target")
+    if match.group("kind") == "s":
+        return f"/help section:{target}"
+    return f"/help {target}"
+
+
+def _button_label(value: str) -> str:
+    label = str(value).strip()
+    if not label:
+        raise ValueError("Telegram help button labels cannot be empty.")
+    return label
+
+
+def _callback_data(kind: str, value: str) -> str:
+    target = str(value).strip().lower()
+    if _HELP_TARGET_RE.fullmatch(target) is None:
+        raise ValueError(f"Invalid Telegram help target: {value!r}")
+    return f"{HELP_CALLBACK_PREFIX}:{kind}:{target}"

--- a/libraries/telegram/tests/test_help_navigation.py
+++ b/libraries/telegram/tests/test_help_navigation.py
@@ -1,0 +1,195 @@
+import json
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROVIDER_KIT = ROOT.parent / "provider-kit"
+sys.path.insert(0, str(PROVIDER_KIT / "src"))
+sys.path.insert(0, str(ROOT / "src"))
+
+from our_ark_telegram import (
+    TelegramClient,
+    TelegramConfig,
+    TelegramError,
+    telegram_event,
+    telegram_help_callback_command,
+    telegram_help_reply_markup,
+)
+
+
+class TelegramHelpNavigationTests(unittest.TestCase):
+    def test_renderer_builds_overview_section_and_command_keyboards(self) -> None:
+        overview = telegram_help_reply_markup(
+            "overview",
+            (
+                ("Common", "common"),
+                ("Work", "work"),
+                ("Evolve", "evolve"),
+            ),
+        )
+        self.assertEqual(
+            overview,
+            {
+                "inline_keyboard": [
+                    [
+                        {
+                            "text": "Common",
+                            "callback_data": "enoch:help:s:common",
+                        },
+                        {
+                            "text": "Work",
+                            "callback_data": "enoch:help:s:work",
+                        },
+                    ],
+                    [
+                        {
+                            "text": "Evolve",
+                            "callback_data": "enoch:help:s:evolve",
+                        }
+                    ],
+                ]
+            },
+        )
+
+        section = telegram_help_reply_markup(
+            "section",
+            (("/do", "do"), ("/task", "task"), ("/queue", "queue")),
+        )
+        self.assertEqual(
+            section["inline_keyboard"][-1],
+            [
+                {
+                    "text": "← All commands",
+                    "callback_data": "enoch:help:h",
+                }
+            ],
+        )
+        self.assertEqual(
+            section["inline_keyboard"][0],
+            [
+                {"text": "/do", "callback_data": "enoch:help:c:do"},
+                {"text": "/task", "callback_data": "enoch:help:c:task"},
+            ],
+        )
+
+        command = telegram_help_reply_markup("command", ())
+        self.assertEqual(
+            command,
+            {
+                "inline_keyboard": [
+                    [
+                        {
+                            "text": "← All commands",
+                            "callback_data": "enoch:help:h",
+                        }
+                    ]
+                ]
+            },
+        )
+
+    def test_client_attaches_navigation_once_at_delivery_time(self) -> None:
+        client = TelegramClient(TelegramConfig(token="test"))
+        calls = []
+
+        def fake_call(method, payload):
+            calls.append((method, payload))
+            return {"ok": True, "result": {"message_id": 9}}
+
+        client._call = fake_call
+        client.prepare_help_navigation(
+            "overview",
+            (("Common", "common"), ("Work", "work")),
+        )
+
+        client.send_message(42, "Enoch commands:")
+        client.send_message(42, "ordinary response")
+
+        markup = json.loads(calls[0][1]["reply_markup"])
+        self.assertEqual(markup["inline_keyboard"][0][0]["text"], "Common")
+        self.assertNotIn("reply_markup", calls[1][1])
+
+    def test_callback_updates_become_help_commands(self) -> None:
+        update = {
+            "update_id": 8,
+            "callback_query": {
+                "id": "callback-1",
+                "data": "enoch:help:s:work",
+                "message": {
+                    "message_id": 4,
+                    "chat": {"id": 42},
+                    "text": "Enoch commands:",
+                },
+            },
+        }
+
+        event = telegram_event(update)
+
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(event.cursor, 9)
+        self.assertEqual(event.conversation_id, 42)
+        self.assertEqual(event.message_id, 4)
+        self.assertEqual(event.text, "/help section:work")
+        self.assertEqual(
+            telegram_help_callback_command("enoch:help:h"),
+            "/help",
+        )
+        self.assertIsNone(
+            telegram_help_callback_command("enoch:help:c:../../restart")
+        )
+
+    def test_receive_acknowledges_recognized_callback(self) -> None:
+        client = TelegramClient(TelegramConfig(token="test"))
+        calls = []
+        update = {
+            "update_id": 8,
+            "callback_query": {
+                "id": "callback-1",
+                "data": "enoch:help:c:cron",
+                "message": {
+                    "message_id": 4,
+                    "chat": {"id": 42},
+                    "text": "Work commands:",
+                },
+            },
+        }
+
+        def fake_call(method, payload):
+            calls.append((method, payload))
+            if method == "getUpdates":
+                return {"ok": True, "result": [update]}
+            return {"ok": True, "result": True}
+
+        client._call = fake_call
+
+        events = client.receive()
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].text, "/help cron")
+        self.assertEqual(
+            calls[1],
+            (
+                "answerCallbackQuery",
+                {"callback_query_id": "callback-1"},
+            ),
+        )
+
+    def test_repeated_button_edit_treats_unchanged_message_as_success(self) -> None:
+        client = TelegramClient(TelegramConfig(token="test"))
+
+        def fake_call(_method, _payload):
+            raise TelegramError(
+                "Bad Request: message is not modified: "
+                "specified new message content and reply markup are exactly the same"
+            )
+
+        client._call = fake_call
+        client.prepare_help_navigation("command", ())
+
+        client.edit_message(42, 4, "Cron commands:")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -278,6 +278,9 @@ from enoch.commands import (
     config_command,
     core_command,
     core_command_names,
+    core_command_sections,
+    core_commands_in_section,
+    core_section_topic,
     doctor_command,
     help_message as _help_message,
     identity_summary,
@@ -699,7 +702,8 @@ class EnochApplication:
     def _dispatch_chat_event(self, event: ChatEvent) -> tuple[str, str]:
         chat_id = event.conversation_id
         text = event.text.strip()
-        self._safe_send_read_ack(chat_id, event.message_id)
+        if self._interaction_reply_target(event) is None:
+            self._safe_send_read_ack(chat_id, event.message_id)
         try:
             self.authorization.require(
                 "runtime.reset-usage",
@@ -741,16 +745,30 @@ class EnochApplication:
         return reply, logged_input
 
     def _finish_chat_event(self, event: ChatEvent, receipt: InboxReceipt) -> None:
+        edit_target = self._interaction_reply_target(event)
         if not receipt.reply_sent:
-            delivery = (
-                self._deliver_message(
-                    event.conversation_id,
-                    receipt.reply,
-                    notification_key=f"inbox:{receipt.key}:reply",
-                )
-                if receipt.reply
-                else NotificationResult(delivered=True)
+            presentation_prepared = self._prepare_help_navigation(
+                receipt.logged_input
             )
+            try:
+                if receipt.reply and edit_target is not None:
+                    delivery = self._deliver_message_edit(
+                        event.conversation_id,
+                        edit_target,
+                        receipt.reply,
+                        notification_key=f"inbox:{receipt.key}:reply",
+                    )
+                elif receipt.reply:
+                    delivery = self._deliver_message(
+                        event.conversation_id,
+                        receipt.reply,
+                        notification_key=f"inbox:{receipt.key}:reply",
+                    )
+                else:
+                    delivery = NotificationResult(delivered=True)
+            finally:
+                if presentation_prepared:
+                    self._clear_help_navigation()
             if not delivery.delivered:
                 details = {
                     "provider": self.channel_name,
@@ -768,12 +786,13 @@ class EnochApplication:
                 )
                 if not delivery.terminal:
                     return
-            self._record_turn(
-                event.conversation_id,
-                receipt.logged_input,
-                receipt.reply,
-            )
-            self._flush_session_syncs()
+            if edit_target is None:
+                self._record_turn(
+                    event.conversation_id,
+                    receipt.logged_input,
+                    receipt.reply,
+                )
+                self._flush_session_syncs()
             mark_reply_sent(self.channel_name, receipt.key, self.root)
         self._remember_update_offset(event.cursor)
         acknowledge_event(self.channel_name, receipt.key, self.root)
@@ -824,6 +843,60 @@ class EnochApplication:
             ),
         ]
         return "\n\n".join([core_help, "\n".join(profile_help)])
+
+    def _prepare_help_navigation(self, logged_input: str) -> bool:
+        prepare = getattr(self.client, "prepare_help_navigation", None)
+        if not callable(prepare):
+            return False
+        command, argument = _parse_chat_command(logged_input.strip())
+        if command.lstrip("/").lower() != "help":
+            return False
+
+        topic = argument.strip().lower().lstrip("/")
+        if not topic:
+            entries = tuple(
+                (section, core_section_topic(section))
+                for section in core_command_sections()
+            )
+            prepare("overview", entries)
+            return True
+
+        first_topic = topic.split(maxsplit=1)[0]
+        explicit_section = first_topic.startswith("section:")
+        section_topic = (
+            first_topic.partition(":")[2]
+            if explicit_section
+            else first_topic
+        )
+        section_commands = core_commands_in_section(section_topic)
+        if section_commands and (
+            explicit_section or core_command(first_topic) is None
+        ):
+            prepare(
+                "section",
+                tuple(
+                    (candidate.command, candidate.name)
+                    for candidate in section_commands
+                ),
+            )
+            return True
+
+        prepare("command", ())
+        return True
+
+    def _clear_help_navigation(self) -> None:
+        clear = getattr(self.client, "clear_help_navigation", None)
+        if callable(clear):
+            clear()
+
+    def _interaction_reply_target(
+        self,
+        event: ChatEvent,
+    ) -> MessageId | None:
+        resolve = getattr(self.client, "interaction_reply_target", None)
+        if not callable(resolve):
+            return None
+        return normalize_message_id(resolve(event))
 
     def _run_core_command(
         self,
@@ -1843,6 +1916,33 @@ class EnochApplication:
         try:
             return self.notifications.send(
                 chat_id,
+                message,
+                idempotency_key=key,
+            )
+        except (OSError, ChatProviderError, CapabilityAuthorizationError) as error:
+            return NotificationResult(
+                delivered=False,
+                error=str(error),
+            )
+
+    def _deliver_message_edit(
+        self,
+        chat_id: ConversationId,
+        message_id: MessageId,
+        message: str,
+        *,
+        notification_key: str = "",
+    ) -> NotificationResult:
+        key = notification_key or self._notification_key(
+            "edit",
+            chat_id,
+            message,
+            message_id=message_id,
+        )
+        try:
+            return self.notifications.edit(
+                chat_id,
+                message_id,
                 message,
                 idempotency_key=key,
             )

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -763,9 +763,28 @@ def help_message(topic: str = "", *, chat_provider: str = "chat") -> str:
     del chat_provider
     normalized_topic = _normalize_help_topic(topic)
     if normalized_topic:
+        explicit_section = normalized_topic.startswith("section:")
+        section_topic = (
+            normalized_topic.partition(":")[2]
+            if explicit_section
+            else normalized_topic
+        )
         command = core_command(normalized_topic)
-        if command is not None:
+        if command is not None and not explicit_section:
             return command.usage_message("/")
+        section_commands = core_commands_in_section(section_topic)
+        if section_commands:
+            section = section_commands[0].section
+            return "\n".join(
+                [
+                    f"{section} commands:",
+                    "",
+                    *(command.summary_line("/") for command in section_commands),
+                    "",
+                    "Use /help <command> for detailed usage and subcommands.",
+                    "Use /help to return to every command.",
+                ]
+            )
         return "\n".join(
             [
                 f"No help found for /{normalized_topic}.",
@@ -783,8 +802,7 @@ def help_message(topic: str = "", *, chat_provider: str = "chat") -> str:
     standalone = [command for command in CORE_COMMANDS if not command.section]
     if standalone:
         lines.extend(["", *(command.summary_line("/") for command in standalone)])
-    sections = tuple(dict.fromkeys(command.section for command in CORE_COMMANDS if command.section))
-    for section in sections:
+    for section in core_command_sections():
         lines.extend(
             [
                 "",
@@ -1081,6 +1099,9 @@ CORE_COMMANDS = (
 _CORE_COMMAND_INDEX = {command.name: command for command in CORE_COMMANDS}
 if len(_CORE_COMMAND_INDEX) != len(CORE_COMMANDS):
     raise RuntimeError("Core command registry contains duplicate command names.")
+_CORE_COMMAND_SECTIONS = tuple(
+    dict.fromkeys(command.section for command in CORE_COMMANDS if command.section)
+)
 
 
 def core_command(name: str) -> CoreCommand | None:
@@ -1090,3 +1111,20 @@ def core_command(name: str) -> CoreCommand | None:
 
 def core_command_names() -> frozenset[str]:
     return frozenset(_CORE_COMMAND_INDEX)
+
+
+def core_command_sections() -> tuple[str, ...]:
+    return _CORE_COMMAND_SECTIONS
+
+
+def core_section_topic(section: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", section.strip().lower()).strip("_")
+
+
+def core_commands_in_section(section: str) -> tuple[CoreCommand, ...]:
+    normalized = core_section_topic(section)
+    return tuple(
+        command
+        for command in CORE_COMMANDS
+        if core_section_topic(command.section) == normalized
+    )

--- a/tests/test_enoch_command_registry.py
+++ b/tests/test_enoch_command_registry.py
@@ -55,6 +55,29 @@ class CoreCommandRegistryTests(unittest.TestCase):
         )
         self.assertIn("Example: /help worktree", overview)
 
+    def test_help_section_lists_only_commands_from_that_registry_section(self) -> None:
+        work = help_message("work")
+
+        self.assertTrue(work.startswith("Work commands:"))
+        self.assertIn("/do <request> - run work now instead of queueing it", work)
+        self.assertIn("/cron - show scheduled jobs", work)
+        self.assertNotIn("/status - show identity", work)
+        self.assertIn(
+            "Use /help <command> for detailed usage and subcommands.",
+            work,
+        )
+        self.assertIn("Use /help to return to every command.", work)
+
+        inherit = help_message("section:inherit")
+        self.assertIn(
+            "/ancestors - show ancestor chain and ancestor skills",
+            inherit,
+        )
+        self.assertNotIn(
+            "/ancestors - show ancestor chain and ancestor skills",
+            help_message("inherit"),
+        )
+
     def test_evolve_help_exposes_only_the_consolidated_surface(self) -> None:
         usage = help_message("evolve")
 

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -796,6 +796,30 @@ class EnochTelegramTests(unittest.TestCase):
         self.assertIn("/restart - restart Enoch's chat daemon from the locked conversation", client.sent[0][1])
         self.assertNotIn("/shutdown", client.sent[0][1])
         self.assertIn("say the request naturally", client.sent[0][1])
+        self.assertEqual(client.help_navigation[0][0], "overview")
+        self.assertIn(("Work", "work"), client.help_navigation[0][1])
+
+    def test_help_button_edits_message_without_logging_a_conversation_turn(self) -> None:
+        client = FakeTelegramClient(allowed_chat_id=42)
+        bot = EnochApplication(load_identity(), ROOT, client)
+        self.log_conversation_turn.reset_mock()
+
+        _handle_update(
+            bot,
+            _help_callback_update(
+                data="enoch:help:s:work",
+                message_id=71,
+            ),
+        )
+
+        self.assertEqual(client.sent, [])
+        self.assertEqual(len(client.edited), 1)
+        self.assertEqual(client.edited[0][0:2], (42, 71))
+        self.assertIn("Work commands:", client.edited[0][2])
+        self.assertEqual(client.help_navigation[0][0], "section")
+        self.assertIn(("/cron", "cron"), client.help_navigation[0][1])
+        self.assertEqual(client.acks, [])
+        self.log_conversation_turn.assert_not_called()
 
     def test_every_registered_core_command_has_a_dispatch_handler(self) -> None:
         client = FakeTelegramClient(allowed_chat_id=42)
@@ -5657,6 +5681,8 @@ class FakeTelegramClient:
         self.updates = []
         self.offsets = []
         self.downloads = []
+        self.help_navigation = []
+        self.current_help_navigation = None
 
     def get_updates(self, offset=None):
         self.offsets.append(offset)
@@ -5684,6 +5710,19 @@ class FakeTelegramClient:
     def download_file(self, file_id, destination, *, max_bytes):
         self.downloads.append((file_id, max_bytes))
         destination.write_bytes(b"\xff\xd8\xfftelegram-photo")
+
+    def prepare_help_navigation(self, mode, entries):
+        navigation = (mode, tuple(entries))
+        self.current_help_navigation = navigation
+        self.help_navigation.append(navigation)
+
+    def clear_help_navigation(self):
+        self.current_help_navigation = None
+
+    def interaction_reply_target(self, event):
+        if isinstance(event.raw.get("callback_query"), dict):
+            return event.message_id
+        return None
 
 
 class FailingTelegramClient(FakeTelegramClient):
@@ -5743,6 +5782,27 @@ def _message_update(update_id=1, chat_id=42, text="hello", reply_text=None):
     return {
         "update_id": update_id,
         "message": message,
+    }
+
+
+def _help_callback_update(
+    *,
+    update_id=1,
+    chat_id=42,
+    message_id=1001,
+    data="enoch:help:h",
+):
+    return {
+        "update_id": update_id,
+        "callback_query": {
+            "id": f"callback-{update_id}",
+            "data": data,
+            "message": {
+                "message_id": message_id,
+                "chat": {"id": chat_id},
+                "text": "Enoch commands:",
+            },
+        },
     }
 
 


### PR DESCRIPTION
## What changed

- adds registry-driven inline keyboards to Telegram `/help` responses
- lets section and command buttons edit the existing help message
- acknowledges Telegram callback queries and treats repeated identical edits as successful
- keeps button navigation out of conversation logs and Codex sessions
- preserves the existing text-only help path for other chat providers

## Why

The complete text command list is difficult to navigate in Telegram. This adds a cosmetic, Telegram-specific navigation layer without changing command behavior or generated assistant responses.

## Validation

- tests were written and observed failing before implementation
- `bin/enoch doctor`
- all provider-library test suites
- `git diff --check`