### PR TITLE
Use application name in update messages

### DIFF
--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -4651,6 +4651,9 @@ class EnochApplication:
                 update_from_authoritative,
                 self.root,
                 repository=self.repository,
+                application_name=self.presentation.resolved_display_name(
+                    self.identity
+                ),
             )
         except CapabilityAuthorizationError as error:
             return str(error)

--- a/src/enoch/operations/updater.py
+++ b/src/enoch/operations/updater.py
@@ -36,7 +36,9 @@ def update_from_authoritative(
     root: Path,
     *,
     repository: RepositoryProvider | None = None,
+    application_name: str = "Enoch",
 ) -> UpdateResult:
+    application_name = application_name.strip() or "Enoch"
     repository = repository or as_repository_provider(load_provider("vcs", root))
     try:
         working_copy = repository.inspect_working_copy(root)
@@ -57,7 +59,7 @@ def update_from_authoritative(
             )
         ):
             return _message(
-                "Enoch could not update: current revision "
+                f"{application_name} could not update: current revision "
                 f"{previous_revision.id} is not in the history of authoritative "
                 f"revision {authoritative.revision.id}. Finish or publish that work first."
             )
@@ -73,7 +75,7 @@ def update_from_authoritative(
                 f"{authoritative.revision.id}."
             )
     except RepositoryProviderError as error:
-        return _message(f"Enoch could not update: {error}")
+        return _message(f"{application_name} could not update: {error}")
 
     previous_head = previous_revision.id
     updated_head = updated_revision.id
