### PR TITLE
Prepare Enoch v0.3.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,11 +7,11 @@ authors:
     given-names: Gary
   - family-names: Zhao
     given-names: Roy
-version: 0.3.0
-date-released: 2026-07-26
+version: 0.3.1
+date-released: 2026-07-27
 license: Apache-2.0
 repository-code: "https://github.com/our-ark/enoch"
-url: "https://github.com/our-ark/enoch/releases/tag/v0.3.0"
+url: "https://github.com/our-ark/enoch/releases/tag/v0.3.1"
 keywords:
   - agent-owned software
   - personal agents

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Genesis is open source at
 [`our-ark/genesis`](https://github.com/our-ark/genesis). The current stable
 public path pairs [Genesis
 v0.1.1](https://github.com/our-ark/genesis/releases/tag/v0.1.1) with [Enoch
-v0.3.0](https://github.com/our-ark/enoch/releases/tag/v0.3.0). The command below
+v0.3.1](https://github.com/our-ark/enoch/releases/tag/v0.3.1). The command below
 uses adjacent clean checkouts so the selected Enoch source is explicit.
 
 Enoch is a public Genesis-compatible reference body. Its `genesis.toml`

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,64 @@
+# Enoch v0.3.1
+
+Enoch v0.3.1 is a reliability and workflow-refinement release. It hardens
+self-validation and scheduled work, gives inheritance, learning, and
+brainstorming clearer assessment boundaries, and removes duplicate lifecycle
+state once evolution work becomes a normal task.
+
+## Highlights
+
+- Added a content-addressed managed validation environment that provisions the
+  hash-locked build backend without modifying the host Python installation.
+  Doctor and `/update` now recover from a missing `setuptools.build_meta`
+  prerequisite instead of repeatedly failing.
+- Redesigned inheritance as a durable direct-parent inbox. New commits and pull
+  requests are assessed in fresh background Codex sessions, while
+  `/inherit inbox`, `/inherit inspect <change-id>`, `/inherit <change-id>`, and
+  `/inherit ignore <change-id>` keep discovery, review, execution, and dismissal
+  separate.
+- Redesigned learning around immutable published-skill snapshots.
+  `/skills <agent>` resolves inspectable skill links, and
+  `/learn <skill> from <agent>` uses a fresh read-only Codex assessment to
+  create a fully attributed evolution candidate only when the skill applies.
+- Replaced the multi-stage brainstorming pipeline with one bounded, stateless
+  Codex turn that produces validated, deduplicated candidates. Existing
+  brainstorm cooldown state migrates safely.
+- Simplified evolution ownership. Approving a candidate now archives its
+  snapshot and queues a normal task; the task journal alone owns retries,
+  worktrees, commits, reviews, and completion.
+- Added a Telegram-specific presentation layer that groups structured records
+  into readable cards while preserving Enoch's original response text for
+  fallback and debugging.
+- Decoupled cron scheduling from chat polling, coalesced missed runs into one
+  ASAP run after restart, prevented duplicate outstanding schedule work,
+  prioritized due cron tasks, and made timing and context-snapshot failures
+  explicit.
+- Updated the immutable Telegram and GitHub provider pins to the revisions that
+  contain this release's presentation and inheritance changes.
+
+## Validation
+
+- The 753-test Enoch body suite passes.
+- The 72 provider and library tests pass independently.
+- Doctor passes in the managed validation environment, including the portable
+  wheel-install E2E and authenticated Codex and GitHub readiness checks.
+- GitHub Actions covers Python 3.11, 3.12, 3.13, and 3.14.
+
+## Compatibility
+
+- Python 3.11 or newer.
+- `genesis.toml` schema version 1.
+- Workflow API version 3.
+- Profile API version 5.
+- Provider-kit `0.7.0`.
+- Genesis v0.1.1 or a later compatible build.
+- Existing inheritance, brainstorming, cron, task, and evolution state remains
+  readable through explicit migrations and compatibility handling.
+- `/inherit all` and inheritance aliases are retired in favor of the explicit
+  inbox commands above.
+- `/evolve retry` and `/evolve reconcile` are retired; approved work is followed
+  and retried through `/tasks` and `/task retry <task-id>`.
+
+Credentials, memories, logs, chat identifiers, task state, and instance
+configuration remain outside both the public source archive and the inheritable
+software body.

--- a/genesis.toml
+++ b/genesis.toml
@@ -25,14 +25,14 @@ local_source = "libraries/provider-kit/src"
 
 [[runtime_dependencies]]
 name = "telegram"
-requirement = "our-ark-telegram @ git+https://github.com/our-ark/enoch.git@5a7e430dc600b2d761cd66236c87292bd0675ef4#subdirectory=libraries/telegram"
+requirement = "our-ark-telegram @ git+https://github.com/our-ark/enoch.git@9257a57a140950db2b3b3c242c7d2bbc622e26e1#subdirectory=libraries/telegram"
 import_name = "our_ark_telegram"
 local_source = "libraries/telegram/src"
 optional = true
 
 [[runtime_dependencies]]
 name = "github"
-requirement = "our-ark-github @ git+https://github.com/our-ark/enoch.git@5a7e430dc600b2d761cd66236c87292bd0675ef4#subdirectory=libraries/github"
+requirement = "our-ark-github @ git+https://github.com/our-ark/enoch.git@54e6f5525380cf0f3b1275992b9d73bd2f44774e#subdirectory=libraries/github"
 import_name = "our_ark_github"
 local_source = "libraries/github/src"
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enoch"
-version = "0.3.0"
+version = "0.3.1"
 description = "Enoch is a Genesis-created local agent."
 readme = "README.md"
 license = "Apache-2.0"
@@ -13,8 +13,8 @@ dependencies = [
 
 [project.optional-dependencies]
 reference = [
-  "our-ark-telegram @ git+https://github.com/our-ark/enoch.git@5a7e430dc600b2d761cd66236c87292bd0675ef4#subdirectory=libraries/telegram",
-  "our-ark-github @ git+https://github.com/our-ark/enoch.git@5a7e430dc600b2d761cd66236c87292bd0675ef4#subdirectory=libraries/github",
+  "our-ark-telegram @ git+https://github.com/our-ark/enoch.git@9257a57a140950db2b3b3c242c7d2bbc622e26e1#subdirectory=libraries/telegram",
+  "our-ark-github @ git+https://github.com/our-ark/enoch.git@54e6f5525380cf0f3b1275992b9d73bd2f44774e#subdirectory=libraries/github",
   "our-ark-launchd @ git+https://github.com/our-ark/enoch.git@5a7e430dc600b2d761cd66236c87292bd0675ef4#subdirectory=libraries/launchd",
   "our-ark-systemd @ git+https://github.com/our-ark/enoch.git@5a7e430dc600b2d761cd66236c87292bd0675ef4#subdirectory=libraries/systemd",
   "our-ark-telegram-vision @ git+https://github.com/our-ark/enoch.git@6d894d9beb882af7e5f57900b2323361510262de#subdirectory=libraries/telegram-vision",

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -170,7 +170,7 @@ class EnochPortableInstallTests(unittest.TestCase):
         self.assertEqual(result["vcs"], "portable-vcs")
         self.assertEqual(result["runtime"], "codex")
         self.assertEqual(result["forge"], "local")
-        self.assertEqual(result["enoch_version"], "0.3.0")
+        self.assertEqual(result["enoch_version"], "0.3.1")
         self.assertEqual(result["provider_kit_version"], "0.7.0")
         self.assertEqual(result["chat_provider_version"], "0.0.1")
         self.assertEqual(result["vcs_provider_version"], "0.0.1")


### PR DESCRIPTION
## What

- bump Enoch package and citation metadata from 0.3.0 to 0.3.1
- add the v0.3.1 release notes and advance the README stable-release link
- pin the Telegram and GitHub reference providers to the immutable revisions containing the presentation and inheritance changes
- update the portable-install release-version assertion

## Why

This prepares the next patch release from the changes merged after v0.3.0: managed Doctor validation, assessed inheritance and learning, bounded brainstorming, simplified evolution-to-task handoff, Telegram message presentation, and reliable cron scheduling.

## Impact

This commit changes release metadata and dependency revisions only. Runtime behavior comes from changes already reviewed and merged on main. Existing state remains covered by explicit migrations and compatibility handling documented in the release notes.

## Checks

- `bin/enoch doctor`
- 753 Enoch body tests
- 72 provider/library tests across all seven suites
- portable release metadata and immutable provider-tree checks
- `git diff --check`