### PR TITLE
Add ApplicationComposition API v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ hooks, and constrained access to Enoch's single workflow without owning polling
 or a second task queue. Packages are discovered through
 `our_ark.extensions`; see [`docs/extensions.md`](docs/extensions.md).
 
+Descendant launchers can bind their own identity, mutable identity path,
+presentation, required extensions, provider selections, and fenced workflow
+factory through `ApplicationComposition` without subclassing the application
+core. Enoch retains polling and lifecycle ownership; see
+[`docs/application-composition.md`](docs/application-composition.md).
+
 Embedders can replace the task lifecycle implementation through the versioned
 `WorkflowEngine` API while preserving one queue owner. The default local engine
 provides enqueue, claim, heartbeat, cancellation, finalization, recovery, and

--- a/docs/application-composition.md
+++ b/docs/application-composition.md
@@ -1,0 +1,97 @@
+# Application composition
+
+`ApplicationComposition` is Enoch's versioned startup boundary for descendant
+agents. It lets a descendant own identity and domain selection while Enoch
+continues to own polling, authorization, recovery, task execution,
+publication, delivery, and shutdown.
+
+The current contract is `APPLICATION_COMPOSITION_API_VERSION = 1`.
+
+## Descendant launcher
+
+```python
+from enoch.application import (
+    ApplicationComposition,
+    ApplicationPresentation,
+    run_application,
+)
+from enoch.identity import load_identity
+
+
+NOAH = ApplicationComposition(
+    name="noah",
+    identity_loader=load_identity,
+    identity_path_resolver=lambda root: root / "src/noah/identity.yaml",
+    presentation=ApplicationPresentation(
+        display_name="Noah",
+        ready_message="Noah is ready to coordinate.",
+    ),
+    required_extensions=("noah-manager",),
+)
+
+
+def main():
+    run_application(NOAH)
+```
+
+`identity_path_resolver` identifies the descendant's canonical mutable identity
+file in the instance body. The resolved path must remain under the explicit
+instance root. Enoch passes that path to `identity_loader` on every startup, and
+`/mission` reads and writes the same path instead of assuming
+`src/enoch/identity.yaml`. This preserves identity changes across restarts.
+
+`ApplicationPresentation` intentionally contains only bounded, single-line
+application strings. Domain command wording belongs to profiles or extensions,
+not to the startup composition.
+
+## Selection and precedence
+
+A composition may declare:
+
+- `profile_name`, overriding profile selection from private configuration;
+- `required_extensions`, always loaded before configured optional extensions;
+- `include_configured_extensions=False`, for a closed extension set;
+- explicit `chat`, `runtime`, `vcs`, and `forge` provider names through
+  `ApplicationProviderSelection`;
+- a deny-only `authorization_policy`;
+- a `workflow_factory(root, daemon_epoch)` for an alternate versioned workflow.
+
+An explicit `chat_provider_name` passed to `run_application` overrides the
+composition's chat selection. Empty provider and profile names continue to use
+the existing environment and private configuration rules.
+
+Required and configured extensions are de-duplicated by extension identity.
+Required extensions retain declaration order, followed by any additional
+configured extensions. Unknown, duplicate, or API-incompatible components
+fail before the application begins polling.
+
+## Lifecycle ownership
+
+`ApplicationComposition.resolve(root)` returns immutable
+`ApplicationComponents` containing the selected identity, presentation,
+providers, profile, extensions, daemon epoch, workflow, and optional
+authorization policy.
+
+The workflow factory receives the current daemon epoch. Alternate workflows
+must apply that epoch to every mutation, including when their state lives
+outside the application root. `run_application()` then hands the resolved
+components to Enoch's normal runner. A descendant does not subclass
+`EnochApplication` and does not receive polling, worker, recovery,
+finalization, publication, or shutdown ownership.
+
+Direct `EnochApplication(...)` construction remains supported for focused
+embedding and tests. Enoch's own executable uses the default
+`ApplicationComposition`, so the descendant path and the built-in path share
+one startup implementation.
+
+## Conformance and packaging
+
+Descendant packages can inherit
+`ApplicationCompositionConformanceMixin` and return their composition from
+`create_composition()`. The suite validates the public version, identity
+loader, mutable identity boundary, and resolved presentation.
+
+Enoch's offline wheel test installs independent provider, profile, and
+extension packages, resolves them through `ApplicationComposition`, injects a
+fenced workflow with isolated state, and completes real profile and extension
+tasks. This prevents the composition API from depending on the source checkout.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -138,6 +138,18 @@ class ManagerExtensionConformance(
         )
 ```
 
+## Application composition
+
+Descendant launchers should use `ApplicationCompositionConformanceMixin` and
+return their versioned `ApplicationComposition` from `create_composition`.
+The suite checks the public API version, descendant identity loader, mutable
+identity path, and bounded presentation without taking over Enoch's runtime
+lifecycle. Provider, profile, extension, workflow, and installed-wheel
+integration remain covered by Enoch's application and portable-install suites.
+
+See [Application composition](application-composition.md) for the launcher
+contract and selection precedence.
+
 The core test suite applies all behavioral suites to Enoch's built-in runtime,
 workflow engine, a representative profile, and a representative agent
 extension. The offline wheel E2E builds and installs an independent extension

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -126,6 +126,7 @@ from enoch.vcs_tools import (
 from enoch.workflows import (
     LocalWorkflowEngine,
     WorkflowEngine,
+    WorkflowEngineError,
     validate_workflow_engine,
 )
 from enoch.formatting import (
@@ -262,7 +263,6 @@ from enoch.profiles import (
     ProfileError,
     PromptContext,
     PromptPurpose,
-    load_profile,
 )
 from enoch.profiles.contracts import extend_prompt
 from enoch.extensions import (
@@ -275,7 +275,6 @@ from enoch.extensions import (
     ExtensionLifecycleContext,
     ExtensionWorkflow,
     extension_storage,
-    load_extensions,
     normalize_extension_command_result,
 )
 from enoch.extensions.events import (
@@ -400,6 +399,11 @@ from enoch.app.task_workflow import (
     sandbox_description as _sandbox_description,
     work_reply_failed as _work_reply_failed,
 )
+from enoch.application import (
+    ApplicationComposition,
+    ApplicationCompositionError,
+    ApplicationPresentation,
+)
 
 
 TASK_CONTEXT_SOURCE_CHAT = "chat-snapshot"
@@ -473,9 +477,15 @@ class EnochApplication:
         daemon_epoch: DaemonEpoch | None = None,
         workflow: WorkflowEngine | None = None,
         authorization_policy: AuthorizationPolicy | None = None,
+        identity_path: Path | None = None,
+        presentation: ApplicationPresentation | None = None,
     ) -> None:
         self.identity = identity
         self.root = root
+        self.identity_path = Path(
+            identity_path or identity_file_path(root)
+        ).resolve()
+        self.presentation = presentation or ApplicationPresentation()
         self.storage = storage_layout(root)
         assert_private_state_supported(root)
         self.client = client
@@ -629,7 +639,13 @@ class EnochApplication:
             self.identity,
             self.root,
             chat_id,
-            startup_context_note(memory_for_prompt(self.root)),
+            startup_context_note(
+                memory_for_prompt(
+                    self.root,
+                    identity=self.identity,
+                    identity_path=self.identity_path,
+                )
+            ),
             runtime=self.runtime,
             session_key=self._session_key(chat_id),
             effect_fence=self.effect_fence,
@@ -968,7 +984,7 @@ class EnochApplication:
         return {
             "start": lambda: "\n".join(
                 [
-                    "Enoch is ready.",
+                    self.presentation.resolved_ready_message(self.identity),
                     "Use /help to see every command.",
                     "Use /help <command> for detailed usage and subcommands.",
                 ]
@@ -2309,10 +2325,16 @@ class EnochApplication:
         )
 
     def _mission(self, text: str) -> str:
-        reply = mission_command(text, self.identity, self.root)
+        reply = mission_command(
+            text,
+            self.identity,
+            self.root,
+            identity_path=self.identity_path,
+            display_name=self.presentation.resolved_display_name(self.identity),
+        )
         if text.split(maxsplit=1)[0].lower() == "/mission" and len(text.split(maxsplit=1)) > 1:
             try:
-                self.identity = load_identity(identity_file_path(self.root))
+                self.identity = load_identity(self.identity_path)
             except (OSError, ValueError, KeyError):
                 pass
         return reply
@@ -4530,31 +4552,39 @@ class EnochApplication:
             return
 
 
-def main(chat_provider_name: str = "") -> None:
+def main(
+    chat_provider_name: str = "",
+    *,
+    composition: ApplicationComposition | None = None,
+) -> None:
     root = repo_root()
-    identity = load_identity()
+    selected_composition = composition or ApplicationComposition()
     try:
-        chat_provider = load_provider("chat", root, name=chat_provider_name)
-        runtime_provider = load_provider("runtime", root)
-        forge_provider = load_provider("forge", root)
-        profile = load_profile(root)
-        extensions = load_extensions(root)
+        components = selected_composition.resolve(
+            root,
+            chat_provider_name=chat_provider_name,
+        )
     except (
+        ApplicationCompositionError,
         ProviderError,
         ChatProviderError,
         ProfileError,
         AgentExtensionError,
+        WorkflowEngineError,
     ) as error:
         print(str(error))
         raise SystemExit(1) from error
+    identity = components.identity
+    chat_provider = components.chat
+    extensions = components.extensions
     selected_channel = _chat_provider_name(chat_provider)
-    daemon_epoch = begin_daemon_epoch(root, provider=selected_channel)
     previous_shutdown_warning = _begin_lifecycle_run(root, provider=selected_channel)
     _record_system_event(
         "startup",
         root,
         details={
             "identity": identity.name,
+            "composition": components.composition_name,
             "previous_shutdown_warning": previous_shutdown_warning,
             "extensions": [extension.name for extension in extensions],
         },
@@ -4564,11 +4594,16 @@ def main(chat_provider_name: str = "") -> None:
         root=root,
         client=chat_provider,
         previous_shutdown_warning=previous_shutdown_warning,
-        runtime=runtime_provider,
-        forge=forge_provider,
-        profile=profile,
+        runtime=components.runtime,
+        repository=components.repository,
+        review=components.review,
+        profile=components.profile,
         extensions=extensions,
-        daemon_epoch=daemon_epoch,
+        daemon_epoch=components.daemon_epoch,
+        workflow=components.workflow,
+        authorization_policy=components.authorization_policy,
+        identity_path=components.identity_path,
+        presentation=components.presentation,
     )
     _install_shutdown_handlers()
     bot.start()

--- a/src/enoch/application.py
+++ b/src/enoch/application.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+from typing import Callable
+
+from enoch.app.epoch import DaemonEpoch, begin_daemon_epoch
+from enoch.extensions import AgentExtension, AgentExtensionError, load_extensions
+from enoch.identity import Identity, identity_file_path, load_identity
+from enoch.profiles import AgentProfile, load_profile
+from enoch.providers import (
+    AgentRuntime,
+    AuthorizationPolicy,
+    ChatProvider,
+    RepositoryProvider,
+    ReviewProvider,
+    as_repository_provider,
+    as_review_provider,
+)
+from enoch.providers.registry import load_provider
+from enoch.workflows import LocalWorkflowEngine, WorkflowEngine, validate_workflow_engine
+
+
+APPLICATION_COMPOSITION_API_VERSION = 1
+IdentityLoader = Callable[[Path], Identity]
+IdentityPathResolver = Callable[[Path], Path]
+WorkflowFactory = Callable[[Path, DaemonEpoch], WorkflowEngine]
+
+
+class ApplicationCompositionError(RuntimeError):
+    pass
+
+
+def _load_default_identity(path: Path) -> Identity:
+    """Prefer Enoch's mutable source identity, with wheel data as fallback."""
+
+    return load_identity(path if path.is_file() else None)
+
+
+@dataclass(frozen=True)
+class ApplicationPresentation:
+    """Bounded application-level strings owned by a descendant."""
+
+    display_name: str = ""
+    ready_message: str = ""
+
+    def __post_init__(self) -> None:
+        for field_name, limit in (("display_name", 80), ("ready_message", 240)):
+            value = getattr(self, field_name)
+            if not isinstance(value, str):
+                raise ApplicationCompositionError(
+                    f"Application presentation {field_name} must be a string."
+                )
+            value = value.strip()
+            if "\n" in value or len(value) > limit:
+                raise ApplicationCompositionError(
+                    f"Application presentation {field_name} must be one line "
+                    f"and {limit} characters or fewer."
+                )
+            object.__setattr__(self, field_name, value)
+
+    def resolved_display_name(self, identity: Identity) -> str:
+        return self.display_name or identity.name
+
+    def resolved_ready_message(self, identity: Identity) -> str:
+        return self.ready_message or f"{self.resolved_display_name(identity)} is ready."
+
+
+@dataclass(frozen=True)
+class ApplicationProviderSelection:
+    chat: str = ""
+    runtime: str = ""
+    vcs: str = ""
+    forge: str = ""
+
+    def __post_init__(self) -> None:
+        for field_name in ("chat", "runtime", "vcs", "forge"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str):
+                raise ApplicationCompositionError(
+                    f"Application provider selection {field_name} must be a string."
+                )
+            value = value.strip().lower()
+            if value and not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", value):
+                raise ApplicationCompositionError(
+                    f"Invalid {field_name} provider name {value!r}."
+                )
+            object.__setattr__(self, field_name, value)
+
+
+@dataclass(frozen=True)
+class ApplicationComponents:
+    composition_name: str
+    identity: Identity
+    identity_path: Path
+    presentation: ApplicationPresentation
+    chat: ChatProvider
+    runtime: AgentRuntime
+    repository: RepositoryProvider
+    review: ReviewProvider
+    profile: AgentProfile
+    extensions: tuple[AgentExtension, ...]
+    daemon_epoch: DaemonEpoch
+    workflow: WorkflowEngine
+    authorization_policy: AuthorizationPolicy | None = None
+
+
+@dataclass(frozen=True)
+class ApplicationComposition:
+    """Versioned descendant-owned inputs to Enoch application startup."""
+
+    name: str = "enoch"
+    api_version: int = APPLICATION_COMPOSITION_API_VERSION
+    identity_loader: IdentityLoader = _load_default_identity
+    identity_path_resolver: IdentityPathResolver = identity_file_path
+    presentation: ApplicationPresentation = field(
+        default_factory=ApplicationPresentation
+    )
+    profile_name: str = ""
+    required_extensions: tuple[str, ...] = ()
+    include_configured_extensions: bool = True
+    providers: ApplicationProviderSelection = field(
+        default_factory=ApplicationProviderSelection
+    )
+    workflow_factory: WorkflowFactory | None = None
+    authorization_policy: AuthorizationPolicy | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str):
+            raise ApplicationCompositionError(
+                "Application composition name must be a string."
+            )
+        name = self.name.strip().lower()
+        if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", name):
+            raise ApplicationCompositionError(
+                f"Invalid application composition name {self.name!r}."
+            )
+        if self.api_version != APPLICATION_COMPOSITION_API_VERSION:
+            raise ApplicationCompositionError(
+                f"Application composition {name} uses API version "
+                f"{self.api_version}; Enoch supports version "
+                f"{APPLICATION_COMPOSITION_API_VERSION}."
+            )
+        if not isinstance(self.presentation, ApplicationPresentation):
+            raise ApplicationCompositionError(
+                "Application composition presentation must be "
+                "ApplicationPresentation."
+            )
+        if not isinstance(self.providers, ApplicationProviderSelection):
+            raise ApplicationCompositionError(
+                "Application composition providers must be "
+                "ApplicationProviderSelection."
+            )
+        if not callable(self.identity_loader):
+            raise ApplicationCompositionError(
+                "Application composition identity loader must be callable."
+            )
+        if not callable(self.identity_path_resolver):
+            raise ApplicationCompositionError(
+                "Application composition identity path resolver must be callable."
+            )
+        if self.workflow_factory is not None and not callable(self.workflow_factory):
+            raise ApplicationCompositionError(
+                "Application composition workflow factory must be callable."
+            )
+        if not isinstance(self.include_configured_extensions, bool):
+            raise ApplicationCompositionError(
+                "Application composition extension selection must be boolean."
+            )
+        if isinstance(self.required_extensions, str):
+            raise ApplicationCompositionError(
+                "Application composition required extensions must be a tuple."
+            )
+        try:
+            required = tuple(
+                AgentExtension(name=extension_name).name
+                for extension_name in self.required_extensions
+            )
+        except (AgentExtensionError, TypeError) as error:
+            raise ApplicationCompositionError(
+                f"Invalid required application extension: {error}"
+            ) from error
+        if len(set(required)) != len(required):
+            raise ApplicationCompositionError(
+                "Application composition required extensions must be unique."
+            )
+        object.__setattr__(self, "name", name)
+        if not isinstance(self.profile_name, str):
+            raise ApplicationCompositionError(
+                "Application composition profile name must be a string."
+            )
+        profile_name = self.profile_name.strip().lower()
+        if profile_name and not re.fullmatch(
+            r"[a-z0-9][a-z0-9._-]{0,63}",
+            profile_name,
+        ):
+            raise ApplicationCompositionError(
+                f"Invalid application profile name {self.profile_name!r}."
+            )
+        object.__setattr__(self, "profile_name", profile_name)
+        object.__setattr__(self, "required_extensions", required)
+
+    def resolve(
+        self,
+        root: Path,
+        *,
+        chat_provider_name: str = "",
+    ) -> ApplicationComponents:
+        resolved_root = Path(root).resolve()
+        mutable_identity_path = Path(
+            self.identity_path_resolver(resolved_root)
+        ).resolve()
+        try:
+            mutable_identity_path.relative_to(resolved_root)
+        except ValueError as error:
+            raise ApplicationCompositionError(
+                "Application mutable identity path must remain inside the "
+                "instance root."
+            ) from error
+
+        try:
+            identity = self.identity_loader(mutable_identity_path)
+        except (KeyError, OSError, TypeError, ValueError) as error:
+            raise ApplicationCompositionError(
+                f"Application composition {self.name} could not load identity "
+                f"from {mutable_identity_path}: {error}"
+            ) from error
+        if not isinstance(identity, Identity):
+            raise ApplicationCompositionError(
+                f"Application composition {self.name} identity loader did not "
+                "return Identity."
+            )
+
+        chat_name = chat_provider_name.strip() or self.providers.chat
+        chat = load_provider("chat", resolved_root, name=chat_name)
+        runtime = load_provider(
+            "runtime",
+            resolved_root,
+            name=self.providers.runtime,
+        )
+        repository = as_repository_provider(
+            load_provider("vcs", resolved_root, name=self.providers.vcs)
+        )
+        review = as_review_provider(
+            load_provider("forge", resolved_root, name=self.providers.forge)
+        )
+        profile = load_profile(resolved_root, name=self.profile_name)
+        extensions = self._resolve_extensions(resolved_root)
+        provider_name = str(getattr(chat, "name", "chat")).strip() or "chat"
+        daemon_epoch = begin_daemon_epoch(
+            resolved_root,
+            provider=provider_name,
+        )
+        workflow = validate_workflow_engine(
+            (
+                self.workflow_factory(resolved_root, daemon_epoch)
+                if self.workflow_factory is not None
+                else LocalWorkflowEngine(resolved_root, epoch=daemon_epoch)
+            )
+        )
+        return ApplicationComponents(
+            composition_name=self.name,
+            identity=identity,
+            identity_path=mutable_identity_path,
+            presentation=self.presentation,
+            chat=chat,
+            runtime=runtime,
+            repository=repository,
+            review=review,
+            profile=profile,
+            extensions=extensions,
+            daemon_epoch=daemon_epoch,
+            workflow=workflow,
+            authorization_policy=self.authorization_policy,
+        )
+
+    def _resolve_extensions(self, root: Path) -> tuple[AgentExtension, ...]:
+        configured = (
+            load_extensions(root)
+            if self.include_configured_extensions
+            else ()
+        )
+        configured_by_name = {
+            extension.name: extension
+            for extension in configured
+        }
+        required = []
+        for name in self.required_extensions:
+            extension = configured_by_name.get(name)
+            if extension is None:
+                extension = load_extensions(root, names=(name,))[0]
+            required.append(extension)
+        required_names = set(self.required_extensions)
+        return (
+            *required,
+            *(
+                extension
+                for extension in configured
+                if extension.name not in required_names
+            ),
+        )
+
+
+def run_application(
+    composition: ApplicationComposition,
+    *,
+    chat_provider_name: str = "",
+) -> None:
+    """Run a composed descendant through Enoch's owned lifecycle."""
+
+    from enoch.app.core import main
+
+    main(
+        chat_provider_name=chat_provider_name,
+        composition=composition,
+    )
+
+
+__all__ = [
+    "APPLICATION_COMPOSITION_API_VERSION",
+    "ApplicationComponents",
+    "ApplicationComposition",
+    "ApplicationCompositionError",
+    "ApplicationPresentation",
+    "ApplicationProviderSelection",
+    "IdentityLoader",
+    "IdentityPathResolver",
+    "WorkflowFactory",
+    "run_application",
+]

--- a/src/enoch/brain.py
+++ b/src/enoch/brain.py
@@ -375,7 +375,7 @@ def _respond_with_persistent_session_result(
     execution: RuntimeExecutionControl,
 ) -> RuntimeResult:
     state = load_codex_session(session_key, cwd)
-    prompt = _build_persistent_prompt(message, cwd, state)
+    prompt = _build_persistent_prompt(identity, message, cwd, state)
     try:
         result = _run_codex_result(
             identity,
@@ -393,7 +393,7 @@ def _respond_with_persistent_session_result(
         if state is None:
             raise
         forget_codex_session(session_key, cwd)
-        recovery_prompt = _build_persistent_recovery_prompt(message, cwd)
+        recovery_prompt = _build_persistent_recovery_prompt(identity, message, cwd)
         result = _run_codex_result(
             identity,
             recovery_prompt,
@@ -488,7 +488,7 @@ def _act_with_persistent_session_result(
 ) -> RuntimeResult:
     state_root = state_root or cwd
     state = load_codex_session(session_key, state_root)
-    prompt = _build_persistent_prompt(message, state_root, state)
+    prompt = _build_persistent_prompt(identity, message, state_root, state)
     try:
         result = _run_codex_result(
             identity,
@@ -506,7 +506,11 @@ def _act_with_persistent_session_result(
         if state is None:
             raise
         forget_codex_session(session_key, state_root)
-        recovery_prompt = _build_persistent_recovery_prompt(message, state_root)
+        recovery_prompt = _build_persistent_recovery_prompt(
+            identity,
+            message,
+            state_root,
+        )
         result = _run_codex_result(
             identity,
             recovery_prompt,
@@ -529,12 +533,13 @@ def _act_with_persistent_session_result(
 
 
 def _build_persistent_prompt(
+    identity: Identity,
     message: str,
     root: Path | None,
     state: CodexSessionState | None,
 ) -> str:
     if state is None:
-        return _build_persistent_startup_message(message, root)
+        return _build_persistent_startup_message(identity, message, root)
     return _build_persistent_human_message(message)
 
 
@@ -542,14 +547,22 @@ def _build_persistent_human_message(message: str) -> str:
     return f"Human message:\n{message}"
 
 
-def _build_persistent_recovery_prompt(message: str, root: Path | None) -> str:
-    return _build_persistent_startup_message(message, root)
+def _build_persistent_recovery_prompt(
+    identity: Identity,
+    message: str,
+    root: Path | None,
+) -> str:
+    return _build_persistent_startup_message(identity, message, root)
 
 
-def _build_persistent_startup_message(message: str, root: Path | None) -> str:
+def _build_persistent_startup_message(
+    identity: Identity,
+    message: str,
+    root: Path | None,
+) -> str:
     return "\n\n".join(
         [
-            startup_context_note(memory_for_prompt(root)),
+            startup_context_note(memory_for_prompt(root, identity=identity)),
             "Human message:",
             message,
         ]

--- a/src/enoch/commands.py
+++ b/src/enoch/commands.py
@@ -141,11 +141,20 @@ def identity_summary(identity: Identity, root: Path | None = None) -> str:
     )
 
 
-def mission_command(text: str, identity: Identity, root: Path, *, prefix: str = "/") -> str:
+def mission_command(
+    text: str,
+    identity: Identity,
+    root: Path,
+    *,
+    prefix: str = "/",
+    identity_path: Path | None = None,
+    display_name: str = "",
+) -> str:
     parts = text.split(maxsplit=1)
     command = f"{prefix}mission"
+    name = display_name.strip() or identity.name
     if len(parts) == 1:
-        current = _current_identity(identity, root)
+        current = _current_identity(identity, root, identity_path=identity_path)
         return "\n".join(
             [
                 f"{current.name} mission:",
@@ -155,15 +164,20 @@ def mission_command(text: str, identity: Identity, root: Path, *, prefix: str = 
             ]
         )
     try:
-        mission = update_mission(parts[1], root)
+        mission = update_mission(parts[1], root, path=identity_path)
     except (OSError, ValueError) as error:
-        return f"Enoch could not update her mission: {error}"
-    return f"Enoch mission updated.\nMission: {mission}"
+        return f"{name} could not update the mission: {error}"
+    return f"{name} mission updated.\nMission: {mission}"
 
 
-def _current_identity(identity: Identity, root: Path) -> Identity:
+def _current_identity(
+    identity: Identity,
+    root: Path,
+    *,
+    identity_path: Path | None = None,
+) -> Identity:
     try:
-        return load_identity(identity_file_path(root))
+        return load_identity(identity_path or identity_file_path(root))
     except (OSError, ValueError, KeyError):
         return identity
 

--- a/src/enoch/conformance/__init__.py
+++ b/src/enoch/conformance/__init__.py
@@ -14,6 +14,7 @@ from our_ark_provider_kit.conformance import (
 )
 
 from enoch.conformance.profile import ProfileCommandCase, ProfileConformanceMixin
+from enoch.conformance.application import ApplicationCompositionConformanceMixin
 from enoch.conformance.extension import (
     AgentExtensionConformanceMixin,
     ExtensionCommandCase,
@@ -25,6 +26,7 @@ from enoch.conformance.workflow import WorkflowEngineConformanceMixin
 __all__ = [
     "CONFORMANCE_API_VERSION",
     "AgentRuntimeConformanceMixin",
+    "ApplicationCompositionConformanceMixin",
     "AgentExtensionConformanceMixin",
     "DurableNotificationConformanceMixin",
     "ExtensionCommandCase",

--- a/src/enoch/conformance/application.py
+++ b/src/enoch/conformance/application.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from enoch.application import (
+    APPLICATION_COMPOSITION_API_VERSION,
+    ApplicationComposition,
+)
+from enoch.identity import Identity
+
+
+class ApplicationCompositionConformanceMixin:
+    """Reusable structural checks for descendant application compositions."""
+
+    def create_composition(self) -> ApplicationComposition:
+        raise NotImplementedError
+
+    def test_conformance_application_composition_uses_public_api_version(
+        self,
+    ) -> None:
+        composition = self.create_composition()
+
+        self.assertIsInstance(composition, ApplicationComposition)
+        self.assertEqual(
+            composition.api_version,
+            APPLICATION_COMPOSITION_API_VERSION,
+        )
+        self.assertTrue(composition.name)
+
+    def test_conformance_application_composition_owns_identity_boundary(
+        self,
+    ) -> None:
+        composition = self.create_composition()
+        root = Path.cwd().resolve()
+        identity_path = Path(
+            composition.identity_path_resolver(root)
+        ).resolve()
+        identity = composition.identity_loader(identity_path)
+
+        self.assertIsInstance(identity, Identity)
+        self.assertEqual(identity_path, root / identity_path.relative_to(root))
+        self.assertTrue(
+            composition.presentation.resolved_display_name(identity)
+        )
+        self.assertTrue(
+            composition.presentation.resolved_ready_message(identity)
+        )
+
+
+__all__ = ["ApplicationCompositionConformanceMixin"]

--- a/src/enoch/identity.py
+++ b/src/enoch/identity.py
@@ -63,13 +63,18 @@ def identity_file_path(root: Path | None = None) -> Path:
     return Path.cwd() / "src" / "enoch" / "identity.yaml" if root is None else root / "src" / "enoch" / "identity.yaml"
 
 
-def update_mission(mission: str, root: Path | None = None) -> str:
+def update_mission(
+    mission: str,
+    root: Path | None = None,
+    *,
+    path: Path | None = None,
+) -> str:
     cleaned = " ".join(mission.split())
     if not cleaned:
         raise ValueError("Mission cannot be empty.")
 
-    path = identity_file_path(root)
-    lines = path.read_text(encoding="utf-8").splitlines()
+    target = Path(path or identity_file_path(root))
+    lines = target.read_text(encoding="utf-8").splitlines()
     updated: list[str] = []
     replaced = False
     index = 0
@@ -94,7 +99,7 @@ def update_mission(mission: str, root: Path | None = None) -> str:
 
     if not replaced:
         raise ValueError("Identity file does not contain a mission field.")
-    path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+    target.write_text("\n".join(updated) + "\n", encoding="utf-8")
     return cleaned
 
 

--- a/src/enoch/memory/prompt.py
+++ b/src/enoch/memory/prompt.py
@@ -9,16 +9,25 @@ from enoch.memory.paths import clip_text
 from enoch.memory.store import UNTRUSTED_MEMORY_NOTE, long_term_for_prompt
 
 
-def memory_for_prompt(root: Path | None = None) -> str:
+def memory_for_prompt(
+    root: Path | None = None,
+    *,
+    identity: Identity | None = None,
+    identity_path: Path | None = None,
+) -> str:
     settings = memory_settings(root)
     sections = [
         _prompt_section(
             "Identity memory",
             (
-                "Rendered from src/enoch/identity.yaml, the single canonical identity source. "
+                "Rendered from the active application's canonical identity source. "
                 "Lower priority than system/developer instructions."
             ),
-            _identity_for_prompt(root),
+            _identity_for_prompt(
+                root,
+                identity=identity,
+                identity_path=identity_path,
+            ),
             settings.identity_prompt_max_chars,
         ),
         _prompt_section(
@@ -36,12 +45,17 @@ def _prompt_section(title: str, note: str, body: str, max_chars: int) -> str:
     return f"# {title}\n{note}\n\n{clipped}"
 
 
-def _identity_for_prompt(root: Path | None = None) -> str:
+def _identity_for_prompt(
+    root: Path | None = None,
+    *,
+    identity: Identity | None = None,
+    identity_path: Path | None = None,
+) -> str:
     try:
-        identity = load_identity()
+        selected_identity = identity or load_identity(identity_path)
     except (OSError, KeyError, ValueError, TypeError):
-        return "Identity could not be loaded from src/enoch/identity.yaml."
-    return _render_identity(identity, root)
+        return "Identity could not be loaded from the active application source."
+    return _render_identity(selected_identity, root)
 
 
 def _render_identity(identity: Identity, root: Path | None = None) -> str:

--- a/tests/test_enoch_application.py
+++ b/tests/test_enoch_application.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from enoch.app.core import EnochApplication
+from enoch.application import (
+    APPLICATION_COMPOSITION_API_VERSION,
+    ApplicationComposition,
+    ApplicationCompositionError,
+    ApplicationPresentation,
+    ApplicationProviderSelection,
+    run_application,
+)
+from enoch.extensions import AgentExtension
+from enoch.identity import load_identity, update_mission
+from enoch.memory.prompt import memory_for_prompt
+from enoch.profiles import AgentProfile
+from enoch.providers import ChatEvent, ProviderHealth
+from enoch.workflows import LocalWorkflowEngine
+from our_ark_provider_kit import (
+    BranchlessRepositoryFixture,
+    IndependentReviewFixture,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ApplicationCompositionTests(unittest.TestCase):
+    def test_composition_resolves_descendant_owned_startup_components(self) -> None:
+        identity = load_identity()
+        chat = _Chat()
+        runtime = _Runtime()
+        repository = BranchlessRepositoryFixture()
+        review = IndependentReviewFixture()
+        manager = AgentExtension(name="manager")
+        configured = AgentExtension(name="configured")
+        profile = AgentProfile(name="coordinator")
+        provider_calls = []
+        workflow_calls = []
+
+        def provider(kind, root, *, name=""):
+            provider_calls.append((kind, Path(root), name))
+            return {
+                "chat": chat,
+                "runtime": runtime,
+                "vcs": repository,
+                "forge": review,
+            }[kind]
+
+        def extensions(_root, *, names=None):
+            return (configured,) if names is None else (manager,)
+
+        def workflow_factory(root, epoch):
+            workflow_calls.append((root, epoch))
+            return LocalWorkflowEngine(root, epoch=epoch)
+
+        composition = ApplicationComposition(
+            name="noah",
+            identity_loader=lambda _path: identity,
+            identity_path_resolver=lambda root: root / "src/noah/identity.yaml",
+            presentation=ApplicationPresentation(
+                display_name="Noah",
+                ready_message="Noah is ready to coordinate.",
+            ),
+            profile_name="coordinator",
+            required_extensions=("manager",),
+            providers=ApplicationProviderSelection(
+                chat="default-chat",
+                runtime="codex",
+                vcs="local",
+                forge="local",
+            ),
+            workflow_factory=workflow_factory,
+        )
+        with TemporaryDirectory() as temp, patch(
+            "enoch.application.load_provider",
+            side_effect=provider,
+        ), patch(
+            "enoch.application.load_profile",
+            return_value=profile,
+        ) as load_selected_profile, patch(
+            "enoch.application.load_extensions",
+            side_effect=extensions,
+        ):
+            root = Path(temp)
+            components = composition.resolve(
+                root,
+                chat_provider_name="telegram",
+            )
+
+        self.assertEqual(
+            composition.api_version,
+            APPLICATION_COMPOSITION_API_VERSION,
+        )
+        self.assertEqual(components.composition_name, "noah")
+        self.assertIs(components.identity, identity)
+        self.assertEqual(
+            components.identity_path,
+            root.resolve() / "src/noah/identity.yaml",
+        )
+        self.assertEqual(
+            tuple(extension.name for extension in components.extensions),
+            ("manager", "configured"),
+        )
+        self.assertIs(components.profile, profile)
+        self.assertIs(components.chat, chat)
+        self.assertIs(components.runtime, runtime)
+        self.assertIs(components.repository, repository)
+        self.assertIs(components.review, review)
+        self.assertEqual(
+            tuple((kind, name) for kind, _root, name in provider_calls),
+            (
+                ("chat", "telegram"),
+                ("runtime", "codex"),
+                ("vcs", "local"),
+                ("forge", "local"),
+            ),
+        )
+        load_selected_profile.assert_called_once_with(
+            root.resolve(),
+            name="coordinator",
+        )
+        self.assertEqual(len(workflow_calls), 1)
+        self.assertIs(components.workflow.epoch, components.daemon_epoch)
+
+    def test_composition_rejects_identity_path_outside_instance(self) -> None:
+        composition = ApplicationComposition(
+            identity_path_resolver=lambda _root: Path("/tmp/outside/identity.yaml")
+        )
+        with TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(
+                ApplicationCompositionError,
+                "inside the instance root",
+            ):
+                composition.resolve(Path(temp))
+
+    def test_composition_reloads_mutable_identity_after_restart(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            identity_path = root / "src/noah/identity.yaml"
+            identity_path.parent.mkdir(parents=True)
+            shutil.copyfile(ROOT / "src/enoch/identity.yaml", identity_path)
+            composition = ApplicationComposition(
+                name="noah",
+                identity_loader=load_identity,
+                identity_path_resolver=lambda _root: identity_path,
+            )
+            providers = {
+                "chat": _Chat(),
+                "runtime": _Runtime(),
+                "vcs": BranchlessRepositoryFixture(),
+                "forge": IndependentReviewFixture(),
+            }
+            with patch(
+                "enoch.application.load_provider",
+                side_effect=lambda kind, _root, *, name="": providers[kind],
+            ), patch(
+                "enoch.application.load_profile",
+                return_value=AgentProfile(name="default"),
+            ), patch(
+                "enoch.application.load_extensions",
+                return_value=(),
+            ):
+                first = composition.resolve(root)
+                update_mission(
+                    "Coordinate the durable project.",
+                    path=identity_path,
+                )
+                restarted = composition.resolve(root)
+
+        self.assertNotEqual(
+            first.identity.mission,
+            "Coordinate the durable project.",
+        )
+        self.assertEqual(
+            restarted.identity.mission,
+            "Coordinate the durable project.",
+        )
+
+    def test_custom_identity_path_and_presentation_drive_application(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            identity_path = root / "src/noah/identity.yaml"
+            identity_path.parent.mkdir(parents=True)
+            shutil.copyfile(ROOT / "src/enoch/identity.yaml", identity_path)
+            identity_path.write_text(
+                identity_path.read_text(encoding="utf-8").replace(
+                    "name: Enoch",
+                    "name: Noah",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            chat = _Chat()
+            app = EnochApplication(
+                load_identity(identity_path),
+                root,
+                chat,
+                runtime=_Runtime(),
+                repository=BranchlessRepositoryFixture(),
+                review=IndependentReviewFixture(),
+                identity_path=identity_path,
+                presentation=ApplicationPresentation(
+                    display_name="Noah",
+                    ready_message="Noah is ready to coordinate.",
+                ),
+            )
+
+            app.handle_event(_event("/start", "start"))
+            app.handle_event(
+                _event("/mission Coordinate the whole project.", "mission")
+            )
+            reloaded = load_identity(identity_path)
+            prompt_memory = memory_for_prompt(
+                root,
+                identity=app.identity,
+                identity_path=identity_path,
+            )
+
+        self.assertEqual(chat.sent[0][1].splitlines()[0], "Noah is ready to coordinate.")
+        self.assertEqual(
+            chat.sent[1][1],
+            "Noah mission updated.\nMission: Coordinate the whole project.",
+        )
+        self.assertEqual(reloaded.mission, "Coordinate the whole project.")
+        self.assertEqual(app.identity.mission, "Coordinate the whole project.")
+        self.assertIn("Name: Noah", prompt_memory)
+        self.assertIn("Mission: Coordinate the whole project.", prompt_memory)
+
+    def test_run_application_delegates_to_enoch_owned_runner(self) -> None:
+        composition = ApplicationComposition()
+        with patch("enoch.app.core.main") as main:
+            run_application(composition, chat_provider_name="telegram")
+
+        main.assert_called_once_with(
+            chat_provider_name="telegram",
+            composition=composition,
+        )
+
+    def test_composition_validates_version_and_bounded_presentation(self) -> None:
+        with self.assertRaisesRegex(
+            ApplicationCompositionError,
+            "supports version",
+        ):
+            ApplicationComposition(
+                api_version=APPLICATION_COMPOSITION_API_VERSION + 1
+            )
+        with self.assertRaisesRegex(
+            ApplicationCompositionError,
+            "one line",
+        ):
+            ApplicationPresentation(ready_message="line one\nline two")
+
+
+class _Chat:
+    name = "composition-chat"
+    provider_kind = "chat"
+
+    def __init__(self) -> None:
+        self.sent = []
+
+    @property
+    def allowed_conversation_id(self):
+        return "room-1"
+
+    def receive(self, cursor=None):
+        return ()
+
+    def send_message(self, conversation_id, text):
+        self.sent.append((conversation_id, text))
+        return "message-1"
+
+    def edit_message(self, conversation_id, message_id, text):
+        return None
+
+    def send_read_ack(self, conversation_id, message_id):
+        return None
+
+
+class _Runtime:
+    name = "composition-runtime"
+    provider_kind = "runtime"
+    config_section = "composition-runtime"
+
+    def respond(self, identity, message, **kwargs):
+        return "response"
+
+    def act_in_session(self, identity, message, **kwargs):
+        return "task response"
+
+    def model_summary(self, root=None):
+        return "composition runtime"
+
+    def model_options(self):
+        return ()
+
+    def reset_usage(self):
+        return None
+
+    def health(self, root=None):
+        return ProviderHealth("composition runtime", True, "doctor", "ready")
+
+
+def _event(text: str, message_id: str) -> ChatEvent:
+    return ChatEvent(
+        cursor=message_id,
+        conversation_id="room-1",
+        message_id=message_id,
+        text=text,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enoch_brain.py
+++ b/tests/test_enoch_brain.py
@@ -523,7 +523,7 @@ class EnochBrainTests(unittest.TestCase):
         self.assertIn("Enoch startup context:", prompt)
         self.assertIn("Identity and long-term memory.", prompt)
         self.assertIn("Human message:\n\nhello", prompt)
-        _memory.assert_called_once_with(root)
+        _memory.assert_called_once_with(root, identity=load_identity())
         self.assertIsNotNone(state)
         assert state is not None
         self.assertEqual(state.session_id, "session-123")
@@ -642,7 +642,7 @@ class EnochBrainTests(unittest.TestCase):
         self.assertIn("Enoch startup context:", prompt)
         self.assertIn("Old memory should not be sent.", prompt)
         self.assertIn("Human message:\n\nhello", prompt)
-        _memory.assert_called_once_with(root)
+        _memory.assert_called_once_with(root, identity=load_identity())
         self.assertEqual(answer, "Fresh session")
         self.assertIsNotNone(state)
         assert state is not None

--- a/tests/test_enoch_conformance.py
+++ b/tests/test_enoch_conformance.py
@@ -5,12 +5,14 @@ from enoch.app.epoch import DaemonEpoch
 from enoch.conformance import (
     AgentExtensionConformanceMixin,
     AgentRuntimeConformanceMixin,
+    ApplicationCompositionConformanceMixin,
     DurableNotificationConformanceMixin,
     ExtensionCommandCase,
     ProfileCommandCase,
     ProfileConformanceMixin,
     WorkflowEngineConformanceMixin,
 )
+from enoch.application import ApplicationComposition
 from enoch.extensions import (
     AgentExtension,
     ExtensionCommandResult,
@@ -62,6 +64,14 @@ class FunctionRuntimeConformanceTests(
             name="conformance",
             config_section="conformance",
         )
+
+
+class DefaultApplicationCompositionConformanceTests(
+    ApplicationCompositionConformanceMixin,
+    unittest.TestCase,
+):
+    def create_composition(self) -> ApplicationComposition:
+        return ApplicationComposition()
 
 
 class LocalWorkflowConformanceTests(

--- a/tests/test_enoch_memory.py
+++ b/tests/test_enoch_memory.py
@@ -23,7 +23,10 @@ class EnochMemoryTests(unittest.TestCase):
 
             self.assertTrue(long_term_memory_path(root).exists())
             self.assertIn("# Identity memory", prompt_memory)
-            self.assertIn("Rendered from src/enoch/identity.yaml", prompt_memory)
+            self.assertIn(
+                "Rendered from the active application's canonical identity source",
+                prompt_memory,
+            )
             self.assertIn("Name: Enoch", prompt_memory)
             self.assertIn("Mission: Work alongside her human", prompt_memory)
             self.assertIn("# Long-term memory", prompt_memory)

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -182,6 +182,8 @@ class EnochPortableInstallTests(unittest.TestCase):
         self.assertEqual(result["extension"], "notes")
         self.assertEqual(result["extension_version"], "0.0.1")
         self.assertEqual(result["extension_api_version"], 1)
+        self.assertEqual(result["composition_api_version"], 1)
+        self.assertEqual(result["composition"], "portable-descendant")
         self.assertEqual(result["workflow_api_version"], 3)
         self.assertEqual(result["conformance_api_version"], 1)
         self.assertEqual(result["repository_contract_version"], 1)
@@ -646,32 +648,47 @@ def _write_extension_package(root: Path) -> None:
 _INSTALLED_TASK_SCRIPT = textwrap.dedent(
     """
     import json
+    from importlib import resources
     from importlib.metadata import version
     from pathlib import Path
     import subprocess
     import sys
 
     from enoch.app.core import EnochApplication
+    from enoch.app.epoch import daemon_epoch_guard
+    from enoch.application import (
+        APPLICATION_COMPOSITION_API_VERSION,
+        ApplicationComposition,
+        ApplicationPresentation,
+    )
     from enoch.conformance import CONFORMANCE_API_VERSION
-    from enoch.extensions import AGENT_EXTENSION_API_VERSION, load_extensions
+    from enoch.extensions import AGENT_EXTENSION_API_VERSION
     from enoch.identity import load_identity
-    from enoch.profiles import load_profile
     from enoch.providers import (
         REPOSITORY_CONTRACT_VERSION,
         REVIEW_CONTRACT_VERSION,
         ChatEvent,
-        load_provider,
     )
     from enoch.workflows import LocalWorkflowEngine
 
 
     root = Path(sys.argv[1])
     root.mkdir()
+    (root / "identity.yaml").write_text(
+        resources.files("enoch").joinpath("identity.yaml").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
 
     class InstalledWorkflow(LocalWorkflowEngine):
-        def __init__(self, root):
-            super().__init__(root)
+        def __init__(self, root, epoch, epoch_root):
+            super().__init__(root, epoch=epoch)
+            self.epoch_root = epoch_root
             self.operations = []
+
+        def _mutation(self):
+            return daemon_epoch_guard(self.epoch, self.epoch_root)
 
         def enqueue(self, conversation_id, request, *, mode="queued", **options):
             self.operations.append("enqueue")
@@ -714,22 +731,42 @@ _INSTALLED_TASK_SCRIPT = textwrap.dedent(
         encoding="utf-8",
     )
 
-    chat = load_provider("chat", root)
-    runtime = load_provider("runtime", root)
-    vcs = load_provider("vcs", root)
-    forge = load_provider("forge", root)
-    profile = load_profile(root)
-    extensions = load_extensions(root)
-    workflow = InstalledWorkflow(root.parent / "workflow-state")
+    composition = ApplicationComposition(
+        name="portable-descendant",
+        identity_loader=load_identity,
+        identity_path_resolver=lambda body: body / "identity.yaml",
+        presentation=ApplicationPresentation(
+            display_name="Portable descendant",
+            ready_message="Portable descendant is ready.",
+        ),
+        required_extensions=("notes",),
+        workflow_factory=lambda _body, epoch: InstalledWorkflow(
+            root.parent / "workflow-state",
+            epoch,
+            root,
+        ),
+    )
+    components = composition.resolve(root)
+    chat = components.chat
+    runtime = components.runtime
+    vcs = components.repository
+    forge = components.review
+    profile = components.profile
+    extensions = components.extensions
+    workflow = components.workflow
     app = EnochApplication(
-        identity=load_identity(),
+        identity=components.identity,
         root=root,
         client=chat,
         runtime=runtime,
-        forge=forge,
+        repository=vcs,
+        review=forge,
         profile=profile,
         extensions=extensions,
+        daemon_epoch=components.daemon_epoch,
         workflow=workflow,
+        identity_path=components.identity_path,
+        presentation=components.presentation,
     )
     app.notify_startup()
     app.handle_event(
@@ -817,6 +854,8 @@ _INSTALLED_TASK_SCRIPT = textwrap.dedent(
         "extension": extensions[0].name,
         "extension_version": version("enoch-portable-notes-extension"),
         "extension_api_version": AGENT_EXTENSION_API_VERSION,
+        "composition_api_version": APPLICATION_COMPOSITION_API_VERSION,
+        "composition": components.composition_name,
         "workflow_api_version": workflow.api_version,
         "conformance_api_version": CONFORMANCE_API_VERSION,
         "repository_contract_version": REPOSITORY_CONTRACT_VERSION,


### PR DESCRIPTION
## Summary

- add a versioned `ApplicationComposition` startup boundary for descendant agents
- let descendants select identity, mutable identity path, presentation, providers, profile, extensions, authorization policy, and workflow factory while Enoch retains lifecycle ownership
- propagate the composed identity through `/mission`, startup context, and persistent runtime sessions
- add reusable conformance coverage, documentation, and an installed-wheel integration test

## Verification

- `PYTHONPATH=src python3 -m unittest discover -s tests -t .` — 792 tests passed
- `git diff --check`

## Release

This PR intentionally does not change the package version, create a tag, or publish Enoch 0.5.0. Noah integration and cross-repository gates will follow after this API lands.