### PR TITLE
Reconcile stale running workflows from durable evidence

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -2,7 +2,7 @@
 
 `enoch.workflows.WorkflowEngine` is the versioned public boundary for Enoch's
 single-owner task lifecycle. The current contract is
-`WORKFLOW_API_VERSION = 3`.
+`WORKFLOW_API_VERSION = 4`.
 
 The engine owns:
 
@@ -11,6 +11,7 @@ The engine owns:
 - durable worker heartbeats;
 - cancellation, pause, retry, and terminal finalization;
 - interrupted-worker recovery;
+- periodic reconciliation of durable terminal evidence and stale workers;
 - queue inspection and task lookup;
 - task status, runtime evidence, workspace, revision, and review records;
 - bounded extension request metadata and artifact references;
@@ -64,7 +65,7 @@ operation. Durable `TaskJob` state now exposes `workspace_path`,
 `workspace_id`, `revision_id`, `review_id`, `review_url`, `review_urls`, and
 `review_published`.
 
-Queue schema 14 reads schema 11's `worktree_path`, `branch_name`,
+Queue schema 15 reads schema 11's `worktree_path`, `branch_name`,
 `commit_sha`, `remote_branch`, `pr_url`, `pr_urls`, and
 `published_remotely` keys, then writes only the provider-neutral names. It also
 adds extension request metadata, typed artifact references, and canonical
@@ -89,14 +90,25 @@ readers continue to accept earlier schemas, including Git-shaped
 extension request payload and execution lane without mixing either into task
 prompt text.
 
-Workflow API v3 engines may advertise optional behavior through a `features`
+Workflow API v4 engines may advertise optional behavior through a `features`
 iterable. `workflow_features()` normalizes discovery, and extension workflows
 expose it through `features` and `supports()`. The local engine currently
 advertises `structured_task_metadata`, `artifact_references`, and
 `execution_lanes`. The local scheduler still retains one global running task;
 lane support defines ordering and blocking rather than parallel workers. An
-older API v3 engine without `features` continues to work until an extension
-requests an optional feature, which then fails before enqueue.
+API v4 engine without `features` continues to work until an extension requests
+an optional feature, which then fails before enqueue.
+
+Version 4 adds typed terminal evidence and reconciliation. A worker records a
+`TaskTerminalEvidence` immediately before final queue transition. The daemon's
+periodic maintenance tick then calls `reconcile()` with the expected task,
+worker, and heartbeat lease identity. The current daemon epoch still fences the
+mutation. A dead worker with matching terminal evidence is finalized exactly
+once; a dead worker without evidence follows bounded retry or exhaustion; a
+live worker remains authoritative; and conflicting or partial evidence fails
+closed. Queue inspection preserves the last material reconciliation outcome,
+evidence kinds, transition, and reason without replaying provider calls or
+terminal delivery.
 
 Profiles do not receive or own the concrete engine. Their
 `CommandContext.enqueue_task()` method routes through the engine selected by
@@ -123,7 +135,10 @@ recovery remain responsibilities of the workflow engine.
 `enqueue()` accepts `mode="queued"`, `"front"`, or `"direct"`. `start_next()`
 atomically moves one due task into the running slot, and `claim()` binds that
 task to a worker identity and process. `heartbeat()` refreshes the durable
-claim. `finalize()` accepts only `completed`, `failed`, or `cancelled`.
+claim. `record_terminal_evidence()` persists the structured outcome before
+`finalize()`, which accepts only `completed`, `failed`, or `cancelled`.
+`reconcile()` returns a typed no-op, terminal repair, interrupted-worker
+recovery, conflict, or unsupported-evidence result.
 
 An extension may assign a local lane token such as `project-17`. Enoch stores
 the canonical key `extension:<extension-name>:<lane>`, preventing two

