### PR TITLE
Prepare Enoch v0.5.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,11 +7,11 @@ authors:
     given-names: Gary
   - family-names: Zhao
     given-names: Roy
-version: 0.4.0
-date-released: 2026-07-29
+version: 0.5.0
+date-released: 2026-07-31
 license: Apache-2.0
 repository-code: "https://github.com/our-ark/enoch"
-url: "https://github.com/our-ark/enoch/releases/tag/v0.4.0"
+url: "https://github.com/our-ark/enoch/releases/tag/v0.5.0"
 keywords:
   - agent-owned software
   - personal agents

--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ identity and mission, and validates it against inherited contracts.
 Genesis is open source at
 [`our-ark/genesis`](https://github.com/our-ark/genesis). The current stable
 public path pairs [Genesis
-v0.1.1](https://github.com/our-ark/genesis/releases/tag/v0.1.1) with [Enoch
-v0.4.0](https://github.com/our-ark/enoch/releases/tag/v0.4.0). The command below
+v0.2.0](https://github.com/our-ark/genesis/releases/tag/v0.2.0) with [Enoch
+v0.5.0](https://github.com/our-ark/enoch/releases/tag/v0.5.0). The command below
 uses adjacent clean checkouts so the selected Enoch source is explicit.
 
 Enoch is a public Genesis-compatible reference body. Its `genesis.toml`

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,66 @@
+# Enoch v0.5.0
+
+Enoch v0.5.0 makes Enoch an extensible application kernel for descendant
+agents. A descendant can now compose its own identity, presentation, providers,
+profile, extensions, authorization policy, and workflow while Enoch remains the
+single owner of polling, recovery, task execution, publication, delivery, and
+shutdown.
+
+## Highlights
+
+- Added the versioned `ApplicationComposition` API and `run_application()`
+  launcher. Descendants configure bounded startup inputs without subclassing
+  `EnochApplication` or taking ownership of its lifecycle.
+- Added descendant-owned identity loading and mutable identity paths. `/mission`,
+  prompt memory, and persistent runtime sessions now use the composed identity,
+  and mission updates survive process restarts.
+- Added application-level presentation, provider, profile, extension,
+  authorization, and workflow selection with explicit precedence and
+  fail-before-polling validation.
+- Added `ApplicationCompositionConformanceMixin` and expanded the offline wheel
+  E2E to exercise an independently packaged composition with provider, profile,
+  extension, and fenced-workflow dependencies.
+- Added typed `ExtensionCommandResult` responses so extension commands can
+  report success or failure, durable task identities, and structured metadata
+  while remaining compatible with existing string responses.
+- Added extension-scoped task inspection, cancellation, retry, and approval
+  controls without exposing the unrestricted core workflow engine.
+- Made explicit instance roots authoritative across CLI, storage, and
+  application startup paths.
+- Validated the composition boundary with Noah as a real descendant: Noah
+  injects its identity, presentation, providers, and required Manager extension
+  through Enoch's public application API.
+
+## Validation
+
+- The 792-test Enoch body suite passes.
+- All 72 reference provider and library tests pass independently.
+- The Genesis cross-artifact gate creates and validates a fresh descendant from
+  the v0.5.0 release candidate.
+- Noah's Enoch-backed launcher, Manager extension, installed wheel, and
+  Genesis-to-Noah descendant gates pass against this release body.
+- GitHub Actions covers Python 3.11, 3.12, 3.13, and 3.14.
+
+## Compatibility
+
+- Python 3.11 or newer.
+- `genesis.toml` schema version 1.
+- Application Composition API version 1.
+- Agent Extension API version 1.
+- Extension Command Result API version 1.
+- Workflow API version 3.
+- Profile API version 5.
+- Provider-kit `0.7.0`.
+- Genesis v0.2.0 or a later compatible build.
+- Existing Enoch launchers use the default composition and retain their current
+  behavior.
+- Existing extension commands returning strings remain supported.
+- Extension packages and composition factories are trusted Python code rather
+  than sandbox boundaries.
+- Durable task-event delivery remains at least once. Consumers must apply
+  stable event IDs idempotently because a crash can occur after an extension
+  changes its state but before Enoch records the success receipt.
+
+Credentials, memories, logs, chat identifiers, task state, extension state,
+and instance configuration remain outside both the public source archive and
+the inheritable software body.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enoch"
-version = "0.4.0"
+version = "0.5.0"
 description = "Enoch is a Genesis-created local agent."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -173,7 +173,7 @@ class EnochPortableInstallTests(unittest.TestCase):
         self.assertEqual(result["vcs"], "portable-vcs")
         self.assertEqual(result["runtime"], "codex")
         self.assertEqual(result["forge"], "local")
-        self.assertEqual(result["enoch_version"], "0.4.0")
+        self.assertEqual(result["enoch_version"], "0.5.0")
         self.assertEqual(result["provider_kit_version"], "0.7.0")
         self.assertEqual(result["chat_provider_version"], "0.0.1")
         self.assertEqual(result["vcs_provider_version"], "0.0.1")


### PR DESCRIPTION
## Summary

- release Enoch 0.5.0 as an extensible application kernel for descendant agents
- document ApplicationComposition API v1, typed extension results, extension-scoped task lifecycle controls, and explicit instance-root correctness
- advance package and citation metadata to 0.5.0
- pair the stable public descent path with Genesis v0.2.0

## Impact

Descendants such as Noah can now inject identity, presentation, providers, profile, extensions, authorization, and workflow selection through a versioned public startup boundary while Enoch continues to own polling, recovery, execution, publication, delivery, and shutdown.

Existing Enoch launchers retain the default composition, and existing extension commands returning strings remain compatible.

## Validation

- `PYTHONPATH=src python -m unittest discover -s tests -t .` — 792 tests passed
- seven reference provider/library suites — 72 tests passed
- Genesis v0.2.0 cross-artifact descent from commit `9ccf4d8` — passed
- Noah launcher, Manager extension, installed wheel, and Genesis-to-Noah integration gates were validated against the release body
- GitHub Actions covers Python 3.11, 3.12, 3.13, and 3.14
