### PR TITLE
Connect Enoch to the OurArk paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,3 +18,14 @@ keywords:
   - co-evolution
   - software lineage
   - self-evolving agents
+references:
+  - type: article
+    title: "Code Is the Body: Agent-Owned Software Bodies for Recursive Evolution and Descent"
+    authors:
+      - family-names: Zhao
+        given-names: Roy
+      - family-names: Zhao
+        given-names: Zhenyu
+    year: 2026
+    doi: "10.48550/arXiv.2607.28691"
+    url: "https://arxiv.org/abs/2607.28691"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,24 @@ and operational experience into tested, reviewable changes while you control
 what is adopted. It is built for researchers, agent builders, and power users
 who want to run or fork an agent body.
 
-The architecture and its Genesis and Enoch reference implementations are
-described in [*Code Is the Body: Agent-Owned Software Bodies for Recursive
-Evolution and Descent*](https://arxiv.org/abs/2607.28691).
+## Research Foundation
+
+Enoch is the reference agent implementation evaluated in
+[*Code Is the Body: Agent-Owned Software Bodies for Recursive Evolution and
+Descent*](https://arxiv.org/abs/2607.28691). The paper's frozen reproducibility
+snapshot uses [Enoch
+v0.3.1](https://github.com/our-ark/enoch/releases/tag/v0.3.1) at commit
+[`1021e1d`](https://github.com/our-ark/enoch/commit/1021e1dacce85f4a2edebd865673671bb37a2142),
+together with [Genesis
+v0.1.1](https://github.com/our-ark/genesis/releases/tag/v0.1.1).
+
+Current Enoch development has advanced beyond that evaluated snapshot. Use the
+current documentation for current behavior and the frozen releases when
+reproducing the paper. The [OurArk research
+notes](https://github.com/our-ark/.github/blob/main/docs/papers/code-is-the-body.md)
+record the evaluated artifacts, citation, reproduction steps, and the
+difference between the paper's six body-change origins and Enoch's four
+Evolution candidate pathways.
 
 ## Why Enoch Is Different
 
@@ -365,6 +380,12 @@ boundary and private reporting process.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development checks and contribution
 guidelines.
+
+## Citation
+
+Cite [*Code Is the Body*](https://arxiv.org/abs/2607.28691) when referring to
+the OurArk architecture. When reporting experiments or implementation results,
+also cite the exact Enoch release using [CITATION.cff](CITATION.cff).
 
 ## License
 

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -5,6 +5,17 @@ self-validation and scheduled work, gives inheritance, learning, and
 brainstorming clearer assessment boundaries, and removes duplicate lifecycle
 state once evolution work becomes a normal task.
 
+## Research snapshot
+
+This release is the Enoch artifact evaluated in
+[*Code Is the Body: Agent-Owned Software Bodies for Recursive Evolution and
+Descent*](https://arxiv.org/abs/2607.28691). The paper pairs this release at
+commit
+[`1021e1d`](https://github.com/our-ark/enoch/commit/1021e1dacce85f4a2edebd865673671bb37a2142)
+with [Genesis
+v0.1.1](https://github.com/our-ark/genesis/releases/tag/v0.1.1). Later Enoch
+releases are outside the paper's frozen implementation snapshot.
+
 ## Highlights
 
 - Added a content-addressed managed validation environment that provisions the


### PR DESCRIPTION
## What

- add a Research Foundation section distinguishing the evaluated v0.3.1 snapshot from current Enoch development
- link the canonical OurArk research and terminology notes
- add architecture-versus-software citation guidance and record the paper in `CITATION.cff`
- annotate the v0.3.1 release notes as the paper's frozen Enoch artifact

## Why

Readers need a durable link from the current reference body to the paper without implying that the paper evaluates every later Enoch release.

## Checks

- `bin/enoch doctor`
- CFF YAML syntax parse
- `git diff --check`
- confirmed no GitHub Actions workflow was added