### PR TITLE
Honor explicit instance roots

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -45,6 +45,13 @@ or `software_body_path()` from `enoch.paths` instead of joining paths onto the
 repository root or `.enoch` directly. `enoch_home()` remains a compatibility
 alias for the private-state root.
 
+An explicit root is authoritative. Passing `root=instance` to a path, queue,
+event, workflow, or storage API always selects that exact software body, even
+when it is nested beneath an unrelated `.git` directory or
+`pyproject.toml`. Omit the root to opt into repository discovery from the
+current working directory; `discover_repo_root()` exposes that operation
+directly for CLI entry points.
+
 ## Compatibility and retention
 
 New logs and append-only task, semantic evidence, evidence-scan, evolution,

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -206,7 +206,7 @@ from enoch.logs import log_conversation_turn, log_system_event, system_log_dirs
 from enoch.memory.paths import clean_text
 from enoch.memory.prompt import memory_for_prompt
 from enoch.memory.store import ensure_long_term_memory, remember_memory
-from enoch.paths import storage_layout
+from enoch.paths import repo_root, storage_layout
 from enoch.prompt_append import (
     TaskRegressionSignal,
     extract_edit_request,
@@ -4471,7 +4471,7 @@ class EnochApplication:
 
 
 def main(chat_provider_name: str = "") -> None:
-    root = Path.cwd()
+    root = repo_root()
     identity = load_identity()
     try:
         chat_provider = load_provider("chat", root, name=chat_provider_name)

--- a/src/enoch/cli.py
+++ b/src/enoch/cli.py
@@ -12,6 +12,7 @@ from enoch.immune import run_immune_system
 from enoch.instance import InstanceError, format_instance_init_result, init_instance
 from enoch.logs import log_system_event
 from enoch.memory.store import ensure_long_term_memory
+from enoch.paths import repo_root
 from enoch.providers.registry import load_provider
 from enoch.commands import (
     config_command,
@@ -136,7 +137,7 @@ EXIT = object()
 
 def main(argv: list[str] | None = None) -> None:
     identity = load_identity()
-    root = Path.cwd()
+    root = repo_root()
     args = sys.argv[1:] if argv is None else argv
     if args:
         result = _command_output(" ".join(args), identity, root)

--- a/src/enoch/paths.py
+++ b/src/enoch/paths.py
@@ -6,7 +6,15 @@ from enoch.storage import StorageLayout, local_storage_layout
 
 
 def repo_root(start: Path | None = None) -> Path:
-    path = (start or Path.cwd()).resolve()
+    if start is not None:
+        return start.expanduser().resolve()
+    return discover_repo_root()
+
+
+def discover_repo_root(start: Path | None = None) -> Path:
+    """Discover a repository only when the caller explicitly asks for it."""
+
+    path = (start or Path.cwd()).expanduser().resolve()
     for candidate in [path, *path.parents]:
         if (candidate / ".git").exists() or (candidate / "pyproject.toml").exists():
             return candidate

--- a/tests/test_enoch_storage.py
+++ b/tests/test_enoch_storage.py
@@ -17,17 +17,23 @@ from enoch.cron import cron_path
 from enoch.evolution.curation import curation_index_path
 from enoch.evolution.core import evolve_brainstorm_schedule_path
 from enoch.evolution.events import evolve_event_path
+from enoch.extensions import ExtensionTaskEvent, extension_storage
+from enoch.extensions.events import (
+    acknowledge_extension_task_event,
+    extension_task_event_receipt_path,
+)
 from enoch.logs import conversation_log_dir, log_system_event
 from enoch.memory.paths import memory_dir
 from enoch.paths import (
     artifact_path,
+    repo_root,
     private_state_path,
     software_body_path,
     storage_layout,
 )
 from enoch.storage import STORAGE_API_VERSION, StorageLayout, StorageLayoutError
 from enoch.tasks.events import load_task_events, task_event_path
-from enoch.tasks.queue import task_queue_path
+from enoch.tasks.queue import enqueue_task, task_queue_path
 
 
 class EnochStorageTests(unittest.TestCase):
@@ -88,6 +94,127 @@ class EnochStorageTests(unittest.TestCase):
 
         self.assertEqual(layout.artifacts, Path(artifacts).resolve())
         self.assertEqual(path.parent.parent.parent, Path(artifacts).resolve())
+
+    def test_explicit_sibling_roots_are_not_captured_by_ancestor_repo(self) -> None:
+        with TemporaryDirectory() as directory:
+            ancestor = Path(directory)
+            ancestor.joinpath(".git").mkdir()
+            ancestor.joinpath("pyproject.toml").write_text(
+                "[project]\nname = \"unrelated\"\nversion = \"0\"\n",
+                encoding="utf-8",
+            )
+            first = ancestor / "instances" / "first"
+            second = ancestor / "instances" / "second"
+            first.mkdir(parents=True)
+            second.mkdir(parents=True)
+
+            first_layout = storage_layout(first)
+            second_layout = storage_layout(second)
+            first_queue = task_queue_path(first)
+            second_queue = task_queue_path(second)
+            first_events = task_event_path(first)
+            second_events = task_event_path(second)
+            first_receipts = extension_task_event_receipt_path(
+                extension_storage(first_layout, "manager")
+            )
+            enqueue_task(1, "first task", first)
+            enqueue_task(2, "second task", second)
+            acknowledge_extension_task_event(
+                extension_storage(first_layout, "manager"),
+                ExtensionTaskEvent(
+                    id="first-extension-event",
+                    extension_name="manager",
+                    task_id=1,
+                    event="queued",
+                    occurred_at="2026-07-30T00:00:00+00:00",
+                    request="first task",
+                ),
+            )
+            written_paths = tuple(
+                path.is_file()
+                for path in (
+                    first_queue,
+                    second_queue,
+                    first_events,
+                    second_events,
+                    first_receipts,
+                )
+            )
+            ancestor_state_exists = ancestor.joinpath(".enoch").exists()
+
+        self.assertEqual(repo_root(first), first.resolve())
+        self.assertEqual(first_layout.software_body, first.resolve())
+        self.assertEqual(second_layout.software_body, second.resolve())
+        self.assertEqual(first_queue, first.resolve() / ".enoch" / "task_queue.json")
+        self.assertEqual(second_queue, second.resolve() / ".enoch" / "task_queue.json")
+        self.assertEqual(
+            first_events,
+            first.resolve() / ".enoch" / "artifacts" / "task_events.jsonl",
+        )
+        self.assertEqual(
+            second_events,
+            second.resolve() / ".enoch" / "artifacts" / "task_events.jsonl",
+        )
+        self.assertEqual(
+            first_receipts,
+            first.resolve()
+            / ".enoch"
+            / "extensions"
+            / "manager"
+            / "task_event_receipts.jsonl",
+        )
+        self.assertNotEqual(first_layout.private_state, second_layout.private_state)
+        self.assertTrue(all(written_paths))
+        self.assertFalse(ancestor_state_exists)
+        self.assertFalse(first_queue.is_relative_to(ancestor / ".enoch"))
+
+    def test_implicit_root_discovery_still_finds_ancestor_repo(self) -> None:
+        with TemporaryDirectory() as directory:
+            ancestor = Path(directory)
+            ancestor.joinpath("pyproject.toml").write_text(
+                "[project]\nname = \"ancestor\"\nversion = \"0\"\n",
+                encoding="utf-8",
+            )
+            nested = ancestor / "nested" / "working"
+            nested.mkdir(parents=True)
+            previous = Path.cwd()
+            try:
+                os.chdir(nested)
+                discovered = repo_root()
+                layout = storage_layout()
+            finally:
+                os.chdir(previous)
+
+        self.assertEqual(discovered, ancestor.resolve())
+        self.assertEqual(layout.software_body, ancestor.resolve())
+        self.assertEqual(layout.private_state, ancestor.resolve() / ".enoch")
+
+    def test_state_redirect_matches_only_the_explicit_software_body(self) -> None:
+        with TemporaryDirectory() as directory, TemporaryDirectory() as redirected:
+            ancestor = Path(directory)
+            ancestor.joinpath(".git").mkdir()
+            configured = ancestor / "configured"
+            sibling = ancestor / "sibling"
+            configured.mkdir()
+            sibling.mkdir()
+            with patch.dict(
+                os.environ,
+                {
+                    "ENOCH_STATE_REDIRECT_ROOT": str(configured),
+                    "ENOCH_STATE_HOME": redirected,
+                },
+            ):
+                configured_layout = storage_layout(configured)
+                sibling_layout = storage_layout(sibling)
+
+        self.assertEqual(
+            configured_layout.private_state,
+            Path(redirected).resolve(),
+        )
+        self.assertEqual(
+            sibling_layout.private_state,
+            sibling.resolve() / ".enoch",
+        )
 
     def test_core_paths_are_owned_by_their_declared_area(self) -> None:
         with TemporaryDirectory() as directory:


### PR DESCRIPTION
## What changed

- make a non-`None` root authoritative instead of walking into an ancestor repository
- expose `discover_repo_root()` as the explicit opt-in discovery operation
- keep CLI and daemon startup discovery behavior by calling `repo_root()` without an explicit root
- document exact-root versus discovery semantics
- add regression coverage for sibling instances beneath unrelated `.git` and `pyproject.toml` ancestors, queue/event/receipt writes, implicit discovery, and exact redirect matching

## Why

Explicit instance roots could previously be captured by the first ancestor containing `.git` or `pyproject.toml`. Sibling instances could therefore share the ancestor's `.enoch` queue, events, extension receipts, and other private state. Test behavior could also depend on whether an unrelated temporary-directory ancestor was a repository.

## User impact

Callers that pass an explicit software-body root now always receive storage beneath that exact root. Callers that omit a root retain repository discovery. The default on-disk layout and redirect environment variables are unchanged.

## Validation

- 773 Enoch tests passed
- 9 focused storage tests passed after adding actual sibling queue, task-event, and extension-receipt writes
- `git diff --check`

Fixes #61