@@ -90,7 +92,14 @@ def update_from_authoritative(
     if previous_head == updated_head:
         restart_note = _running_commit_restart_note(root, updated_head)
         return UpdateResult(
-            message="\n\n".join(part for part in ["Enoch is already up to date.", restart_note] if part),
+            message="\n\n".join(
+                part
+                for part in [
+                    f"{application_name} is already up to date.",
+                    restart_note,
+                ]
+                if part
+            ),
             direct_action_result="\n\n".join(
                 part for part in [update_summary, restart_note] if part
             ),
@@ -109,10 +118,12 @@ def update_from_authoritative(
         return _message(
             "\n\n".join(
                 [
-                    f"Enoch updated to latest {authoritative_name}, but doctor failed. I am not restarting.",
+                    f"{application_name} updated to latest {authoritative_name}, "
+                    "but doctor failed. I am not restarting.",
                     format_doctor_result(doctor),
                     rollback,
-                    "The currently running Enoch process is still the pre-update code.",
+                    f"The currently running {application_name} process is still "
+                    "the pre-update code.",
                 ]
             )
         )
@@ -122,9 +133,11 @@ def update_from_authoritative(
         message="\n\n".join(
             part
             for part in [
-                f"Enoch updated to latest {authoritative_name} and doctor passed.",
+                f"{application_name} updated to latest {authoritative_name} "
+                "and doctor passed.",
                 formatted_doctor,
-                "Restarting now. The startup notification will confirm Enoch came back.",
+                "Restarting now. The startup notification will confirm "
+                f"{application_name} came back.",
             ]
             if part
         ),
@@ -144,9 +157,13 @@ def update_from_authoritative(
     )
 
 
-def update_from_main(root: Path) -> UpdateResult:
+def update_from_main(
+    root: Path,
+    *,
+    application_name: str = "Enoch",
+) -> UpdateResult:
     """Compatibility alias for integrations using the original Git-specific name."""
-    return update_from_authoritative(root)
+    return update_from_authoritative(root, application_name=application_name)
 
 
 def _message(message: str) -> UpdateResult:

--- a/tests/test_enoch_telegram.py
+++ b/tests/test_enoch_telegram.py
@@ -104,6 +104,7 @@ from enoch.app.core import (
     _signal_reason,
     _task_context_snapshot_prompt,
 )
+from enoch.application import ApplicationPresentation
 from enoch.app import core as telegram
 from enoch.channel import (
     MAX_IMAGE_BYTES as MAX_TELEGRAM_IMAGE_BYTES,
@@ -4650,6 +4651,7 @@ class EnochTelegramTests(unittest.TestCase):
         update_from_authoritative.assert_called_once_with(
             ROOT,
             repository=ANY,
+            application_name="Enoch",
         )
         schedule_restart.assert_called_once_with(ROOT)
         self.assertIn("Enoch pulled latest main and doctor passed.", client.sent[0][1])
@@ -4662,20 +4664,29 @@ class EnochTelegramTests(unittest.TestCase):
         update_from_authoritative: MagicMock,
         schedule_restart: MagicMock,
     ) -> None:
-        update_from_authoritative.return_value.message = "Enoch is already up to date.\nAlready up to date."
+        update_from_authoritative.return_value.message = (
+            "Noah is already up to date.\nAlready up to date."
+        )
         update_from_authoritative.return_value.direct_action_result = "Already up to date."
         update_from_authoritative.return_value.restart_required = False
         client = FakeTelegramClient(allowed_chat_id=42)
-        bot = EnochApplication(load_identity(), ROOT, client)
+        bot = EnochApplication(
+            load_identity(),
+            ROOT,
+            client,
+            presentation=ApplicationPresentation(display_name="Noah"),
+        )
 
         _handle_update(bot, _message_update(chat_id=42, text="/update"))
 
         update_from_authoritative.assert_called_once_with(
             ROOT,
             repository=ANY,
+            application_name="Noah",
         )
         schedule_restart.assert_not_called()
-        self.assertIn("Enoch is already up to date.", client.sent[0][1])
+        self.assertIn("Noah is already up to date.", client.sent[0][1])
+        self.assertNotIn("Enoch", client.sent[0][1])
 
     @patch("enoch.app.core.update_from_authoritative")
     def test_update_requires_locked_chat(self, update_from_authoritative: MagicMock) -> None:

--- a/tests/test_enoch_updater.py
+++ b/tests/test_enoch_updater.py
@@ -95,16 +95,22 @@ class EnochUpdaterTests(unittest.TestCase):
         repository = _repository_with_update()
         run_update_doctor.return_value = _doctor_result()
 
-        result = update_from_authoritative(ROOT, repository=repository)
+        result = update_from_authoritative(
+            ROOT,
+            repository=repository,
+            application_name="Noah",
+        )
 
         run_update_doctor.assert_called_once_with(ROOT)
         self.assertEqual(repository.current.id, "r1")
         self.assertTrue(result.restart_required)
         self.assertIn(
-            "Enoch updated to latest authoritative and doctor passed.",
+            "Noah updated to latest authoritative and doctor passed.",
             result.message,
         )
         self.assertIn("Restarting now.", result.message)
+        self.assertIn("confirm Noah came back.", result.message)
+        self.assertNotIn("Enoch", result.message)
         self.assertIn("Updated repository from r0 to r1", result.direct_action_result)
         self.assertIn("Restarting into r1.", result.direct_action_result)
         self.assertEqual(result.previous_revision_id, "r0")
@@ -116,11 +122,15 @@ class EnochUpdaterTests(unittest.TestCase):
         run_update_doctor: MagicMock,
     ) -> None:
         repository = BranchlessRepositoryFixture()
-        result = update_from_authoritative(ROOT, repository=repository)
+        result = update_from_authoritative(
+            ROOT,
+            repository=repository,
+            application_name="Noah",
+        )
 
         run_update_doctor.assert_not_called()
         self.assertFalse(result.restart_required)
-        self.assertEqual(result.message, "Enoch is already up to date.")
+        self.assertEqual(result.message, "Noah is already up to date.")
         self.assertEqual(
             result.direct_action_result,
             "Already at authoritative revision r0.",
@@ -141,11 +151,15 @@ class EnochUpdaterTests(unittest.TestCase):
         _load_lifecycle_state: MagicMock,
     ) -> None:
         repository = BranchlessRepositoryFixture()
-        result = update_from_authoritative(ROOT, repository=repository)
+        result = update_from_authoritative(
+            ROOT,
+            repository=repository,
+            application_name="Noah",
+        )
 
         run_update_doctor.assert_not_called()
         self.assertFalse(result.restart_required)
-        self.assertIn("Enoch is already up to date.", result.message)
+        self.assertIn("Noah is already up to date.", result.message)
         self.assertIn("daemon started on 0000000", result.message)
         self.assertIn("Run /restart to load the current code.", result.message)
         self.assertIn("Run /restart to load the current code.", result.direct_action_result)
@@ -163,9 +177,14 @@ class EnochUpdaterTests(unittest.TestCase):
         _load_lifecycle_state: MagicMock,
     ) -> None:
         repository = BranchlessRepositoryFixture()
-        result = update_from_authoritative(ROOT, repository=repository)
+        result = update_from_authoritative(
+            ROOT,
+            repository=repository,
+            application_name="Noah",
+        )
 
         self.assertNotIn("Run /restart", result.message)
+        self.assertIn("Noah is already up to date.", result.message)
         self.assertEqual(
             result.direct_action_result,
             "Already at authoritative revision r0.",
@@ -187,12 +206,18 @@ class EnochUpdaterTests(unittest.TestCase):
         )
         run_update_doctor.return_value = doctor
 
-        result = update_from_authoritative(ROOT, repository=repository)
+        result = update_from_authoritative(
+            ROOT,
+            repository=repository,
+            application_name="Noah",
+        )
 
         self.assertEqual(repository.current.id, "r0")
         self.assertFalse(result.restart_required)
         self.assertIn("doctor failed", result.message)
         self.assertIn("Rolled back to r0.", result.message)
+        self.assertIn("currently running Noah process", result.message)
+        self.assertNotIn("Enoch", result.message)
         self.assertEqual(result.direct_action_result, "")
 
     def test_update_refuses_revision_outside_authoritative_history(self) -> None:
@@ -201,24 +226,41 @@ class EnochUpdaterTests(unittest.TestCase):
         repository.revisions[divergent.id] = divergent
         repository.current = divergent
 
-        result = update_from_authoritative(ROOT, repository=repository)
+        result = update_from_authoritative(
+            ROOT,
+            repository=repository,
+            application_name="Noah",
+        )
 
         self.assertIn(
             "is not in the history of authoritative revision r1",
             result.message,
         )
+        self.assertTrue(result.message.startswith("Noah could not update:"))
 
     def test_update_refuses_dirty_working_copy(self) -> None:
         repository = BranchlessRepositoryFixture()
         repository.mark_changed("src/enoch/app/core.py")
 
-        result = update_from_authoritative(ROOT, repository=repository)
+        result = update_from_authoritative(
+            ROOT,
+            repository=repository,
+            application_name="Noah",
+        )
 
         self.assertEqual(
             result.message,
-            "Enoch could not update: working copy has uncommitted changes: "
+            "Noah could not update: working copy has uncommitted changes: "
             "src/enoch/app/core.py",
         )
+
+    def test_update_defaults_to_enoch_application_name(self) -> None:
+        result = update_from_authoritative(
+            ROOT,
+            repository=BranchlessRepositoryFixture(),
+        )
+
+        self.assertEqual(result.message, "Enoch is already up to date.")
 
 
 def _doctor_result() -> MagicMock:


### PR DESCRIPTION
## What changed
- let `update_from_authoritative` accept an application display name while preserving `Enoch` as the backward-compatible default
- pass `ApplicationPresentation.resolved_display_name(...)` from the composed application into the updater
- use that name consistently across update success, already-current, failure, rollback, and restart messages

## Why
Descendants such as Noah already define their display name through `ApplicationPresentation`, but updater text was still hard-coded to `Enoch`. This leaked host branding through the extension boundary.

## Impact
Enoch continues to say `Enoch`. A composed descendant such as Noah now says `Noah` throughout `/update` without forking the updater.

## Validation
- targeted updater and Telegram tests: 12 passed
- canonical full suite: 814 passed
- `git diff --check`