### PR TITLE
Prepare Enoch v0.4.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,11 +7,11 @@ authors:
     given-names: Gary
   - family-names: Zhao
     given-names: Roy
-version: 0.3.1
-date-released: 2026-07-27
+version: 0.4.0
+date-released: 2026-07-29
 license: Apache-2.0
 repository-code: "https://github.com/our-ark/enoch"
-url: "https://github.com/our-ark/enoch/releases/tag/v0.3.1"
+url: "https://github.com/our-ark/enoch/releases/tag/v0.4.0"
 keywords:
   - agent-owned software
   - personal agents

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Genesis is open source at
 [`our-ark/genesis`](https://github.com/our-ark/genesis). The current stable
 public path pairs [Genesis
 v0.1.1](https://github.com/our-ark/genesis/releases/tag/v0.1.1) with [Enoch
-v0.3.1](https://github.com/our-ark/enoch/releases/tag/v0.3.1). The command below
+v0.4.0](https://github.com/our-ark/enoch/releases/tag/v0.4.0). The command below
 uses adjacent clean checkouts so the selected Enoch source is explicit.
 
 Enoch is a public Genesis-compatible reference body. Its `genesis.toml`

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,59 @@
+# Enoch v0.4.0
+
+Enoch v0.4.0 establishes a public agent-composition boundary. Descendants can
+now add durable domain capabilities as independently packaged agent extensions
+while Enoch remains the single owner of providers, authorization, polling,
+workflow execution, recovery, publication, and delivery.
+
+## Highlights
+
+- Added the versioned `AgentExtension` API with namespaced private state and
+  artifacts, capability-governed commands, lifecycle hooks, `/help`
+  integration, entry-point discovery, and explicit configuration.
+- Added `ExtensionWorkflow`, a constrained façade over Enoch's governed
+  workflow. Extension commands retain task provenance and may use stable,
+  domain-derived idempotency keys for retries and multi-task fan-out.
+- Added durable extension task events for `queued`, `started`, `completed`,
+  `failed`, and `cancelled` work. Events carry stable identities plus result,
+  failure, revision, review, and runtime-output evidence.
+- Added ordered, extension-scoped delivery receipts. A hook failure, restart,
+  or crash before receipt replays the same event ID, providing an explicit
+  at-least-once contract for idempotent downstream consumers.
+- Made process startup hooks independent of chat locks and notification
+  delivery, with exactly one `on_startup` invocation per application process.
+- Added `AgentExtensionConformanceMixin` and `ExtensionCommandCase` so
+  independently packaged extensions can verify API compatibility, discovery,
+  storage isolation, lifecycle behavior, and governed task submission.
+- Expanded the offline installation E2E to build and install an independent
+  extension wheel, discover it by entry point and configuration, complete its
+  work, and observe its durable completion event.
+- Added active extension names and API versions to `/status`, and documented
+  the stable profile/extension boundary and trusted-code model.
+
+## Validation
+
+- The 770-test Enoch body suite passes.
+- All 72 reference provider and library tests pass independently.
+- The Genesis cross-artifact gate creates and validates a fresh descendant from
+  the v0.4.0 body.
+- GitHub Actions covers Python 3.11, 3.12, 3.13, and 3.14.
+
+## Compatibility
+
+- Python 3.11 or newer.
+- `genesis.toml` schema version 1.
+- Agent Extension API version 1.
+- Workflow API version 3.
+- Profile API version 5.
+- Provider-kit `0.7.0`.
+- Genesis v0.1.1 or a later compatible build.
+- Existing installations select no extensions by default and retain their
+  current behavior.
+- Extension packages are trusted Python code rather than sandbox boundaries.
+- Durable task-event delivery is at least once. Consumers must apply stable
+  event IDs idempotently because a crash can occur after the extension changes
+  its state but before Enoch records the success receipt.
+
+Credentials, memories, logs, chat identifiers, task state, extension state,
+and instance configuration remain outside both the public source archive and
+the inheritable software body.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enoch"
-version = "0.3.1"
+version = "0.4.0"
 description = "Enoch is a Genesis-created local agent."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -173,7 +173,7 @@ class EnochPortableInstallTests(unittest.TestCase):
         self.assertEqual(result["vcs"], "portable-vcs")
         self.assertEqual(result["runtime"], "codex")
         self.assertEqual(result["forge"], "local")
-        self.assertEqual(result["enoch_version"], "0.3.1")
+        self.assertEqual(result["enoch_version"], "0.4.0")
         self.assertEqual(result["provider_kit_version"], "0.7.0")
         self.assertEqual(result["chat_provider_version"], "0.0.1")
         self.assertEqual(result["vcs_provider_version"], "0.0.1")


### PR DESCRIPTION
## What changed

- bump the Enoch package and citation metadata from `0.3.1` to `0.4.0`
- add the v0.4.0 release notes for the public AgentExtension v1 composition boundary
- update the stable Genesis × Enoch release pairing in the README
- update the offline installed-wheel E2E to require version `0.4.0`

## Why

AgentExtension v1, durable extension task events, downstream conformance tooling, and the independently installed extension E2E form a new public capability rather than a patch-level correction. Releasing v0.4.0 creates a stable baseline before the next CollaboratorDirectory and ExecutorRouter work begins.

## Compatibility

- Python 3.11+
- Agent Extension API 1
- Workflow API 3
- Profile API 5
- Provider-kit 0.7.0
- Genesis v0.1.1+
- existing installations select no extensions by default

## Validation

- Enoch body: 770 tests passed
- reference providers and libraries: 72 tests passed
- Genesis cross-artifact gate created and validated a fresh descendant from release commit `777a0e05adc3bed2f86dd9e0b3ae0dee88b517f3`
- offline wheel E2E built and installed Enoch v0.4.0 plus an independent AgentExtension package
- `git diff --check`

After merge, create the annotated `v0.4.0` tag on the squash commit and publish the GitHub Release from `docs/releases/v0.4.0.md`.