--- a/src/enoch/app/core.py
+++ b/src/enoch/app/core.py
@@ -124,7 +124,11 @@ from enoch.vcs_tools import (
     switch_branch,
 )
 from enoch.workflows import (
+    FinalTaskStatus,
     LocalWorkflowEngine,
+    TaskReconciliationRequest,
+    TaskReconciliationResult,
+    TaskTerminalEvidence,
     WorkflowEngine,
     WorkflowEngineError,
     validate_workflow_engine,
@@ -704,12 +708,7 @@ class EnochApplication:
         self._run_profile_hook("before_run")
         self._run_extension_hooks("before_run")
         try:
-            recovered = _recover_running_task_from_direct_action_log(
-                self.root,
-                workflow=self.workflow,
-            )
-            if recovered is None:
-                recovered = self.workflow.recover()
+            recovered = self._reconcile_workflow()
             _cleanup_completed_task_worktree(recovered, self.root)
             self.effect_fence.authorize(
                 "chat.receive",
@@ -725,6 +724,36 @@ class EnochApplication:
             self._drain_extension_task_events()
             self._run_extension_hooks("after_run", reverse=True)
             self._run_profile_hook("after_run")
+
+    def _reconcile_workflow(self) -> TaskJob | None:
+        running = self.workflow.inspect().running
+        request = (
+            TaskReconciliationRequest(
+                expected_task_id=running.id,
+                expected_worker_id=running.worker_id,
+                expected_worker_heartbeat_at=running.worker_heartbeat_at,
+            )
+            if running is not None
+            else None
+        )
+        result = self.workflow.reconcile(request)
+        if result.recorded:
+            _record_system_event(
+                "workflow_reconciliation",
+                self.root,
+                status=(
+                    "failed"
+                    if result.outcome in {"conflict", "unsupported_evidence"}
+                    else "ok"
+                ),
+                details=_workflow_reconciliation_details(result),
+            )
+        if result.outcome not in {
+            "terminal_repair",
+            "interrupted_worker_recovery",
+        } or result.task_id is None:
+            return None
+        return self.workflow.find(result.task_id)
 
     def handle_event(self, event: ChatEvent) -> None:
         require_current_daemon_epoch(self.daemon_epoch, self.root)
@@ -1858,7 +1887,7 @@ class EnochApplication:
             _CURRENT_TASK_WORKER_ID.reset(worker_token)
             self._task_cancellations.pop(job.id, None)
             if completed_status == "cancelled":
-                finished_job = self.workflow.finalize(
+                finished_job = self._finalize_with_terminal_evidence(
                     job.id,
                     "cancelled",
                     result=reply,
@@ -1868,7 +1897,7 @@ class EnochApplication:
                 )
             elif completed_status == "failed":
                 failure = failure or classify_task_failure(reply)
-                finished_job = self.workflow.finalize(
+                finished_job = self._finalize_with_terminal_evidence(
                     job.id,
                     "failed",
                     result=reply,
@@ -1888,7 +1917,7 @@ class EnochApplication:
                     worker_id=worker_id,
                 )
             else:
-                finished_job = self.workflow.finalize(
+                finished_job = self._finalize_with_terminal_evidence(
                     job.id,
                     "completed",
                     result=reply,
@@ -2068,6 +2097,44 @@ class EnochApplication:
             context=context,
             session_key=session_key,
             execution=execution,
+        )
+
+    def _finalize_with_terminal_evidence(
+        self,
+        task_id: int,
+        status: FinalTaskStatus,
+        *,
+        result: str,
+        worker_id: str,
+        event_actor: str = "agent",
+        trigger: str = "task-runner",
+        failure_code: str = "",
+        failure_class: str = "",
+        retryable: bool = False,
+    ) -> TaskJob | None:
+        recorded = self.workflow.record_terminal_evidence(
+            task_id,
+            worker_id,
+            TaskTerminalEvidence(
+                status=status,
+                result=result,
+                failure_code=failure_code,
+                failure_class=failure_class,
+                retryable=retryable,
+            ),
+        )
+        if recorded is None:
+            return self.workflow.find(task_id)
+        return self.workflow.finalize(
+            task_id,
+            status,
+            result=result,
+            event_actor=event_actor,
+            trigger=trigger,
+            worker_id=worker_id,
+            failure_code=failure_code,
+            failure_class=failure_class,
+            retryable=retryable,
         )
 
     def _prepare_task_worktree(self, request: str) -> TaskWorktree:
@@ -4106,7 +4173,7 @@ class EnochApplication:
             except StaleDaemonEpoch:
                 return
             if completed_status == "cancelled":
-                finished_job = self.workflow.finalize(
+                finished_job = self._finalize_with_terminal_evidence(
                     job.id,
                     "cancelled",
                     result=reply,
@@ -4132,7 +4199,7 @@ class EnochApplication:
                     if finished_job is not None:
                         completed_status = "retrying"
                 if finished_job is None:
-                    finished_job = self.workflow.finalize(
+                    finished_job = self._finalize_with_terminal_evidence(
                         job.id,
                         "failed",
                         result=reply,
@@ -4152,7 +4219,7 @@ class EnochApplication:
                     worker_id=worker_id,
                 )
             else:
-                finished_job = self.workflow.finalize(
+                finished_job = self._finalize_with_terminal_evidence(
                     job.id,
                     "completed",
                     result=reply,
@@ -5002,6 +5069,22 @@ def _reconciled_retry_result(
                 f"{record.identity.url or record.identity.id}"
             )
     return ""
+
+
+def _workflow_reconciliation_details(
+    result: TaskReconciliationResult,
+) -> dict[str, object]:
+    return {
+        "outcome": result.outcome,
+        "checked_at": result.checked_at,
+        "task_id": result.task_id,
+        "previous_status": result.previous_status,
+        "resulting_status": result.resulting_status,
+        "evidence": list(result.evidence),
+        "reason": result.reason,
+        "worker_id": result.worker_id,
+        "worker_heartbeat_at": result.worker_heartbeat_at,
+    }
 
 
 def _recover_running_task_from_direct_action_log(

--- a/src/enoch/conformance/workflow.py
+++ b/src/enoch/conformance/workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -11,6 +12,8 @@ from enoch.workflows import (
     WORKFLOW_FEATURE_ARTIFACT_REFERENCES,
     WORKFLOW_FEATURE_EXECUTION_LANES,
     WORKFLOW_FEATURE_STRUCTURED_METADATA,
+    TaskReconciliationRequest,
+    TaskTerminalEvidence,
     WorkflowEngine,
     workflow_features,
 )
@@ -109,6 +112,73 @@ class WorkflowEngineConformanceMixin:
             self.assertEqual(recovered.status, "pending")
             self.assertEqual(recovered.execution_lane, queued.execution_lane)
             self.assertEqual(restarted.inspect().pending_count, 1)
+
+    def test_conformance_workflow_reconciles_terminal_crash_point_once(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            engine = self._new_engine(root)
+            running = engine.enqueue(42, "terminal crash point", mode="direct")
+            claimed = engine.claim(running.id, "conformance-worker", 999_999)
+            assert claimed is not None
+            recorded = engine.record_terminal_evidence(
+                claimed.id,
+                claimed.worker_id,
+                TaskTerminalEvidence(
+                    status="completed",
+                    result="durable terminal result",
+                ),
+            )
+            assert recorded is not None
+
+            repaired = engine.reconcile(
+                TaskReconciliationRequest(
+                    recorded.id,
+                    recorded.worker_id,
+                    recorded.worker_heartbeat_at,
+                )
+            )
+            repeated = engine.reconcile()
+            status = engine.inspect()
+
+            self.assertEqual(repaired.outcome, "terminal_repair")
+            self.assertEqual(repeated.outcome, "no_op")
+            self.assertIsNone(status.running)
+            self.assertEqual(len(status.history), 1)
+
+    def test_conformance_workflow_reconciliation_preserves_live_worker(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            engine = self._new_engine(root)
+            running = engine.enqueue(42, "live worker", mode="direct")
+            claimed = engine.claim(running.id, "conformance-worker", os.getpid())
+            assert claimed is not None
+            recorded = engine.record_terminal_evidence(
+                claimed.id,
+                claimed.worker_id,
+                TaskTerminalEvidence(status="completed", result="done"),
+            )
+            assert recorded is not None
+
+            result = engine.reconcile(
+                TaskReconciliationRequest(
+                    recorded.id,
+                    recorded.worker_id,
+                    recorded.worker_heartbeat_at,
+                )
+            )
+
+            self.assertEqual(result.outcome, "no_op")
+            self.assertIsNotNone(engine.inspect().running)
+            engine.finalize(
+                claimed.id,
+                "completed",
+                result="done",
+                worker_id=claimed.worker_id,
+            )
 
     def test_conformance_workflow_rejects_stale_fencing_token(self) -> None:
         with TemporaryDirectory() as directory:

--- a/src/enoch/private_state.py
+++ b/src/enoch/private_state.py
@@ -84,13 +84,14 @@ class PrivateStateMigrationResult:
 STATE_FILE_SCHEMAS = (
     StateFileSchema(
         "task_queue.json",
-        14,
+        15,
         (
             ("next_id", 1),
             ("pending", []),
             ("paused", []),
             ("running", None),
             ("history", []),
+            ("reconciliation", None),
         ),
         (
             ("next_id", (int,)),
@@ -98,6 +99,7 @@ STATE_FILE_SCHEMAS = (
             ("paused", (list,)),
             ("running", (dict, type(None))),
             ("history", (list,)),
+            ("reconciliation", (dict, type(None))),
         ),
     ),
     StateFileSchema(
@@ -511,7 +513,12 @@ def _normalized_payload(path: Path, schema: StateFileSchema) -> dict[str, Any]:
 
 
 def _normalize_task_queue(path: Path, data: dict[str, Any]) -> dict[str, Any]:
-    from enoch.tasks.queue import _job_to_dict, _parse_job
+    from enoch.tasks.queue import (
+        _job_to_dict,
+        _parse_job,
+        _parse_reconciliation,
+        _reconciliation_to_dict,
+    )
 
     parsed: dict[str, list[Any]] = {}
     for key in ("pending", "paused", "history"):
@@ -522,6 +529,9 @@ def _normalize_task_queue(path: Path, data: dict[str, Any]) -> dict[str, Any]:
     running = _parse_job(data.get("running"))
     if data.get("running") is not None and running is None:
         raise StateCorruptionError(path, "found an invalid running task")
+    reconciliation = _parse_reconciliation(data.get("reconciliation"))
+    if data.get("reconciliation") is not None and reconciliation is None:
+        raise StateCorruptionError(path, "found an invalid reconciliation record")
     ids = [job.id for jobs in parsed.values() for job in jobs]
     if running is not None:
         ids.append(running.id)
@@ -535,6 +545,7 @@ def _normalize_task_queue(path: Path, data: dict[str, Any]) -> dict[str, Any]:
         "paused": [_job_to_dict(job) for job in parsed["paused"]],
         "running": _job_to_dict(running) if running is not None else None,
         "history": [_job_to_dict(job) for job in parsed["history"]],
+        "reconciliation": _reconciliation_to_dict(reconciliation),
     }
 
 

--- a/src/enoch/tasks/queue.py
+++ b/src/enoch/tasks/queue.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 import re
+from typing import Callable, Literal
 from urllib.parse import urlsplit
 
 from enoch.memory.paths import atomic_write, now as current_time
@@ -32,8 +33,16 @@ from enoch.tasks.payloads import (
 from enoch.state import StateCorruptionError, file_transaction, load_json_object
 
 
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 DEFAULT_MAX_ATTEMPTS = 3
+ReconciliationOutcome = Literal[
+    "no_op",
+    "terminal_repair",
+    "interrupted_worker_recovery",
+    "conflict",
+    "unsupported_evidence",
+]
+TerminalTaskStatus = Literal["completed", "failed", "cancelled"]
 LEGACY_REVIEW_URL_PATTERN = re.compile(
     r"https://[^\s]+/(?:pull|pulls|merge_requests)/\d+"
 )
@@ -93,6 +102,9 @@ class TaskJob:
     review_id: str = ""
     review_url: str = ""
     review_published: bool = False
+    terminal_status: str = ""
+    terminal_evidence_source: str = ""
+    terminal_evidence_at: str = ""
 
     # Compatibility aliases for task queue schema <= 11 and workflow API v1.
     @property
@@ -132,6 +144,59 @@ class TaskQueueStatus:
     pending: tuple[TaskJob, ...] = ()
     paused: tuple[TaskJob, ...] = ()
     history: tuple[TaskJob, ...] = ()
+    reconciliation: TaskReconciliationResult | None = None
+
+
+@dataclass(frozen=True)
+class TaskTerminalEvidence:
+    status: TerminalTaskStatus
+    result: str = ""
+    source: str = "work-outcome"
+    failure_code: str = ""
+    failure_class: str = ""
+    retryable: bool = False
+
+    def __post_init__(self) -> None:
+        if self.status not in {"completed", "failed", "cancelled"}:
+            raise ValueError(f"Unknown terminal task status {self.status!r}.")
+        source = self.source.strip().lower()
+        if not source:
+            raise ValueError("Terminal task evidence source is required.")
+        object.__setattr__(self, "source", source)
+        object.__setattr__(self, "result", self.result.strip())
+        object.__setattr__(self, "failure_code", self.failure_code.strip())
+        object.__setattr__(self, "failure_class", self.failure_class.strip())
+
+
+@dataclass(frozen=True)
+class TaskReconciliationRequest:
+    expected_task_id: int
+    expected_worker_id: str = ""
+    expected_worker_heartbeat_at: str = ""
+
+    def __post_init__(self) -> None:
+        if self.expected_task_id <= 0:
+            raise ValueError("Reconciliation requires a positive task id.")
+        object.__setattr__(self, "expected_worker_id", self.expected_worker_id.strip())
+        object.__setattr__(
+            self,
+            "expected_worker_heartbeat_at",
+            self.expected_worker_heartbeat_at.strip(),
+        )
+
+
+@dataclass(frozen=True)
+class TaskReconciliationResult:
+    outcome: ReconciliationOutcome
+    checked_at: str
+    task_id: int | None = None
+    previous_status: str = ""
+    resulting_status: str = ""
+    evidence: tuple[str, ...] = ()
+    reason: str = ""
+    worker_id: str = ""
+    worker_heartbeat_at: str = ""
+    recorded: bool = True
 
 
 @dataclass(frozen=True)
@@ -704,6 +769,9 @@ def retry_running_task(
             failure_code=failure_code.strip(),
             failure_class=failure_class.strip(),
             retryable=True,
+            terminal_status="",
+            terminal_evidence_source="",
+            terminal_evidence_at="",
         )
         data["running"] = None
         data["pending"] = [
@@ -876,6 +944,9 @@ def pause_task(
             worker_id="",
             worker_pid=None,
             worker_heartbeat_at="",
+            terminal_status="",
+            terminal_evidence_source="",
+            terminal_evidence_at="",
         )
         paused = [job for job in _paused_jobs(data) if job.id != task_id]
         paused.append(paused_job)
@@ -1241,6 +1312,56 @@ def record_task_runtime_result(
         _write_queue(data, root)
 
 
+def record_task_terminal_evidence(
+    task_id: int,
+    worker_id: str,
+    evidence: TaskTerminalEvidence,
+    root: Path | None = None,
+) -> TaskJob | None:
+    cleaned_worker_id = worker_id.strip()
+    if not cleaned_worker_id:
+        raise ValueError("A worker id is required.")
+    with _queue_transaction(root):
+        data = _load_queue(root)
+        running = _parse_job(data.get("running"))
+        if (
+            running is None
+            or running.id != task_id
+            or running.worker_id != cleaned_worker_id
+        ):
+            return None
+        if running.terminal_status:
+            if (
+                running.terminal_status == evidence.status
+                and running.terminal_evidence_source == evidence.source
+                and running.result == evidence.result
+                and running.failure_code == evidence.failure_code
+                and running.failure_class == evidence.failure_class
+                and running.retryable == evidence.retryable
+            ):
+                return running
+            raise ValueError(
+                f"Task #{task_id} already has conflicting terminal evidence."
+            )
+        updated = _replace_job(
+            running,
+            result=evidence.result,
+            review_urls=_merge_review_urls(
+                running.review_urls,
+                _review_urls(evidence.result),
+            ),
+            failure_code=evidence.failure_code,
+            failure_class=evidence.failure_class,
+            retryable=evidence.retryable,
+            terminal_status=evidence.status,
+            terminal_evidence_source=evidence.source,
+            terminal_evidence_at=current_time(),
+        )
+        data["running"] = _job_to_dict(updated)
+        _write_queue(data, root)
+        return updated
+
+
 def _finish_running_task(
     task_id: int,
     status: str,
@@ -1383,41 +1504,169 @@ def cancel_running_task(
 
 
 def recover_interrupted_task(root: Path | None = None) -> TaskJob | None:
+    result = reconcile_running_task(root=root)
+    if result.outcome not in {
+        "terminal_repair",
+        "interrupted_worker_recovery",
+    } or result.task_id is None:
+        return None
+    return _find_task_in_status(result.task_id, root)
+
+
+def reconcile_running_task(
+    request: TaskReconciliationRequest | None = None,
+    root: Path | None = None,
+    *,
+    worker_liveness: Callable[[TaskJob], bool] = task_worker_is_active,
+    checked_at: str = "",
+) -> TaskReconciliationResult:
+    checked_at = checked_at.strip() or current_time()
     with _queue_transaction(root):
         data = _load_queue(root)
         running = _parse_job(data.get("running"))
         if running is None:
-            return None
-        if task_worker_is_active(running):
-            return None
-        if _job_has_review(running):
-            completed = _replace_job(
+            return TaskReconciliationResult(
+                outcome="no_op",
+                checked_at=checked_at,
+                previous_status="idle",
+                resulting_status="idle",
+                reason="No task is running.",
+                recorded=False,
+            )
+        mismatch = _reconciliation_request_mismatch(request, running)
+        if mismatch:
+            result = _store_reconciliation(
+                data,
+                TaskReconciliationResult(
+                    outcome="conflict",
+                    checked_at=checked_at,
+                    task_id=running.id,
+                    previous_status=running.status,
+                    resulting_status=running.status,
+                    evidence=("task-worker-lease",),
+                    reason=mismatch,
+                    worker_id=running.worker_id,
+                    worker_heartbeat_at=running.worker_heartbeat_at,
+                ),
+            )
+            if result.recorded:
+                _write_queue(data, root)
+            return result
+        if worker_liveness(running):
+            return TaskReconciliationResult(
+                outcome="no_op",
+                checked_at=checked_at,
+                task_id=running.id,
+                previous_status=running.status,
+                resulting_status=running.status,
+                evidence=("active-worker",),
+                reason="The authoritative worker is still active.",
+                worker_id=running.worker_id,
+                worker_heartbeat_at=running.worker_heartbeat_at,
+                recorded=False,
+            )
+        terminal_status, terminal_evidence, terminal_conflict = (
+            _terminal_reconciliation_evidence(running)
+        )
+        if terminal_conflict:
+            result = _store_reconciliation(
+                data,
+                TaskReconciliationResult(
+                    outcome="conflict",
+                    checked_at=checked_at,
+                    task_id=running.id,
+                    previous_status=running.status,
+                    resulting_status=running.status,
+                    evidence=terminal_evidence,
+                    reason=terminal_conflict,
+                    worker_id=running.worker_id,
+                    worker_heartbeat_at=running.worker_heartbeat_at,
+                ),
+            )
+            if result.recorded:
+                _write_queue(data, root)
+            return result
+        if terminal_status:
+            history = _history_jobs(data)
+            if any(job.id == running.id for job in history):
+                result = _store_reconciliation(
+                    data,
+                    TaskReconciliationResult(
+                        outcome="conflict",
+                        checked_at=checked_at,
+                        task_id=running.id,
+                        previous_status=running.status,
+                        resulting_status=running.status,
+                        evidence=terminal_evidence,
+                        reason="Task history already contains the running task id.",
+                        worker_id=running.worker_id,
+                        worker_heartbeat_at=running.worker_heartbeat_at,
+                    ),
+                )
+                if result.recorded:
+                    _write_queue(data, root)
+                return result
+            finished = _replace_job(
                 running,
-                status="completed",
-                completed_at=current_time(),
+                status=terminal_status,
+                completed_at=checked_at,
                 worker_id="",
                 worker_pid=None,
                 worker_heartbeat_at="",
+                next_attempt_at="",
             )
-            history = _history_jobs(data)
-            history.append(completed)
+            history.append(finished)
+            result = TaskReconciliationResult(
+                outcome="terminal_repair",
+                checked_at=checked_at,
+                task_id=running.id,
+                previous_status=running.status,
+                resulting_status=finished.status,
+                evidence=terminal_evidence,
+                reason="Durable terminal evidence finalized the running task.",
+                worker_id=running.worker_id,
+                worker_heartbeat_at=running.worker_heartbeat_at,
+            )
             data["running"] = None
             data["history"] = [_job_to_dict(job) for job in history]
+            data["reconciliation"] = _reconciliation_to_dict(result)
             _write_queue(data, root)
             _record_task_event_safely(
-                completed,
-                "completed",
+                finished,
+                finished.status,
                 root,
                 event_actor="system",
-                trigger="recovery",
-                result=completed.result,
+                trigger="reconciliation",
+                result=finished.result,
             )
-            return completed
+            return result
+        unsupported = _unsupported_reconciliation_evidence(running)
+        if unsupported:
+            result = _store_reconciliation(
+                data,
+                TaskReconciliationResult(
+                    outcome="unsupported_evidence",
+                    checked_at=checked_at,
+                    task_id=running.id,
+                    previous_status=running.status,
+                    resulting_status=running.status,
+                    evidence=unsupported,
+                    reason=(
+                        "Durable evidence exists, but it does not prove a terminal "
+                        "task outcome. Reconciliation failed closed."
+                    ),
+                    worker_id=running.worker_id,
+                    worker_heartbeat_at=running.worker_heartbeat_at,
+                ),
+            )
+            if result.recorded:
+                _write_queue(data, root)
+            return result
         if running.attempt >= running.max_attempts:
             failed = _replace_job(
                 running,
                 status="failed",
-                completed_at=current_time(),
+                completed_at=checked_at,
                 result=(
                     f"Task worker was interrupted and automatic recovery exhausted "
                     f"{running.max_attempts} attempts."
@@ -1432,8 +1681,20 @@ def recover_interrupted_task(root: Path | None = None) -> TaskJob | None:
             )
             history = _history_jobs(data)
             history.append(failed)
+            result = TaskReconciliationResult(
+                outcome="interrupted_worker_recovery",
+                checked_at=checked_at,
+                task_id=running.id,
+                previous_status=running.status,
+                resulting_status=failed.status,
+                evidence=("inactive-worker", "retry-policy-exhausted"),
+                reason="The inactive worker exhausted bounded recovery attempts.",
+                worker_id=running.worker_id,
+                worker_heartbeat_at=running.worker_heartbeat_at,
+            )
             data["running"] = None
             data["history"] = [_job_to_dict(job) for job in history]
+            data["reconciliation"] = _reconciliation_to_dict(result)
             _write_queue(data, root)
             _record_task_event_safely(
                 failed,
@@ -1443,7 +1704,7 @@ def recover_interrupted_task(root: Path | None = None) -> TaskJob | None:
                 trigger="recovery-exhausted",
                 result=failed.result,
             )
-            return failed
+            return result
         recovered = _replace_job(
             running,
             status="pending",
@@ -1451,13 +1712,25 @@ def recover_interrupted_task(root: Path | None = None) -> TaskJob | None:
             worker_id="",
             worker_pid=None,
             worker_heartbeat_at="",
-            next_attempt_at=_retry_at(0),
+            next_attempt_at=_retry_at_from(checked_at, 0),
             failure_code="worker_interrupted",
             failure_class="transient",
             retryable=True,
         )
+        result = TaskReconciliationResult(
+            outcome="interrupted_worker_recovery",
+            checked_at=checked_at,
+            task_id=running.id,
+            previous_status=running.status,
+            resulting_status=recovered.status,
+            evidence=("inactive-worker", "retry-policy-available"),
+            reason="The inactive worker was returned to the bounded retry queue.",
+            worker_id=running.worker_id,
+            worker_heartbeat_at=running.worker_heartbeat_at,
+        )
         data["running"] = None
         data["pending"] = [_job_to_dict(recovered), *[_job_to_dict(job) for job in _pending_jobs(data)]]
+        data["reconciliation"] = _reconciliation_to_dict(result)
         _write_queue(data, root)
         _record_task_event_safely(
             recovered,
@@ -1475,7 +1748,7 @@ def recover_interrupted_task(root: Path | None = None) -> TaskJob | None:
             trigger="recovery",
             result="Task worker was interrupted.",
         )
-        return recovered
+        return result
 
 
 def task_queue_status(root: Path | None = None) -> TaskQueueStatus:
@@ -1490,6 +1763,7 @@ def task_queue_status(root: Path | None = None) -> TaskQueueStatus:
             pending=pending,
             paused=paused,
             history=tuple(_history_jobs(data)),
+            reconciliation=_parse_reconciliation(data.get("reconciliation")),
         )
 
 
@@ -1509,6 +1783,122 @@ def _job_has_review(job: TaskJob) -> bool:
     return bool(job.review_urls) or task_result_has_review(job.result)
 
 
+def _reconciliation_request_mismatch(
+    request: TaskReconciliationRequest | None,
+    running: TaskJob,
+) -> str:
+    if request is None:
+        return ""
+    mismatches = []
+    if request.expected_task_id != running.id:
+        mismatches.append("task")
+    if request.expected_worker_id != running.worker_id:
+        mismatches.append("worker")
+    if request.expected_worker_heartbeat_at != running.worker_heartbeat_at:
+        mismatches.append("lease")
+    if not mismatches:
+        return ""
+    return (
+        "The running task no longer matches the expected "
+        + ", ".join(mismatches)
+        + " identity."
+    )
+
+
+def _terminal_reconciliation_evidence(
+    running: TaskJob,
+) -> tuple[str, tuple[str, ...], str]:
+    statuses: dict[str, list[str]] = {}
+    if running.terminal_status:
+        if running.terminal_evidence_source and running.terminal_evidence_at:
+            statuses.setdefault(running.terminal_status, []).append(
+                f"terminal-evidence:{running.terminal_evidence_source}"
+            )
+        elif _job_has_review(running):
+            return (
+                "",
+                ("terminal-evidence:incomplete", "published-review"),
+                "Incomplete terminal evidence conflicts with a published review.",
+            )
+    if _job_has_review(running):
+        statuses.setdefault("completed", []).append("published-review")
+    evidence = tuple(
+        item
+        for status_evidence in statuses.values()
+        for item in status_evidence
+    )
+    if len(statuses) > 1:
+        return "", evidence, "Durable terminal evidence has conflicting outcomes."
+    if not statuses:
+        return "", (), ""
+    status = next(iter(statuses))
+    if status not in {"completed", "failed", "cancelled"}:
+        return "", evidence, f"Unsupported terminal status {status!r}."
+    return status, evidence, ""
+
+
+def _unsupported_reconciliation_evidence(running: TaskJob) -> tuple[str, ...]:
+    evidence = []
+    if running.terminal_status and (
+        not running.terminal_evidence_source or not running.terminal_evidence_at
+    ):
+        evidence.append("terminal-evidence:incomplete")
+    if running.publish_stage and running.publish_stage not in {
+        "validated",
+        "committed",
+        "pushed",
+        "pr_opened",
+        "captured",
+        "review_published",
+    }:
+        evidence.append(f"publish-stage:{running.publish_stage}")
+    if (
+        running.publish_stage == "review_published" or running.review_published
+    ) and not _job_has_review(running):
+        evidence.append("published-review:incomplete")
+    if running.review_id and not _job_has_review(running):
+        evidence.append("unconfirmed-review")
+    return _dedupe_strings(tuple(evidence))
+
+
+def _store_reconciliation(
+    data: dict,
+    result: TaskReconciliationResult,
+) -> TaskReconciliationResult:
+    previous = _parse_reconciliation(data.get("reconciliation"))
+    if previous is not None and _same_reconciliation(previous, result):
+        return TaskReconciliationResult(
+            outcome=result.outcome,
+            checked_at=previous.checked_at,
+            task_id=result.task_id,
+            previous_status=result.previous_status,
+            resulting_status=result.resulting_status,
+            evidence=result.evidence,
+            reason=result.reason,
+            worker_id=result.worker_id,
+            worker_heartbeat_at=result.worker_heartbeat_at,
+            recorded=False,
+        )
+    data["reconciliation"] = _reconciliation_to_dict(result)
+    return result
+
+
+def _same_reconciliation(
+    first: TaskReconciliationResult,
+    second: TaskReconciliationResult,
+) -> bool:
+    return (
+        first.outcome == second.outcome
+        and first.task_id == second.task_id
+        and first.previous_status == second.previous_status
+        and first.resulting_status == second.resulting_status
+        and first.evidence == second.evidence
+        and first.reason == second.reason
+        and first.worker_id == second.worker_id
+        and first.worker_heartbeat_at == second.worker_heartbeat_at
+    )
+
+
 def _load_queue(root: Path | None = None) -> dict:
     path = task_queue_path(root)
     raw = load_json_object(path, default_factory=_empty_queue)
@@ -1521,6 +1911,10 @@ def _load_queue(root: Path | None = None) -> dict:
         raise StateCorruptionError(path, "expected running to be an object or null")
     if isinstance(raw.get("running"), dict) and _parse_job(raw["running"]) is None:
         raise StateCorruptionError(path, "found an invalid running task")
+    if raw.get("reconciliation") is not None and _parse_reconciliation(
+        raw.get("reconciliation")
+    ) is None:
+        raise StateCorruptionError(path, "found an invalid reconciliation record")
     pending = [_job_to_dict(job) for job in _pending_jobs(raw)]
     paused_jobs = _paused_jobs(raw)
     paused = [_job_to_dict(job) for job in paused_jobs]
@@ -1542,6 +1936,9 @@ def _load_queue(root: Path | None = None) -> dict:
         "paused": paused,
         "running": _job_to_dict(running) if running is not None else None,
         "history": history,
+        "reconciliation": _reconciliation_to_dict(
+            _parse_reconciliation(raw.get("reconciliation"))
+        ),
     }
 
 
@@ -1553,6 +1950,9 @@ def _write_queue(data: dict, root: Path | None = None) -> None:
         "paused": [_job_to_dict(job) for job in _paused_jobs(data)],
         "running": _job_to_dict(_parse_job(data.get("running"))) if _parse_job(data.get("running")) else None,
         "history": [_job_to_dict(job) for job in _history_jobs(data)],
+        "reconciliation": _reconciliation_to_dict(
+            _parse_reconciliation(data.get("reconciliation"))
+        ),
     }
     atomic_write(task_queue_path(root), json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
@@ -1623,6 +2023,53 @@ def _find_task_by_idempotency_key(data: dict, key: str) -> TaskJob | None:
 def _find_task_in_status(task_id: int, root: Path | None = None) -> TaskJob | None:
     with _queue_transaction(root):
         return _find_task(_load_queue(root), task_id)
+
+
+def _parse_reconciliation(raw: object) -> TaskReconciliationResult | None:
+    if not isinstance(raw, dict):
+        return None
+    outcome = str(raw.get("outcome") or "").strip()
+    if outcome not in {
+        "no_op",
+        "terminal_repair",
+        "interrupted_worker_recovery",
+        "conflict",
+        "unsupported_evidence",
+    }:
+        return None
+    task_id = _positive_int(raw.get("task_id"))
+    checked_at = str(raw.get("checked_at") or "").strip()
+    if not checked_at:
+        return None
+    return TaskReconciliationResult(
+        outcome=outcome,
+        checked_at=checked_at,
+        task_id=task_id,
+        previous_status=str(raw.get("previous_status") or "").strip(),
+        resulting_status=str(raw.get("resulting_status") or "").strip(),
+        evidence=_parse_string_tuple(raw.get("evidence")),
+        reason=str(raw.get("reason") or "").strip(),
+        worker_id=str(raw.get("worker_id") or "").strip(),
+        worker_heartbeat_at=str(raw.get("worker_heartbeat_at") or "").strip(),
+    )
+
+
+def _reconciliation_to_dict(
+    result: TaskReconciliationResult | None,
+) -> dict | None:
+    if result is None:
+        return None
+    return {
+        "outcome": result.outcome,
+        "checked_at": result.checked_at,
+        "task_id": result.task_id,
+        "previous_status": result.previous_status,
+        "resulting_status": result.resulting_status,
+        "evidence": list(result.evidence),
+        "reason": result.reason,
+        "worker_id": result.worker_id,
+        "worker_heartbeat_at": result.worker_heartbeat_at,
+    }
 
 
 def _parse_job(raw: object) -> TaskJob | None:
@@ -1731,6 +2178,17 @@ def _parse_job(raw: object) -> TaskJob | None:
         if raw_review_published is None
         else bool(raw_review_published)
     )
+    terminal_status = str(raw.get("terminal_status") or "").strip().lower()
+    terminal_evidence_source = str(
+        raw.get("terminal_evidence_source") or ""
+    ).strip().lower()
+    terminal_evidence_at = str(raw.get("terminal_evidence_at") or "").strip()
+    if terminal_status and terminal_status not in {
+        "completed",
+        "failed",
+        "cancelled",
+    }:
+        return None
     if candidate_id:
         evidence_source = evidence_source or source
         signal_actor = signal_actor or _legacy_signal_actor(evidence_source)
@@ -1791,6 +2249,9 @@ def _parse_job(raw: object) -> TaskJob | None:
         review_id=review_id,
         review_url=review_url,
         review_published=review_published,
+        terminal_status=terminal_status,
+        terminal_evidence_source=terminal_evidence_source,
+        terminal_evidence_at=terminal_evidence_at,
     )
 
 
@@ -1854,6 +2315,9 @@ def _job_to_dict(job: TaskJob | None) -> dict:
         "review_id": job.review_id,
         "review_url": job.review_url,
         "review_published": job.review_published,
+        "terminal_status": job.terminal_status,
+        "terminal_evidence_source": job.terminal_evidence_source,
+        "terminal_evidence_at": job.terminal_evidence_at,
     }
 
 
@@ -1884,6 +2348,7 @@ def _replace_job(job: TaskJob, **changes: object) -> TaskJob:
         "source_task_id": job.source_task_id,
         "worker_id": job.worker_id,
         "worker_pid": job.worker_pid,
+        "worker_heartbeat_at": job.worker_heartbeat_at,
         "workspace_path": job.workspace_path,
         "workspace_id": job.workspace_id,
         "attempt": job.attempt,
@@ -1912,6 +2377,9 @@ def _replace_job(job: TaskJob, **changes: object) -> TaskJob:
         "review_id": job.review_id,
         "review_url": job.review_url,
         "review_published": job.review_published,
+        "terminal_status": job.terminal_status,
+        "terminal_evidence_source": job.terminal_evidence_source,
+        "terminal_evidence_at": job.terminal_evidence_at,
     }
     values.update(changes)
     return TaskJob(**values)
@@ -2016,6 +2484,19 @@ def _retry_at(delay_seconds: int) -> str:
     ).isoformat()
 
 
+def _retry_at_from(timestamp: str, delay_seconds: int) -> str:
+    try:
+        base = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return _retry_at(delay_seconds)
+    if base.tzinfo is None:
+        base = base.replace(tzinfo=timezone.utc)
+    return (
+        base.replace(microsecond=0)
+        + timedelta(seconds=max(0, delay_seconds))
+    ).isoformat()
+
+
 def _task_is_due(job: TaskJob) -> bool:
     if not job.next_attempt_at:
         return True
@@ -2101,4 +2582,5 @@ def _empty_queue() -> dict:
         "paused": [],
         "running": None,
         "history": [],
+        "reconciliation": None,
     }

--- a/src/enoch/workflows/__init__.py
+++ b/src/enoch/workflows/__init__.py
@@ -11,6 +11,11 @@ from enoch.workflows.contracts import (
     workflow_features,
 )
 from enoch.workflows.local import LocalWorkflowEngine
+from enoch.tasks.queue import (
+    TaskReconciliationRequest,
+    TaskReconciliationResult,
+    TaskTerminalEvidence,
+)
 
 
 __all__ = [
@@ -21,6 +26,9 @@ __all__ = [
     "EnqueueMode",
     "FinalTaskStatus",
     "LocalWorkflowEngine",
+    "TaskReconciliationRequest",
+    "TaskReconciliationResult",
+    "TaskTerminalEvidence",
     "WorkflowEngine",
     "WorkflowEngineError",
     "validate_workflow_engine",

--- a/src/enoch/workflows/contracts.py
+++ b/src/enoch/workflows/contracts.py
@@ -4,11 +4,18 @@ from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
 
 from enoch.providers.contracts import ConversationId, MessageId, RuntimeResult
-from enoch.tasks.queue import TaskJob, TaskPublicationState, TaskQueueStatus
+from enoch.tasks.queue import (
+    TaskJob,
+    TaskPublicationState,
+    TaskQueueStatus,
+    TaskReconciliationRequest,
+    TaskReconciliationResult,
+    TaskTerminalEvidence,
+)
 from enoch.tasks.payloads import ExtensionArtifactReference, JsonValue
 
 
-WORKFLOW_API_VERSION = 3
+WORKFLOW_API_VERSION = 4
 WORKFLOW_FEATURE_STRUCTURED_METADATA = "structured_task_metadata"
 WORKFLOW_FEATURE_ARTIFACT_REFERENCES = "artifact_references"
 WORKFLOW_FEATURE_EXECUTION_LANES = "execution_lanes"
@@ -92,6 +99,11 @@ class WorkflowEngine(Protocol):
     ) -> TaskJob | None: ...
 
     def recover(self) -> TaskJob | None: ...
+
+    def reconcile(
+        self,
+        request: TaskReconciliationRequest | None = None,
+    ) -> TaskReconciliationResult: ...
 
     def inspect(self) -> TaskQueueStatus: ...
 
@@ -188,6 +200,13 @@ class WorkflowEngine(Protocol):
         provider: str,
     ) -> None: ...
 
+    def record_terminal_evidence(
+        self,
+        task_id: int,
+        worker_id: str,
+        evidence: TaskTerminalEvidence,
+    ) -> TaskJob | None: ...
+
     def worker_is_active(self, job: TaskJob) -> bool: ...
 
 def validate_workflow_engine(engine: WorkflowEngine) -> WorkflowEngine:
@@ -204,7 +223,7 @@ def validate_workflow_engine(engine: WorkflowEngine) -> WorkflowEngine:
 
 
 def workflow_features(engine: WorkflowEngine) -> frozenset[str]:
-    """Discover optional workflow features without breaking API v3 engines."""
+    """Discover optional workflow features without breaking API v4 engines."""
 
     raw = getattr(engine, "features", ())
     if isinstance(raw, str):

--- a/src/enoch/workflows/local.py
+++ b/src/enoch/workflows/local.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from pathlib import Path
+from typing import Callable
 
 from enoch.app.epoch import DaemonEpoch, daemon_epoch_guard
+from enoch.memory.paths import now as current_time
 from enoch.providers.contracts import ConversationId, MessageId, RuntimeResult
 from enoch.tasks.queue import (
     TaskJob,
     TaskPublicationState,
     TaskQueueStatus,
+    TaskReconciliationRequest,
+    TaskReconciliationResult,
+    TaskTerminalEvidence,
     begin_direct_task,
     begin_next_task,
     cancel_running_task,
@@ -24,8 +29,9 @@ from enoch.tasks.queue import (
     record_task_result,
     record_task_runtime_result,
     record_task_status_message,
+    record_task_terminal_evidence,
     record_task_workspace,
-    recover_interrupted_task,
+    reconcile_running_task,
     regress_task,
     resolve_regressed_task,
     resume_paused_tasks,
@@ -58,9 +64,18 @@ class LocalWorkflowEngine:
         }
     )
 
-    def __init__(self, root: Path, *, epoch: DaemonEpoch | None = None) -> None:
+    def __init__(
+        self,
+        root: Path,
+        *,
+        epoch: DaemonEpoch | None = None,
+        clock: Callable[[], str] = current_time,
+        worker_liveness: Callable[[TaskJob], bool] = task_worker_is_active,
+    ) -> None:
         self.root = root
         self.epoch = epoch
+        self._clock = clock
+        self._worker_liveness = worker_liveness
 
     def enqueue(
         self,
@@ -225,7 +240,29 @@ class LocalWorkflowEngine:
 
     def recover(self) -> TaskJob | None:
         with self._mutation():
-            return recover_interrupted_task(self.root)
+            result = reconcile_running_task(
+                root=self.root,
+                worker_liveness=self._worker_liveness,
+                checked_at=self._clock(),
+            )
+        if result.outcome not in {
+            "terminal_repair",
+            "interrupted_worker_recovery",
+        } or result.task_id is None:
+            return None
+        return self.find(result.task_id)
+
+    def reconcile(
+        self,
+        request: TaskReconciliationRequest | None = None,
+    ) -> TaskReconciliationResult:
+        with self._mutation():
+            return reconcile_running_task(
+                request,
+                self.root,
+                worker_liveness=self._worker_liveness,
+                checked_at=self._clock(),
+            )
 
     def inspect(self) -> TaskQueueStatus:
         return task_queue_status(self.root)
@@ -454,8 +491,22 @@ class LocalWorkflowEngine:
                 provider=provider,
             )
 
+    def record_terminal_evidence(
+        self,
+        task_id: int,
+        worker_id: str,
+        evidence: TaskTerminalEvidence,
+    ) -> TaskJob | None:
+        with self._mutation():
+            return record_task_terminal_evidence(
+                task_id,
+                worker_id,
+                evidence,
+                self.root,
+            )
+
     def worker_is_active(self, job: TaskJob) -> bool:
-        return task_worker_is_active(job)
+        return self._worker_liveness(job)
 
     def result_has_review(self, result: str) -> bool:
         return task_result_has_review(result)

--- a/tests/test_enoch_portable_install.py
+++ b/tests/test_enoch_portable_install.py
@@ -184,7 +184,7 @@ class EnochPortableInstallTests(unittest.TestCase):
         self.assertEqual(result["extension_api_version"], 1)
         self.assertEqual(result["composition_api_version"], 1)
         self.assertEqual(result["composition"], "portable-descendant")
-        self.assertEqual(result["workflow_api_version"], 3)
+        self.assertEqual(result["workflow_api_version"], 4)
         self.assertEqual(result["conformance_api_version"], 1)
         self.assertEqual(result["repository_contract_version"], 1)
         self.assertEqual(result["review_contract_version"], 1)
@@ -197,7 +197,7 @@ class EnochPortableInstallTests(unittest.TestCase):
                 "finalize:completed",
                 "enqueue",
                 "finalize:completed",
-                "recover",
+                "reconcile",
             ],
         )
         self.assertTrue(result["workflow_state_isolated"])
@@ -707,6 +707,10 @@ _INSTALLED_TASK_SCRIPT = textwrap.dedent(
         def recover(self):
             self.operations.append("recover")
             return super().recover()
+
+        def reconcile(self, request=None):
+            self.operations.append("reconcile")
+            return super().reconcile(request)
 
     def git(*args):
         result = subprocess.run(

--- a/tests/test_enoch_private_state.py
+++ b/tests/test_enoch_private_state.py
@@ -129,7 +129,8 @@ class EnochPrivateStateTests(unittest.TestCase):
 
         self.assertTrue(result.applied)
         self.assertIsNotNone(result.backup_path)
-        self.assertEqual(migrated_queue["schema_version"], 14)
+        self.assertEqual(migrated_queue["schema_version"], 15)
+        self.assertIsNone(migrated_queue["reconciliation"])
         self.assertEqual(migrated_queue["paused"], [])
         self.assertEqual(migrated_queue["pending"][0]["required_capabilities"], [])
         self.assertEqual(migrated_queue["pending"][0]["extension_metadata"], {})

--- a/tests/test_enoch_task_queue.py
+++ b/tests/test_enoch_task_queue.py
@@ -13,7 +13,9 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from enoch.tasks.queue import (
     TaskPublicationState,
+    TaskReconciliationRequest,
     TaskRetryError,
+    TaskTerminalEvidence,
     begin_direct_task,
     begin_next_task,
     cancel_task,
@@ -24,12 +26,14 @@ from enoch.tasks.queue import (
     enqueue_task_front,
     fail_task,
     pause_task,
+    reconcile_running_task,
     recover_interrupted_task,
     record_task_result,
     record_task_runtime_result,
     record_task_publish_state,
     record_task_publication,
     record_task_status_message,
+    record_task_terminal_evidence,
     record_task_worktree,
     regress_task,
     resolve_regressed_task,
@@ -103,7 +107,7 @@ class EnochTaskQueueTests(unittest.TestCase):
         )
         self.assertEqual(loaded.review_url, loaded.review_urls[0])
         self.assertTrue(loaded.review_published)
-        self.assertEqual(rewritten["schema_version"], 14)
+        self.assertEqual(rewritten["schema_version"], 15)
         self.assertEqual(persisted["workspace_id"], "legacy-workspace-id")
         self.assertEqual(persisted["revision_id"], "legacy-revision")
         self.assertEqual(persisted["extension_metadata"], {})
@@ -864,6 +868,118 @@ class EnochTaskQueueTests(unittest.TestCase):
         self.assertEqual(recovered.status_message_id, 2001)
         self.assertEqual(recovered.context, "Resume with chat context.")
         self.assertEqual(status.pending[0].id, queued.id)
+
+    def test_reconciliation_repairs_terminal_evidence_once(self) -> None:
+        checked_at = "2026-08-16T21:30:00+00:00"
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            running = begin_direct_task(42, "finish after crash", root)
+            claimed = claim_running_task(running.id, "worker-one", 999_999, root)
+            assert claimed is not None
+            recorded = record_task_terminal_evidence(
+                claimed.id,
+                claimed.worker_id,
+                TaskTerminalEvidence(status="completed", result="done"),
+                root,
+            )
+            assert recorded is not None
+            request = TaskReconciliationRequest(
+                recorded.id,
+                recorded.worker_id,
+                recorded.worker_heartbeat_at,
+            )
+
+            repaired = reconcile_running_task(
+                request,
+                root,
+                worker_liveness=lambda _job: False,
+                checked_at=checked_at,
+            )
+            repeated = reconcile_running_task(
+                root=root,
+                worker_liveness=lambda _job: False,
+                checked_at=checked_at,
+            )
+            status = task_queue_status(root)
+
+        self.assertEqual(repaired.outcome, "terminal_repair")
+        self.assertEqual(repaired.checked_at, checked_at)
+        self.assertEqual(repeated.outcome, "no_op")
+        self.assertEqual(len(status.history), 1)
+        self.assertEqual(status.reconciliation, repaired)
+
+    def test_reconciliation_fails_closed_on_conflicting_or_unsupported_evidence(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            running = begin_direct_task(42, "incomplete review", root)
+            claimed = claim_running_task(running.id, "worker-one", 999_999, root)
+            assert claimed is not None
+            conflict = reconcile_running_task(
+                TaskReconciliationRequest(
+                    claimed.id,
+                    claimed.worker_id,
+                    "stale-lease",
+                ),
+                root,
+                worker_liveness=lambda _job: False,
+            )
+            record_task_publication(
+                claimed.id,
+                claimed.worker_id,
+                TaskPublicationState(
+                    stage="review_published",
+                    review_id="review-without-url",
+                    review_published=True,
+                ),
+                root,
+            )
+            unsupported = reconcile_running_task(
+                TaskReconciliationRequest(
+                    claimed.id,
+                    claimed.worker_id,
+                    claimed.worker_heartbeat_at,
+                ),
+                root,
+                worker_liveness=lambda _job: False,
+            )
+            status = task_queue_status(root)
+
+        self.assertEqual(conflict.outcome, "conflict")
+        self.assertEqual(unsupported.outcome, "unsupported_evidence")
+        self.assertIsNotNone(status.running)
+        self.assertEqual(status.history, ())
+
+    def test_reconciliation_retries_known_nonterminal_progress(self) -> None:
+        with TemporaryDirectory() as temp:
+            root = Path(temp)
+            running = begin_direct_task(42, "resume captured work", root)
+            claimed = claim_running_task(running.id, "worker-one", 999_999, root)
+            assert claimed is not None
+            record_task_runtime_result(
+                claimed.id,
+                RuntimeResult(final_text="runtime finished"),
+                root,
+                provider="fake-runtime",
+            )
+            record_task_publication(
+                claimed.id,
+                claimed.worker_id,
+                TaskPublicationState(stage="committed", revision_id="abc123"),
+                root,
+            )
+
+            recovered = reconcile_running_task(
+                root=root,
+                worker_liveness=lambda _job: False,
+            )
+            status = task_queue_status(root)
+
+        self.assertEqual(recovered.outcome, "interrupted_worker_recovery")
+        self.assertIsNone(status.running)
+        self.assertEqual(status.pending_count, 1)
+        self.assertEqual(status.pending[0].revision_id, "abc123")
 
     def test_recover_interrupted_task_with_pr_url_completes_it(self) -> None:
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
Closes #69.

## Summary

- bump the public workflow contract to API v4 and queue schema 15
- record typed terminal evidence immediately before normal finalization
- run authoritative reconciliation during the application maintenance tick
- fence reconciliation by daemon epoch plus expected task, worker, and heartbeat lease identity
- finalize durable terminal proof exactly once, preserve live workers, and return inactive nonterminal work to bounded retry
- fail closed on conflicting or incomplete terminal/review evidence
- expose the last material reconciliation result through queue inspection

Reconciliation only mutates workflow state. It does not call providers, replay external effects, or resend terminal notifications.

## Verification

- `python3 -m compileall -q src tests`
- `git diff --check`
- focused workflow/application suite: 102 tests passed
- deterministic repository suite excluding the existing environment/live-model modules: 564 tests across 50 modules passed
- crash-point behavior probes verified terminal repair once, repeat no-op, preserved captured revision retry, and fail-closed incomplete review evidence

- GitHub Actions: all 819 tests passed on Python 3.11, 3.12, 3.13, and 3.14
