### PR TITLE
Add typed extension command results

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -101,8 +101,11 @@ class ResearcherProfileConformance(
 Agent-extension packages should use `AgentExtensionConformanceMixin`, return
 their `AgentExtension` from `create_extension`, and optionally return an
 `ExtensionCommandCase`. The suite checks API-version compatibility, command
-discovery, namespaced storage, lifecycle isolation, and real governed task
-submission with extension provenance and a stable idempotency key.
+discovery, typed command-result normalization, namespaced storage, lifecycle
+isolation, and real governed task submission with extension provenance and a
+stable idempotency key. The Enoch application conformance coverage also
+exercises typed success, validation and authorization failures, enqueue and
+capability failures, and handler-exception isolation.
 Stateful commands may override `prepare_command` to populate their isolated
 fixture before the representative command is invoked. When an extension
 declares `on_task_event`, the lifecycle check also invokes it with a typed,

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -10,6 +10,7 @@ The version 1 API provides:
 
 - namespaced private state and artifact storage;
 - chat commands with capability requirements and `/help` integration;
+- typed command outcomes linked to durable tasks and output evidence;
 - application lifecycle hooks and durable task-result events;
 - a constrained façade over Enoch's single governed workflow.
 
@@ -33,13 +34,20 @@ capability that can coexist with other capabilities.
 ## Define an extension
 
 ```python
-from enoch.extensions import ExtensionCommandSpec, AgentExtension
+from enoch.extensions import (
+    AgentExtension,
+    ExtensionCommandResult,
+    ExtensionCommandSpec,
+)
 
 
 def project(context):
     goal = context.argument.strip()
     if not goal:
-        return "Usage: /project <goal>"
+        return ExtensionCommandResult.failure(
+            "Usage: /project <goal>",
+            code="missing_goal",
+        )
 
     state = context.storage.private_path("projects.json")
     state.parent.mkdir(parents=True, exist_ok=True)
@@ -48,7 +56,12 @@ def project(context):
         context="Define deliverables, acceptance criteria, and owners.",
         idempotency_key=f"project:{goal}",
     )
-    return f"Queued project-planning task #{job.id}."
+    return ExtensionCommandResult.success(
+        f"Queued project-planning task #{job.id}.",
+        code="project_plan_queued",
+        task_ids=(job.id,),
+        output_refs=(f"artifact://projects/{goal}",),
+    )
 
 
 def create_extension(root=None):
@@ -78,6 +91,28 @@ optional `idempotency_key` is scoped to the extension. Use a stable,
 domain-derived key whenever a command can be retried or can enqueue more than
 one durable task; the message identifier remains the fallback for simple
 one-task commands.
+
+## Typed command results
+
+An extension command may return `ExtensionCommandResult` with:
+
+- `final_text`, rendered through the active chat presentation;
+- `status`, either `succeeded` or `failed`;
+- a stable machine-readable `code`;
+- durable `task_ids` created by the command;
+- bounded `output_refs` for artifacts or other evidence.
+
+The result contract is independently versioned by
+`EXTENSION_COMMAND_RESULT_API_VERSION`. Returning a string remains the
+backward-compatible shorthand for a successful text-only result with code
+`ok`.
+
+Enoch records `agent_extension_command_result` for every invocation. The audit
+event retains the result version, status, stable code, task IDs, and output
+references; chat receives only `final_text`. Authorization denial, enqueue
+failure, capability unavailability, invalid typed output, and an isolated
+handler exception are normalized to stable failure codes rather than escaping
+the chat event loop. Internal exception text is not part of the chat contract.
 
 ## Lifecycle and observability
 
@@ -164,9 +199,10 @@ checks govern use of Enoch's public provider and workflow surfaces; arbitrary
 Python code installed by an operator still has the process's operating-system
 permissions.
 
-The current contract is `AGENT_EXTENSION_API_VERSION = 1`. Enoch rejects an
-extension that declares another version. Extension command and lifecycle
-failures are isolated and recorded as system events.
+The current contracts are `AGENT_EXTENSION_API_VERSION = 1` and
+`EXTENSION_COMMAND_RESULT_API_VERSION = 1`. Enoch rejects unsupported versions.
+Extension command and lifecycle failures are isolated and recorded as system
+events.
 
 Downstream extension packages should inherit
 `AgentExtensionConformanceMixin` and, when possible, provide an

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -267,6 +267,8 @@ from enoch.profiles import (
 from enoch.profiles.contracts import extend_prompt
 from enoch.extensions import (
     ExtensionCommandContext,
+    ExtensionCommandEnqueueError,
+    ExtensionCommandResult,
     ExtensionCommandSpec,
     AgentExtension,
     AgentExtensionError,
@@ -274,6 +276,7 @@ from enoch.extensions import (
     ExtensionWorkflow,
     extension_storage,
     load_extensions,
+    normalize_extension_command_result,
 )
 from enoch.extensions.events import (
     acknowledge_extension_task_event,
@@ -1105,6 +1108,7 @@ class EnochApplication:
             review=self.review,
             workflow=self._extension_workflow(extension),
         )
+        result: ExtensionCommandResult
         try:
             self.authorization.require(
                 f"extension-command:{extension.name}:{spec.name}",
@@ -1114,20 +1118,70 @@ class EnochApplication:
                     "command": command,
                 },
             )
-            return str(spec.handler(context))
+            result = normalize_extension_command_result(spec.handler(context))
         except CapabilityAuthorizationError as error:
-            return str(error)
+            result = ExtensionCommandResult.failure(
+                str(error),
+                code="authorization_denied",
+            )
+        except ExtensionCommandEnqueueError as error:
+            result = ExtensionCommandResult.failure(
+                f"Extension command {command} could not enqueue work: {error}",
+                code=error.code,
+                task_ids=error.task_ids,
+            )
+        except AgentRuntimeAccessUnavailable as error:
+            result = ExtensionCommandResult.failure(
+                f"Extension command {command} cannot access a required capability: "
+                f"{error}",
+                code="capability_unavailable",
+            )
+        except ProviderError as error:
+            result = ExtensionCommandResult.failure(
+                f"Extension command {command} cannot access a required capability: "
+                f"{error}",
+                code="capability_unavailable",
+            )
+        except AgentExtensionError as error:
+            result = ExtensionCommandResult.failure(
+                f"Extension command {command} returned an invalid result: {error}",
+                code="invalid_result",
+            )
+        except ValueError as error:
+            result = ExtensionCommandResult.failure(
+                f"Extension command {command} could not validate its input: {error}",
+                code="validation_failed",
+            )
         except Exception as error:
             _record_system_event(
                 "agent_extension_command_failed",
                 self.root,
+                status="failed",
                 details={
                     "extension": extension.name,
                     "command": command,
-                    "error": str(error),
+                    "error_class": type(error).__name__,
                 },
             )
-            return f"Extension command {command} failed: {error}"
+            result = ExtensionCommandResult.failure(
+                f"Extension command {command} failed.",
+                code="internal_failure",
+            )
+        _record_system_event(
+            "agent_extension_command_result",
+            self.root,
+            status="ok" if result.succeeded else "failed",
+            details={
+                "extension": extension.name,
+                "command": command,
+                "result_api_version": result.api_version,
+                "result_status": result.status,
+                "code": result.code,
+                "task_ids": list(result.task_ids),
+                "output_refs": list(result.output_refs),
+            },
+        )
+        return result.final_text
 
     def _profile_task_options(
         self,

--- a/src/enoch/conformance/extension.py
+++ b/src/enoch/conformance/extension.py
@@ -7,11 +7,14 @@ from tempfile import TemporaryDirectory
 from enoch.extensions import (
     AGENT_EXTENSION_API_VERSION,
     AgentExtension,
+    AgentExtensionError,
     ExtensionCommandContext,
+    ExtensionCommandResult,
     ExtensionLifecycleContext,
     ExtensionTaskEvent,
     ExtensionWorkflow,
     extension_storage,
+    normalize_extension_command_result,
 )
 from enoch.identity import load_identity
 from enoch.providers import ChatEvent, RuntimeResult, TaskRequirements
@@ -118,10 +121,11 @@ class AgentExtensionConformanceMixin:
                 workflow=ExtensionWorkflow.from_engine(extension.name, engine),
             )
             self.prepare_command(extension, context, case)
-            response = spec.handler(context)
+            response = normalize_extension_command_result(spec.handler(context))
             pending = engine.inspect().pending
 
-        self.assertIsInstance(response, str)
+        self.assertIsInstance(response, ExtensionCommandResult)
+        self.assertTrue(response.succeeded)
         self.assertEqual(len(pending), 1)
         job = pending[0]
         self.assertEqual(job.text, case.expected_request)
@@ -139,6 +143,32 @@ class AgentExtensionConformanceMixin:
             job.idempotency_key,
             f"extension:{extension.name}:{local_key}",
         )
+        if response.task_ids:
+            self.assertIn(job.id, response.task_ids)
+
+    def test_conformance_extension_command_result_normalization(self) -> None:
+        shorthand = normalize_extension_command_result("Ready.")
+        typed = normalize_extension_command_result(
+            ExtensionCommandResult.failure(
+                "A stable validation error.",
+                code="validation_failed",
+                output_refs=("artifact://validation/report",),
+            )
+        )
+
+        self.assertTrue(shorthand.succeeded)
+        self.assertEqual(shorthand.final_text, "Ready.")
+        self.assertFalse(typed.succeeded)
+        self.assertEqual(typed.code, "validation_failed")
+        self.assertEqual(
+            typed.output_refs,
+            ("artifact://validation/report",),
+        )
+        with self.assertRaisesRegex(
+            AgentExtensionError,
+            "must return str or ExtensionCommandResult",
+        ):
+            normalize_extension_command_result(object())
 
     def test_conformance_extension_lifecycle_accepts_isolated_context(self) -> None:
         extension = self.create_extension()

--- a/src/enoch/extensions/__init__.py
+++ b/src/enoch/extensions/__init__.py
@@ -1,7 +1,11 @@
 from enoch.extensions.contracts import (
     AGENT_EXTENSION_API_VERSION,
+    EXTENSION_COMMAND_RESULT_API_VERSION,
     ExtensionCommandContext,
+    ExtensionCommandEnqueueError,
     ExtensionCommandHandler,
+    ExtensionCommandResult,
+    ExtensionCommandStatus,
     ExtensionCommandSpec,
     AgentExtension,
     AgentExtensionError,
@@ -13,6 +17,7 @@ from enoch.extensions.contracts import (
     ExtensionTaskEventType,
     ExtensionWorkflow,
     extension_storage,
+    normalize_extension_command_result,
 )
 from enoch.extensions.registry import (
     available_extensions,
@@ -23,8 +28,12 @@ from enoch.extensions.registry import (
 
 __all__ = [
     "AGENT_EXTENSION_API_VERSION",
+    "EXTENSION_COMMAND_RESULT_API_VERSION",
     "ExtensionCommandContext",
+    "ExtensionCommandEnqueueError",
     "ExtensionCommandHandler",
+    "ExtensionCommandResult",
+    "ExtensionCommandStatus",
     "ExtensionCommandSpec",
     "AgentExtension",
     "AgentExtensionError",
@@ -38,5 +47,6 @@ __all__ = [
     "available_extensions",
     "extension_storage",
     "load_extensions",
+    "normalize_extension_command_result",
     "register_extension",
 ]

--- a/src/enoch/extensions/contracts.py
+++ b/src/enoch/extensions/contracts.py
@@ -15,12 +15,15 @@ from enoch.providers.contracts import (
     ReviewProvider,
     TaskRequirements,
 )
+from enoch.providers.authorization import CapabilityAuthorizationError
 from enoch.storage import StorageLayout
-from enoch.tasks.queue import TaskJob, TaskQueueStatus
-from enoch.workflows import WorkflowEngine
+from enoch.tasks.queue import TaskAlreadyExists, TaskJob, TaskQueueStatus
+from enoch.workflows import WorkflowEngine, WorkflowEngineError
 
 
 AGENT_EXTENSION_API_VERSION = 1
+EXTENSION_COMMAND_RESULT_API_VERSION = 1
+ExtensionCommandStatus = Literal["succeeded", "failed"]
 ExtensionTaskEventType = Literal[
     "queued",
     "started",
@@ -32,6 +35,119 @@ ExtensionTaskEventType = Literal[
 
 class AgentExtensionError(RuntimeError):
     pass
+
+
+class ExtensionCommandEnqueueError(AgentExtensionError):
+    """A governed task could not be enqueued by an extension command."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "enqueue_failed",
+        task_ids: tuple[int, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.task_ids = task_ids
+
+
+@dataclass(frozen=True)
+class ExtensionCommandResult:
+    """Versioned outcome returned by an agent-extension command."""
+
+    final_text: str
+    status: ExtensionCommandStatus = "succeeded"
+    code: str = "ok"
+    task_ids: tuple[int, ...] = ()
+    output_refs: tuple[str, ...] = ()
+    api_version: int = EXTENSION_COMMAND_RESULT_API_VERSION
+
+    def __post_init__(self) -> None:
+        if self.api_version != EXTENSION_COMMAND_RESULT_API_VERSION:
+            raise AgentExtensionError(
+                "Extension command result uses API version "
+                f"{self.api_version}; Enoch supports version "
+                f"{EXTENSION_COMMAND_RESULT_API_VERSION}."
+            )
+        if not isinstance(self.final_text, str):
+            raise AgentExtensionError(
+                "Extension command result final text must be a string."
+            )
+        if self.status not in ("succeeded", "failed"):
+            raise AgentExtensionError(
+                f"Invalid extension command result status {self.status!r}."
+            )
+        if not isinstance(self.code, str):
+            raise AgentExtensionError(
+                "Extension command result code must be a string."
+            )
+        code = self.code.strip().lower()
+        if not re.fullmatch(r"[a-z][a-z0-9._-]{0,63}", code):
+            raise AgentExtensionError(
+                f"Invalid extension command result code {self.code!r}."
+            )
+        if self.status == "failed" and code == "ok":
+            raise AgentExtensionError(
+                "Failed extension command results require a non-ok code."
+            )
+        task_ids = _result_task_ids(self.task_ids)
+        output_refs = _result_output_refs(self.output_refs)
+        object.__setattr__(self, "code", code)
+        object.__setattr__(self, "task_ids", task_ids)
+        object.__setattr__(self, "output_refs", output_refs)
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == "succeeded"
+
+    @classmethod
+    def success(
+        cls,
+        final_text: str,
+        *,
+        code: str = "ok",
+        task_ids: tuple[int, ...] = (),
+        output_refs: tuple[str, ...] = (),
+    ) -> ExtensionCommandResult:
+        return cls(
+            final_text=final_text,
+            status="succeeded",
+            code=code,
+            task_ids=task_ids,
+            output_refs=output_refs,
+        )
+
+    @classmethod
+    def failure(
+        cls,
+        final_text: str,
+        *,
+        code: str,
+        task_ids: tuple[int, ...] = (),
+        output_refs: tuple[str, ...] = (),
+    ) -> ExtensionCommandResult:
+        return cls(
+            final_text=final_text,
+            status="failed",
+            code=code,
+            task_ids=task_ids,
+            output_refs=output_refs,
+        )
+
+
+def normalize_extension_command_result(
+    result: str | ExtensionCommandResult,
+) -> ExtensionCommandResult:
+    """Normalize the v1 string shorthand into a typed command result."""
+
+    if isinstance(result, ExtensionCommandResult):
+        return result
+    if isinstance(result, str):
+        return ExtensionCommandResult.success(result)
+    raise AgentExtensionError(
+        "Extension command handlers must return str or ExtensionCommandResult."
+    )
 
 
 @dataclass(frozen=True)
@@ -157,19 +273,33 @@ class ExtensionCommandContext:
         idempotency_key: str = "",
     ) -> TaskJob:
         key = idempotency_key.strip() or f"command:{self.event.message_id}"
-        return self.workflow.enqueue(
-            self.conversation_id,
-            request,
-            context=context,
-            initiated_by="human",
-            event_actor="human",
-            trigger=self.command,
-            required_capabilities=required_capabilities,
-            idempotency_key=key,
-        )
+        try:
+            return self.workflow.enqueue(
+                self.conversation_id,
+                request,
+                context=context,
+                initiated_by="human",
+                event_actor="human",
+                trigger=self.command,
+                required_capabilities=required_capabilities,
+                idempotency_key=key,
+            )
+        except TaskAlreadyExists as error:
+            raise ExtensionCommandEnqueueError(
+                str(error),
+                code="task_already_exists",
+                task_ids=(error.job.id,),
+            ) from error
+        except CapabilityAuthorizationError:
+            raise
+        except (OSError, ValueError, WorkflowEngineError) as error:
+            raise ExtensionCommandEnqueueError(str(error)) from error
 
 
-ExtensionCommandHandler = Callable[[ExtensionCommandContext], str]
+ExtensionCommandHandler = Callable[
+    [ExtensionCommandContext],
+    str | ExtensionCommandResult,
+]
 
 
 @dataclass(frozen=True)
@@ -294,3 +424,66 @@ def _command_name(value: str) -> str:
     if not re.fullmatch(r"[a-z][a-z0-9_-]{0,31}", name):
         raise AgentExtensionError(f"Invalid agent extension command {value!r}.")
     return name
+
+
+def _result_task_ids(values: tuple[int, ...]) -> tuple[int, ...]:
+    try:
+        task_ids = tuple(values)
+    except TypeError as error:
+        raise AgentExtensionError(
+            "Extension command result task IDs must be an iterable."
+        ) from error
+    if len(task_ids) > 64:
+        raise AgentExtensionError(
+            "Extension command results support at most 64 task IDs."
+        )
+    if any(
+        isinstance(task_id, bool)
+        or not isinstance(task_id, int)
+        or task_id < 1
+        for task_id in task_ids
+    ):
+        raise AgentExtensionError(
+            "Extension command result task IDs must be positive integers."
+        )
+    if len(set(task_ids)) != len(task_ids):
+        raise AgentExtensionError(
+            "Extension command result task IDs must be unique."
+        )
+    return task_ids
+
+
+def _result_output_refs(values: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(values, str):
+        raise AgentExtensionError(
+            "Extension command result output references must be an iterable "
+            "of strings, not one string."
+        )
+    try:
+        raw_refs = tuple(values)
+    except TypeError as error:
+        raise AgentExtensionError(
+            "Extension command result output references must be an iterable."
+        ) from error
+    if any(not isinstance(value, str) for value in raw_refs):
+        raise AgentExtensionError(
+            "Extension command result output references must be strings."
+        )
+    output_refs = tuple(value.strip() for value in raw_refs)
+    if len(output_refs) > 64:
+        raise AgentExtensionError(
+            "Extension command results support at most 64 output references."
+        )
+    if any(
+        not value or "\n" in value or len(value) > 512
+        for value in output_refs
+    ):
+        raise AgentExtensionError(
+            "Extension command result output references must be non-empty, "
+            "single-line strings of 512 characters or fewer."
+        )
+    if len(set(output_refs)) != len(output_refs):
+        raise AgentExtensionError(
+            "Extension command result output references must be unique."
+        )
+    return output_refs

--- a/tests/test_enoch_conformance.py
+++ b/tests/test_enoch_conformance.py
@@ -13,6 +13,7 @@ from enoch.conformance import (
 )
 from enoch.extensions import (
     AgentExtension,
+    ExtensionCommandResult,
     ExtensionCommandSpec,
     ExtensionLifecycleHooks,
 )
@@ -137,13 +138,17 @@ class AgentExtensionConformanceTests(
 
     def create_extension(self) -> AgentExtension:
         def research(command):
-            command.enqueue_task(
+            job = command.enqueue_task(
                 f"Research {command.argument}",
                 context="Use cited primary sources.",
                 required_capabilities=("runtime.execute",),
                 idempotency_key=f"research:{command.argument}",
             )
-            return "Research queued."
+            return ExtensionCommandResult.success(
+                "Research queued.",
+                code="research_queued",
+                task_ids=(job.id,),
+            )
 
         return AgentExtension(
             name="research",

--- a/tests/test_enoch_extensions.py
+++ b/tests/test_enoch_extensions.py
@@ -13,6 +13,8 @@ sys.path.insert(0, str(ROOT / "src"))
 from enoch.app.core import EnochApplication
 from enoch.extensions import (
     AGENT_EXTENSION_API_VERSION,
+    EXTENSION_COMMAND_RESULT_API_VERSION,
+    ExtensionCommandResult,
     ExtensionCommandSpec,
     ExtensionTaskEvent,
     AgentExtension,
@@ -25,7 +27,11 @@ from enoch.extensions.events import load_extension_task_event_receipts
 from enoch.extensions import registry as extension_registry
 from enoch.identity import load_identity
 from enoch.profiles import AgentProfile, CommandSpec, LifecycleHooks
-from enoch.providers import ChatEvent, ProviderHealth
+from enoch.providers import (
+    AgentRuntimeAccessUnavailable,
+    ChatEvent,
+    ProviderHealth,
+)
 from enoch.tasks.events import load_task_events
 from enoch.tasks.queue import task_queue_status
 
@@ -288,6 +294,223 @@ class EnochExtensionTests(unittest.TestCase):
             tuple(job.context_source for job in pending),
             ("extension:manager", "extension:manager"),
         )
+
+    def test_typed_extension_command_result_links_durable_work_and_audit_refs(
+        self,
+    ) -> None:
+        def plan(context):
+            job = context.enqueue_task("Create the governed plan")
+            return ExtensionCommandResult.success(
+                f"Queued planning task #{job.id}.",
+                code="plan_queued",
+                task_ids=(job.id,),
+                output_refs=("artifact://plans/project-1",),
+            )
+
+        extension = AgentExtension(
+            name="manager",
+            commands=(
+                ExtensionCommandSpec("project", "queue a project plan", plan),
+            ),
+        )
+        with TemporaryDirectory() as temp, patch(
+            "enoch.app.core._record_system_event"
+        ) as record_event:
+            root = Path(temp)
+            chat = _Chat()
+            app = EnochApplication(
+                load_identity(),
+                root,
+                chat,
+                runtime=_Runtime(),
+                extensions=(extension,),
+            )
+
+            app.handle_event(_event("/project"))
+            queued = task_queue_status(root).pending
+
+        self.assertEqual(chat.sent[-1][1], "Queued planning task #1.")
+        self.assertEqual(tuple(job.id for job in queued), (1,))
+        result_event = next(
+            call
+            for call in record_event.call_args_list
+            if call.args[0] == "agent_extension_command_result"
+        )
+        self.assertEqual(result_event.kwargs["status"], "ok")
+        self.assertEqual(
+            result_event.kwargs["details"],
+            {
+                "extension": "manager",
+                "command": "/project",
+                "result_api_version": EXTENSION_COMMAND_RESULT_API_VERSION,
+                "result_status": "succeeded",
+                "code": "plan_queued",
+                "task_ids": [1],
+                "output_refs": ["artifact://plans/project-1"],
+            },
+        )
+
+    def test_string_extension_command_result_remains_text_shorthand(self) -> None:
+        extension = AgentExtension(
+            name="legacy",
+            commands=(
+                ExtensionCommandSpec(
+                    "ready",
+                    "return legacy text",
+                    lambda _context: "  Ready.  ",
+                ),
+            ),
+        )
+        with TemporaryDirectory() as temp, patch(
+            "enoch.app.core._record_system_event"
+        ) as record_event:
+            chat = _Chat()
+            app = EnochApplication(
+                load_identity(),
+                Path(temp),
+                chat,
+                runtime=_Runtime(),
+                extensions=(extension,),
+            )
+
+            app.handle_event(_event("/ready"))
+
+        self.assertEqual(chat.sent[-1][1], "  Ready.  ")
+        result_event = next(
+            call
+            for call in record_event.call_args_list
+            if call.args[0] == "agent_extension_command_result"
+        )
+        self.assertEqual(result_event.kwargs["details"]["code"], "ok")
+        self.assertEqual(
+            result_event.kwargs["details"]["result_status"],
+            "succeeded",
+        )
+
+    def test_extension_command_result_rejects_invalid_typed_fields(self) -> None:
+        cases = (
+            (
+                "API version",
+                lambda: ExtensionCommandResult(
+                    "Ready.",
+                    api_version=EXTENSION_COMMAND_RESULT_API_VERSION + 1,
+                ),
+            ),
+            (
+                "status",
+                lambda: ExtensionCommandResult("Ready.", status="unknown"),
+            ),
+            (
+                "non-ok code",
+                lambda: ExtensionCommandResult("Failed.", status="failed"),
+            ),
+            (
+                "positive integers",
+                lambda: ExtensionCommandResult("Ready.", task_ids=(0,)),
+            ),
+            (
+                "output references",
+                lambda: ExtensionCommandResult(
+                    "Ready.",
+                    output_refs=("artifact://one\nartifact://two",),
+                ),
+            ),
+        )
+
+        for message, create_result in cases:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                AgentExtensionError,
+                message,
+            ):
+                create_result()
+
+    def test_extension_command_failures_have_typed_outcomes(self) -> None:
+        def explicit_failure(_context):
+            return ExtensionCommandResult.failure(
+                "A project goal is required.",
+                code="missing_goal",
+            )
+
+        def validation_failure(_context):
+            raise ValueError("project goal is required")
+
+        def enqueue_failure(context):
+            context.enqueue_task("")
+            return "unreachable"
+
+        def unavailable(_context):
+            raise AgentRuntimeAccessUnavailable("runtime is offline")
+
+        def internal_failure(_context):
+            raise RuntimeError("secret implementation detail")
+
+        extension = AgentExtension(
+            name="manager",
+            commands=(
+                ExtensionCommandSpec("explicit", "typed failure", explicit_failure),
+                ExtensionCommandSpec("validate", "invalid input", validation_failure),
+                ExtensionCommandSpec("enqueue", "failed enqueue", enqueue_failure),
+                ExtensionCommandSpec(
+                    "authorize",
+                    "denied capability",
+                    lambda _context: "unreachable",
+                    required_capabilities=("runtime.admin",),
+                ),
+                ExtensionCommandSpec("unavailable", "missing runtime", unavailable),
+                ExtensionCommandSpec(
+                    "explode",
+                    "isolated exception",
+                    internal_failure,
+                ),
+            ),
+        )
+        with TemporaryDirectory() as temp, patch(
+            "enoch.app.core._record_system_event"
+        ) as record_event:
+            chat = _Chat()
+            app = EnochApplication(
+                load_identity(),
+                Path(temp),
+                chat,
+                runtime=_Runtime(),
+                extensions=(extension,),
+            )
+
+            for index, command in enumerate(
+                (
+                    "/explicit",
+                    "/validate",
+                    "/enqueue",
+                    "/authorize",
+                    "/unavailable",
+                    "/explode",
+                ),
+                start=1,
+            ):
+                app.handle_event(_event(command, message_id=f"failure-{index}"))
+
+        result_calls = [
+            call
+            for call in record_event.call_args_list
+            if call.args[0] == "agent_extension_command_result"
+        ]
+        self.assertEqual(
+            tuple(call.kwargs["details"]["code"] for call in result_calls),
+            (
+                "missing_goal",
+                "validation_failed",
+                "enqueue_failed",
+                "authorization_denied",
+                "capability_unavailable",
+                "internal_failure",
+            ),
+        )
+        self.assertTrue(
+            all(call.kwargs["status"] == "failed" for call in result_calls)
+        )
+        self.assertEqual(chat.sent[0][1], "A project goal is required.")
+        self.assertNotIn("secret implementation detail", chat.sent[-1][1])
+        self.assertEqual(chat.sent[-1][1], "Extension command /explode failed.")
 
     def test_status_reports_active_extension_api_versions(self) -> None:
         extension = AgentExtension(name="manager")
@@ -579,11 +802,12 @@ class EnochExtensionTests(unittest.TestCase):
 
         self.assertEqual(
             chat.sent[-1][1],
-            "Extension command /fault failed: command exploded",
+            "Extension command /fault failed.",
         )
         events = [call.args[0] for call in record_event.call_args_list]
         self.assertIn("agent_extension_lifecycle_failed", events)
         self.assertIn("agent_extension_command_failed", events)
+        self.assertIn("agent_extension_command_result", events)
 
 
 def _event(text: str, *, message_id: str = "message-1") -> ChatEvent:


### PR DESCRIPTION
## Summary
- add the versioned `ExtensionCommandResult` contract with stable status/code, durable task IDs, and bounded output references
- keep string-returning extension commands as backward-compatible successful shorthand
- normalize authorization, validation, enqueue, unavailable-capability, invalid-result, and internal failures while recording structured audit outcomes
- extend agent-extension conformance coverage and documentation

## Validation
- `PYTHONPATH=src .../python3 -m unittest tests.test_enoch_extensions tests.test_enoch_conformance` (42 tests)
- `PYTHONPATH=src .../python3 -m unittest discover -s tests -t .` (776 tests)
- `git diff --check`

Fixes #59